### PR TITLE
Add signup page with secure email validation

### DIFF
--- a/interface/README.md
+++ b/interface/README.md
@@ -27,6 +27,8 @@ Just structured responsibility.
 - `interface-loader.js` → loads correct module for OP-0 to OP-8
 - `language-selector.js` → user selects language (ISO 639-1)
 - `source-search.js` → search and verify sources
+├── signup.html
+├── signup.js
 
 ---
 
@@ -58,6 +60,8 @@ interface/
 ├── interface-loader.js
 ├── language-selector.js
 ├── source-search.js
+├── signup.html
+├── signup.js
 ├── modules/
 │   ├── op-0-interface.js
 │   ├── op-1-interface.js

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Ethicom Signup</title>
+  <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="signup.js"></script>
+</head>
+<body>
+  <main class="card">
+    <h2>Sign up</h2>
+    <label for="email_input">Email:</label>
+    <input type="email" id="email_input" placeholder="name@provider.com" />
+
+    <label for="pw_input">Password:</label>
+    <input type="password" id="pw_input" placeholder="At least 8 characters" />
+
+    <button onclick="handleSignup()">Create Account</button>
+    <pre id="signup_status" style="white-space:pre-wrap;margin-top:1em;"></pre>
+  </main>
+</body>
+</html>

--- a/interface/signup.js
+++ b/interface/signup.js
@@ -1,0 +1,34 @@
+const secureHosts = [
+  'protonmail.com',
+  'tutanota.com',
+  'mailbox.org',
+  'posteo.de'
+];
+
+function handleSignup() {
+  const emailInput = document.getElementById('email_input');
+  const pwInput = document.getElementById('pw_input');
+  const statusEl = document.getElementById('signup_status');
+  const email = emailInput.value.trim();
+  const password = pwInput.value;
+  statusEl.textContent = '';
+
+  if (!/^[^@]+@[^@]+\.[^@]+$/.test(email)) {
+    statusEl.textContent = 'Invalid email format.';
+    return;
+  }
+
+  const domain = email.split('@')[1].toLowerCase();
+  if (!secureHosts.includes(domain)) {
+    statusEl.textContent = 'Email provider not supported. Use a secure host.';
+    return;
+  }
+
+  if (password.length < 8) {
+    statusEl.textContent = 'Password must be at least 8 characters.';
+    return;
+  }
+
+  localStorage.setItem('ethicom_signup_email', email);
+  statusEl.textContent = 'Signup information saved locally.';
+}


### PR DESCRIPTION
## Summary
- create `signup.html` and `signup.js`
- restrict signup to pre-approved secure email providers
- list the new signup files in interface README

## Testing
- `node --test`