### PR TITLE
Add additional interface modules

### DIFF
--- a/interface/README.md
+++ b/interface/README.md
@@ -24,8 +24,13 @@ Just structured responsibility.
 - `ethicom-style.css` → dark mode, badge colors, minimal energy
 - `signature-generator.js` → local signature creation (e.g. `SIG-XXXX-XXXX-XXXX`)
 - `signature-verifier.js` → hash & password check before activation
-- `interface-loader.js` → loads correct module for OP-0 to OP-8
+- `interface-loader.js` → loads correct module for OP-0 to OP-10 and extra tools
 - `language-selector.js` → user selects language (ISO 639-1)
+- `source-search.js` → search and verify sources
+- `manifest-viewer.js` → display any stored evaluation manifest
+- `revision-overview.js` → list withdrawn or revised manifests
+- `permissions-viewer.js` → visualize OP permissions
+- `language-manager.js` → generate snippets for new translations
 
 ---
 
@@ -56,6 +61,11 @@ interface/
 ├── signature-verifier.js
 ├── interface-loader.js
 ├── language-selector.js
+├── source-search.js
+├── manifest-viewer.js
+├── revision-overview.js
+├── permissions-viewer.js
+├── language-manager.js
 ├── modules/
 │   ├── op-0-interface.js
 │   ├── op-1-interface.js

--- a/interface/modules/interface-loader.js
+++ b/interface/modules/interface-loader.js
@@ -21,7 +21,12 @@ function loadInterfaceForOP(op_level) {
     "op79": "op-7.9-interface.js",
     "op8": "op-8-analysis.js",
     "op9": "op-9-interface.js",
-    "op10": "op-10-interface.js"
+    "op10": "op-10-interface.js",
+    "search": "source-search.js",
+    "manifestviewer": "manifest-viewer.js",
+    "revisionoverview": "revision-overview.js",
+    "permissionsviewer": "permissions-viewer.js",
+    "languagemanager": "language-manager.js"
   };
 
   const script = document.createElement("script");
@@ -45,6 +50,16 @@ function loadInterfaceForOP(op_level) {
       window[initFunc]();
     } else if (op_level === "OP-8") {
       initOP8Analysis();
+    } else if (op_level.toLowerCase() === "search") {
+      initSourceSearch();
+    } else if (op_level.toLowerCase() === "manifest-viewer") {
+      initManifestViewer();
+    } else if (op_level.toLowerCase() === "revision-overview") {
+      initRevisionOverview();
+    } else if (op_level.toLowerCase() === "permissions-viewer") {
+      initPermissionsViewer();
+    } else if (op_level.toLowerCase() === "language-manager") {
+      initLanguageManager();
     }
     if (status) status.textContent = "Module loaded";
   };

--- a/interface/modules/language-manager.js
+++ b/interface/modules/language-manager.js
@@ -1,0 +1,49 @@
+// language-manager.js – Add or modify UI translations
+
+function initLanguageManager() {
+  const container = document.getElementById("op_interface");
+  if (!container) return;
+  container.innerHTML = `
+    <div class="card">
+      <h3>Language Management</h3>
+      <p class="info">Generate JSON snippets for new UI translations.</p>
+      <label for="lang_code">Language Code (ISO 639-1):</label>
+      <input type="text" id="lang_code" maxlength="2" />
+      <label for="lang_title">Title Text:</label>
+      <input type="text" id="lang_title" />
+      <label for="lang_source">Label for Source:</label>
+      <input type="text" id="lang_source" />
+      <label for="lang_level">Label for Ethical Level:</label>
+      <input type="text" id="lang_level" />
+      <label for="lang_comment">Label for Comment:</label>
+      <input type="text" id="lang_comment" />
+      <button onclick="generateLangSnippet()">Generate Snippet</button>
+      <pre id="lang_output" style="white-space:pre-wrap;"></pre>
+    </div>
+  `;
+}
+
+function generateLangSnippet() {
+  const code = document.getElementById("lang_code").value.trim();
+  const title = document.getElementById("lang_title").value.trim();
+  const src = document.getElementById("lang_source").value.trim();
+  const lvl = document.getElementById("lang_level").value.trim();
+  const comment = document.getElementById("lang_comment").value.trim();
+  if (!code || !title || !src || !lvl || !comment) {
+    alert("Please fill in all fields.");
+    return;
+  }
+  const snippet = {
+    [code]: {
+      title,
+      label_source: src,
+      label_srclvl: lvl,
+      label_aspects: "Optional Aspects",
+      label_comment: comment,
+      btn_generate: "Show My Evaluation",
+      btn_download: "Download as File",
+      aspects: []
+    }
+  };
+  document.getElementById("lang_output").textContent = JSON.stringify(snippet, null, 2);
+}

