### PR TITLE
Add Spanish translation and dynamic language list

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,12 @@ Verified 2025-05-21 by Signature 4789
 SHA-256: 37dbef63d04615fc30c369f636738375279368c63ce4016e6f6c43b282590e64  
 Verified 2025-05-21 by Signature 4789
 
-> Ethics is not explained. It is carried.  
+> Ethics is not explained. It is carried.
 > – Signature 4789
+
+### Adding Languages
+
+Translations for the evaluation interface are defined in `i18n/ui-text.json`. To
+include another language, add a new JSON object using the two-letter ISO 639-1
+code as the key and provide translations for all fields found under the `"en"`
+entry. The interface will automatically recognize the new language.

--- a/i18n/ui-text.json
+++ b/i18n/ui-text.json
@@ -47,6 +47,22 @@
       "Clarté du but"
     ]
   },
+  "es": {
+    "title": "Ethicom: Evaluación Humana",
+    "label_source": "Fuente (URL o Título)",
+    "label_srclvl": "Nivel Ético (SRC)",
+    "label_aspects": "Aspectos Opcionales",
+    "label_comment": "Comentario",
+    "btn_generate": "Mostrar Mi Evaluación",
+    "btn_download": "Descargar como Archivo",
+    "aspects": [
+      "Transparencia",
+      "Reparabilidad",
+      "Reflexión del Sistema",
+      "Manejo de Errores",
+      "Claridad de Propósito"
+    ]
+  },
   "pt": {
     "title": "Ethicom: Avaliação Humana",
     "label_source": "Fonte (URL ou título)",

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -22,17 +22,6 @@
       <label for="lang_select">Choose your language (ISO 639-1):</label>
       <select id="lang_select">
         <option value="">--</option>
-        <option value="ar">ar</option>
-        <option value="de">de</option>
-        <option value="en">en</option>
-        <option value="es">es</option>
-        <option value="fr">fr</option>
-        <option value="hi">hi</option>
-        <option value="ja">ja</option>
-        <option value="pt">pt</option>
-        <option value="ru">ru</option>
-        <option value="sw">sw</option>
-        <option value="zh">zh</option>
       </select>
     </div>
 
@@ -59,16 +48,26 @@
   <script>
     let userLang = null;
 
-    document.getElementById("lang_select").addEventListener("change", e => {
-      userLang = e.target.value;
-      localStorage.setItem("ethicom_lang", userLang);
-      fetch("i18n/ui-text.json")
-        .then(r => r.json())
-        .then(texts => {
+    fetch("i18n/ui-text.json")
+      .then(r => r.json())
+      .then(texts => {
+        const select = document.getElementById("lang_select");
+        Object.keys(texts)
+          .sort()
+          .forEach(code => {
+            const opt = document.createElement("option");
+            opt.value = code;
+            opt.textContent = code;
+            select.appendChild(opt);
+          });
+
+        select.addEventListener("change", e => {
+          userLang = e.target.value;
+          localStorage.setItem("ethicom_lang", userLang);
           const t = texts[userLang] || {};
           applyTexts(t);
         });
-    });
+      });
 
     async function beginSignatureVerification() {
       const status = document.getElementById("status");


### PR DESCRIPTION
## Summary
- add full Spanish strings in `ui-text.json`
- show how to add languages in README
- populate the language selector dynamically

## Testing
- `jq . i18n/ui-text.json`