### PR TITLE
Implement sha256 helper for signature verification

### DIFF
--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -19,3 +19,21 @@ function renderBadge(currentRank, maxRank) {
     badgeDisplay.appendChild(shadow);
   }
 }
+
+// Calculate a SHA-256 hash in both browser and Node.js environments
+async function sha256(message) {
+  if (typeof window !== "undefined" && window.crypto && window.crypto.subtle) {
+    const data = new TextEncoder().encode(message);
+    const buffer = await window.crypto.subtle.digest("SHA-256", data);
+    return Array.from(new Uint8Array(buffer))
+      .map(b => b.toString(16).padStart(2, "0"))
+      .join("");
+  }
+
+  if (typeof require !== "undefined") {
+    const crypto = require("crypto");
+    return crypto.createHash("sha256").update(message).digest("hex");
+  }
+
+  throw new Error("SHA-256 hashing not supported in this environment");
+}


### PR DESCRIPTION
## Summary
- add a SHA‑256 helper in `ethicom-utils.js` so signatures can be verified

## Testing
- `node --test test/consensus.test.js`
- `node --test test/i18n-structure.test.js`
- `node --test test/json-validity.test.js`