--- a/interface/modules/manifest-viewer.js
+++ b/interface/modules/manifest-viewer.js
@@ -1,0 +1,31 @@
+// manifest-viewer.js – View evaluation manifests
+
+function initManifestViewer() {
+  const container = document.getElementById("op_interface");
+  if (!container) return;
+  container.innerHTML = `
+    <div class="card">
+      <h3>Manifest Viewer</h3>
+      <label for="manifest_id">Manifest filename:</label>
+      <input type="text" id="manifest_id" placeholder="e.g. op-eval-4789-src-0001.json" />
+      <button onclick="loadManifestFile()">Load Manifest</button>
+      <pre id="manifest_view" style="white-space:pre-wrap;"></pre>
+    </div>
+  `;
+}
+
+async function loadManifestFile() {
+  const id = document.getElementById("manifest_id").value.trim();
+  const output = document.getElementById("manifest_view");
+  if (!id) {
+    alert("Please specify a manifest filename.");
+    return;
+  }
+  output.textContent = "Loading manifest...";
+  try {
+    const manifest = await fetch(`../manifests/${id}`).then(r => r.json());
+    output.textContent = JSON.stringify(manifest, null, 2);
+  } catch (e) {
+    output.textContent = "Manifest not found.";
+  }
+}

--- a/interface/modules/permissions-viewer.js
+++ b/interface/modules/permissions-viewer.js
@@ -1,0 +1,29 @@
+// permissions-viewer.js – Display OP permissions table
+
+function initPermissionsViewer() {
+  const container = document.getElementById("op_interface");
+  if (!container) return;
+  container.innerHTML = `
+    <div class="card">
+      <h3>Operator Permissions</h3>
+      <table id="perm_table" class="perm-table"></table>
+    </div>
+  `;
+  loadPermissionTable();
+}
+
+async function loadPermissionTable() {
+  const table = document.getElementById("perm_table");
+  table.innerHTML = "<tr><th>OP Level</th><th>Permissions</th></tr>";
+  try {
+    const data = await fetch("../permissions/op-permissions-expanded.json").then(r => r.json());
+    Object.keys(data).forEach(level => {
+      const row = document.createElement("tr");
+      const actions = Object.keys(data[level]).filter(k => data[level][k]);
+      row.innerHTML = `<td>${level}</td><td>${actions.join(', ')}</td>`;
+      table.appendChild(row);
+    });
+  } catch (e) {
+    table.innerHTML += `<tr><td colspan='2'>Could not load permissions.</td></tr>`;
+  }
+}

--- a/interface/modules/revision-overview.js
+++ b/interface/modules/revision-overview.js
@@ -1,0 +1,44 @@
+// revision-overview.js – Show withdrawn or revised manifests
+
+function initRevisionOverview() {
+  const container = document.getElementById("op_interface");
+  if (!container) return;
+  container.innerHTML = `
+    <div class="card">
+      <h3>Revision & Withdrawal Overview</h3>
+      <button onclick="loadWithdrawnList()">Load Withdrawn Manifests</button>
+      <ul id="withdraw_list"></ul>
+      <pre id="revision_output" style="white-space:pre-wrap;"></pre>
+    </div>
+  `;
+}
+
+async function loadWithdrawnList() {
+  const listEl = document.getElementById("withdraw_list");
+  const output = document.getElementById("revision_output");
+  listEl.innerHTML = "";
+  output.textContent = "";
+  try {
+    const files = await fetch("../manifests/withdrawn/index.json").then(r => r.json());
+    files.forEach(f => {
+      const li = document.createElement("li");
+      li.textContent = f;
+      li.style.cursor = "pointer";
+      li.onclick = () => loadWithdrawnManifest(f);
+      listEl.appendChild(li);
+    });
+  } catch (e) {
+    listEl.innerHTML = `<li>No index found.</li>`;
+  }
+}
+
+async function loadWithdrawnManifest(file) {
+  const output = document.getElementById("revision_output");
+  output.textContent = "Loading...";
+  try {
+    const manifest = await fetch(`../manifests/withdrawn/${file}`).then(r => r.json());
+    output.textContent = JSON.stringify(manifest, null, 2);
+  } catch (e) {
+    output.textContent = "Failed to load " + file;
+  }
+}

--- a/interface/modules/source-search.js
+++ b/interface/modules/source-search.js
@@ -1,0 +1,63 @@
+// source-search.js – Suche und Überprüfung von Quellen
+
+function initSourceSearch() {
+  const container = document.getElementById("op_interface");
+  if (!container) return;
+  container.innerHTML = `
+    <div class="card">
+      <h3>Search Sources</h3>
+      <input type="text" id="search_query" placeholder="Enter ID or keyword" />
+      <button onclick="performSourceSearch()">Search</button>
+      <ul id="search_results"></ul>
+      <pre id="manifest_output" style="white-space:pre-wrap;"></pre>
+    </div>
+  `;
+}
+
+async function performSourceSearch() {
+  const query = document.getElementById("search_query").value.trim().toLowerCase();
+  const results = document.getElementById("search_results");
+  const output = document.getElementById("manifest_output");
+  results.innerHTML = "";
+  output.textContent = "";
+
+  const list = [];
+  try {
+    const candidates = await fetch("../sources/src-candidates.json").then(r => r.json());
+    list.push(...candidates);
+  } catch (e) {}
+
+  try {
+    const src1 = await fetch("../sources/src-0001.json").then(r => r.json());
+    list.push(src1);
+  } catch (e) {}
+
+  const filtered = list.filter(item => {
+    return item.source_id.toLowerCase().includes(query) ||
+           (item.title && item.title.toLowerCase().includes(query));
+  });
+
+  if (!filtered.length) {
+    results.innerHTML = `<li>No sources found.</li>`;
+    return;
+  }
+
+  filtered.forEach(item => {
+    const li = document.createElement("li");
+    li.textContent = `${item.source_id}: ${item.title}`;
+    li.style.cursor = "pointer";
+    li.onclick = () => loadManifest(item.source_id);
+    results.appendChild(li);
+  });
+}
+
+async function loadManifest(id) {
+  const output = document.getElementById("manifest_output");
+  output.textContent = "Loading manifest...";
+  try {
+    const manifest = await fetch(`../manifests/op-eval-4789-${id}.json`).then(r => r.json());
+    output.textContent = JSON.stringify(manifest, null, 2);
+  } catch (e) {
+    output.textContent = "No manifest found for " + id;
+  }
+}

--- a/manifests/withdrawn/index.json
+++ b/manifests/withdrawn/index.json
@@ -1,0 +1,3 @@
+[
+  "withdraw-src-0006.json"
+]


### PR DESCRIPTION
## Summary
- add new interface modules for manifest viewing, revision overview, permissions and language management
- load the new modules from `interface-loader.js`
- document the additional modules in interface README
- index withdrawn manifests for the revision overview module

## Testing
- `echo 'No tests found'`