### PR TITLE
Enable multi-language signup and help

### DIFF
--- a/i18n/ui-text.json
+++ b/i18n/ui-text.json
@@ -13,6 +13,28 @@
       "System Reflection",
       "Error Handling",
       "Purpose Clarity"
+    ],
+    "signup_title": "Sign up",
+    "signup_email": "Email:",
+    "signup_password": "Password:",
+    "signup_btn": "Create Account",
+    "signup_placeholder_email": "name@provider.com",
+    "signup_placeholder_pw": "At least 8 characters",
+    "signup_invalid_email": "Invalid email format.",
+    "signup_unsupported": "Email provider not supported. Use a secure host.",
+    "signup_pw_short": "Password must be at least 8 characters.",
+    "signup_saved": "Signup information saved locally.",
+    "help_title": "Help – Operator Conduct",
+    "help_items": [
+      "Always check if your actions meet the ethics of responsibility.",
+      "Use only the tools assigned to your OP level.",
+      "Document decisions in the manifest for verification.",
+      "Nominations and feedback are structured and without personal pressure.",
+      "Consult a higher structure (from OP-7) if unsure.",
+      "Responsibility outweighs convenience.",
+      "Create signatures locally and confirm them structurally.",
+      "Withdrawals or corrections are part of the process, not weakness.",
+      "Maintain transparency at every step, even with anonymous use."
     ]
   },
   "de": {
@@ -29,6 +51,28 @@
       "Systemreflexion",
       "Fehlerkultur",
       "Zweckklarheit"
+    ],
+    "signup_title": "Registrierung",
+    "signup_email": "E-Mail:",
+    "signup_password": "Passwort:",
+    "signup_btn": "Konto erstellen",
+    "signup_placeholder_email": "name@anbieter.de",
+    "signup_placeholder_pw": "Mindestens 8 Zeichen",
+    "signup_invalid_email": "Ungültiges E-Mail-Format.",
+    "signup_unsupported": "E-Mail-Anbieter nicht unterstützt. Nutze einen sicheren Host.",
+    "signup_pw_short": "Passwort muss mindestens 8 Zeichen haben.",
+    "signup_saved": "Registrierungsdaten lokal gespeichert.",
+    "help_title": "Hilfe – Operator-Verhalten",
+    "help_items": [
+      "Prüfe jederzeit, ob dein Handeln der Verantwortungsethik entspricht.",
+      "Nutze nur die Mittel, die deinem OP-Level zugeordnet sind.",
+      "Dokumentiere Entscheidungen im Manifest zur Überprüfbarkeit.",
+      "Nominierungen und Rückmeldungen erfolgen strukturiert und ohne persönlichen Druck.",
+      "Bei Unsicherheit konsultiere eine höhere Struktur (ab OP-7).",
+      "Verantwortung geht vor Bequemlichkeit.",
+      "Erstelle Signaturen lokal und bestätige sie strukturell.",
+      "Rückzüge oder Korrekturen sind Teil des Prozesses, keine Schwäche.",
+      "Wahre Transparenz in jedem Schritt, auch bei anonymer Nutzung."
     ]
   },
   "fr": {
@@ -45,6 +89,28 @@
       "Réflexion systémique",
       "Gestion des erreurs",
       "Clarté du but"
+    ],
+    "signup_title": "Inscription",
+    "signup_email": "Courriel :",
+    "signup_password": "Mot de passe :",
+    "signup_btn": "Créer le compte",
+    "signup_placeholder_email": "nom@fournisseur.fr",
+    "signup_placeholder_pw": "Au moins 8 caractères",
+    "signup_invalid_email": "Format d'adresse invalide.",
+    "signup_unsupported": "Fournisseur non pris en charge. Utilisez un hôte sûr.",
+    "signup_pw_short": "Le mot de passe doit comporter au moins 8 caractères.",
+    "signup_saved": "Informations d'inscription enregistrées localement.",
+    "help_title": "Aide – Comportement de l'opérateur",
+    "help_items": [
+      "Vérifiez toujours si vos actions suivent l'éthique de responsabilité.",
+      "N'utilisez que les moyens attribués à votre niveau OP.",
+      "Documentez les décisions dans le manifeste pour vérification.",
+      "Les nominations et retours se font de manière structurée sans pression personnelle.",
+      "En cas de doute, consultez une structure supérieure (dès OP-7).",
+      "La responsabilité prime sur la commodité.",
+      "Créez les signatures localement et confirmez-les structurellement.",
+      "Les retraits ou corrections font partie du processus, pas une faiblesse.",
+      "Maintenez la transparence à chaque étape, même en utilisation anonyme."
     ]
   },
   "es": {

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -4,18 +4,19 @@
   <meta charset="UTF-8" />
   <title>Ethicom Signup</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="language-selector.js"></script>
   <script src="signup.js"></script>
 </head>
 <body>
   <main class="card">
-    <h2>Sign up</h2>
-    <label for="email_input">Email:</label>
+    <h2 data-ui="signup_title">Sign up</h2>
+    <label for="email_input" data-ui="signup_email">Email:</label>
     <input type="email" id="email_input" placeholder="name@provider.com" />
 
-    <label for="pw_input">Password:</label>
+    <label for="pw_input" data-ui="signup_password">Password:</label>
     <input type="password" id="pw_input" placeholder="At least 8 characters" />
 
-    <button onclick="handleSignup()">Create Account</button>
+    <button id="signup_btn" onclick="handleSignup()">Create Account</button>
     <pre id="signup_status" style="white-space:pre-wrap;margin-top:1em;"></pre>
   </main>
 </body>

--- a/interface/signup.js
+++ b/interface/signup.js
@@ -5,6 +5,35 @@ const secureHosts = [
   'posteo.de'
 ];
 
+let uiText = {};
+
+function applySignupTexts() {
+  document.documentElement.lang = localStorage.getItem('ethicom_lang') || 'en';
+  const t = uiText;
+  const h2 = document.querySelector('[data-ui="signup_title"]');
+  if (h2) h2.textContent = t.signup_title || h2.textContent;
+  const emailLabel = document.querySelector('label[for="email_input"]');
+  if (emailLabel) emailLabel.textContent = t.signup_email || emailLabel.textContent;
+  const pwLabel = document.querySelector('label[for="pw_input"]');
+  if (pwLabel) pwLabel.textContent = t.signup_password || pwLabel.textContent;
+  const signupBtn = document.getElementById('signup_btn');
+  if (signupBtn) signupBtn.textContent = t.signup_btn || signupBtn.textContent;
+  const emailInput = document.getElementById('email_input');
+  if (emailInput && t.signup_placeholder_email) emailInput.placeholder = t.signup_placeholder_email;
+  const pwInput = document.getElementById('pw_input');
+  if (pwInput && t.signup_placeholder_pw) pwInput.placeholder = t.signup_placeholder_pw;
+}
+
+function initSignup() {
+  const lang = getLanguage();
+  fetch('i18n/ui-text.json')
+    .then(r => r.json())
+    .then(data => {
+      uiText = data[lang] || data.en || {};
+      applySignupTexts();
+    });
+}
+
 function handleSignup() {
   const emailInput = document.getElementById('email_input');
   const pwInput = document.getElementById('pw_input');
@@ -14,21 +43,23 @@ function handleSignup() {
   statusEl.textContent = '';
 
   if (!/^[^@]+@[^@]+\.[^@]+$/.test(email)) {
-    statusEl.textContent = 'Invalid email format.';
+    statusEl.textContent = uiText.signup_invalid_email || 'Invalid email format.';
     return;
   }
 
   const domain = email.split('@')[1].toLowerCase();
   if (!secureHosts.includes(domain)) {
-    statusEl.textContent = 'Email provider not supported. Use a secure host.';
+    statusEl.textContent = uiText.signup_unsupported || 'Email provider not supported. Use a secure host.';
     return;
   }
 
   if (password.length < 8) {
-    statusEl.textContent = 'Password must be at least 8 characters.';
+    statusEl.textContent = uiText.signup_pw_short || 'Password must be at least 8 characters.';
     return;
   }
 
   localStorage.setItem('ethicom_signup_email', email);
-  statusEl.textContent = 'Signup information saved locally.';
+  statusEl.textContent = uiText.signup_saved || 'Signup information saved locally.';
 }
+
+window.addEventListener('DOMContentLoaded', initSignup);

--- a/interface/translation-manager.js
+++ b/interface/translation-manager.js
@@ -32,6 +32,8 @@ function confirmPendingLang(code) {
 
 function applyTexts(t) {
   if (!t) return;
+  const lang = localStorage.getItem("ethicom_lang") || document.documentElement.lang;
+  document.documentElement.lang = lang;
   const titleEl = document.getElementById("title");
   if (titleEl) titleEl.textContent = t.title || titleEl.textContent;
   const sourceLabel = document.querySelector('label[for="sig_input"]');
@@ -40,6 +42,26 @@ function applyTexts(t) {
   if (commentLabel) commentLabel.textContent = t.label_comment || commentLabel.textContent;
   const verifyBtn = document.querySelector('#signature_area button');
   if (verifyBtn) verifyBtn.textContent = t.btn_generate || verifyBtn.textContent;
+
+  const helpTitle = document.querySelector('#help_section summary');
+  if (helpTitle) helpTitle.textContent = t.help_title || helpTitle.textContent;
+  const helpList = document.querySelector('#help_section ol');
+  if (helpList && Array.isArray(t.help_items)) {
+    helpList.innerHTML = t.help_items.map(i => `<li>${i}</li>`).join('');
+  }
+
+  const suTitle = document.querySelector('[data-ui="signup_title"]');
+  if (suTitle) suTitle.textContent = t.signup_title || suTitle.textContent;
+  const suEmail = document.querySelector('[data-ui="signup_email"]');
+  if (suEmail) suEmail.textContent = t.signup_email || suEmail.textContent;
+  const suPw = document.querySelector('[data-ui="signup_password"]');
+  if (suPw) suPw.textContent = t.signup_password || suPw.textContent;
+  const suBtn = document.getElementById('signup_btn');
+  if (suBtn) suBtn.textContent = t.signup_btn || suBtn.textContent;
+  const emailInput = document.getElementById('email_input');
+  if (emailInput && t.signup_placeholder_email) emailInput.placeholder = t.signup_placeholder_email;
+  const pwInput = document.getElementById('pw_input');
+  if (pwInput && t.signup_placeholder_pw) pwInput.placeholder = t.signup_placeholder_pw;
 }
 
 function initTranslationManager() {
@@ -64,7 +86,19 @@ function initTranslationManager() {
       label_comment: "",
       btn_generate: "",
       btn_download: "",
-      aspects: ["", "", "", "", ""]
+      aspects: ["", "", "", "", ""],
+      signup_title: "",
+      signup_email: "",
+      signup_password: "",
+      signup_btn: "",
+      signup_placeholder_email: "",
+      signup_placeholder_pw: "",
+      signup_invalid_email: "",
+      signup_unsupported: "",
+      signup_pw_short: "",
+      signup_saved: "",
+      help_title: "",
+      help_items: ["", "", "", "", "", "", "", "", "", ""]
     };
     showTranslationEditor(code, data);
   });
@@ -97,6 +131,20 @@ function showTranslationEditor(code, data) {
     <label>Button Generate:<br><input id="tr_generate" value="${data.btn_generate || ""}"></label><br>
     <label>Button Download:<br><input id="tr_download" value="${data.btn_download || ""}"></label><br>
     <label>Aspects (comma separated):<br><input id="tr_aspectlist" value="${(data.aspects || []).join(", ")}"></label><br>
+    <h4>Signup</h4>
+    <label>Title:<br><input id="tr_su_title" value="${data.signup_title || ""}"></label><br>
+    <label>Email Label:<br><input id="tr_su_email" value="${data.signup_email || ""}"></label><br>
+    <label>Password Label:<br><input id="tr_su_pw" value="${data.signup_password || ""}"></label><br>
+    <label>Button Text:<br><input id="tr_su_btn" value="${data.signup_btn || ""}"></label><br>
+    <label>Email Placeholder:<br><input id="tr_su_ph_email" value="${data.signup_placeholder_email || ""}"></label><br>
+    <label>Password Placeholder:<br><input id="tr_su_ph_pw" value="${data.signup_placeholder_pw || ""}"></label><br>
+    <label>Msg Invalid Email:<br><input id="tr_su_invalid" value="${data.signup_invalid_email || ""}"></label><br>
+    <label>Msg Unsupported:<br><input id="tr_su_unsupported" value="${data.signup_unsupported || ""}"></label><br>
+    <label>Msg Short Password:<br><input id="tr_su_pwshort" value="${data.signup_pw_short || ""}"></label><br>
+    <label>Msg Saved:<br><input id="tr_su_saved" value="${data.signup_saved || ""}"></label><br>
+    <h4>Help Section</h4>
+    <label>Help Title:<br><input id="tr_help_title" value="${data.help_title || ""}"></label><br>
+    <label>Help Items (comma separated):<br><input id="tr_help_items" value="${(data.help_items || []).join(', ')}"></label><br>
     <button id="tr_save">Save</button>
     <button id="tr_cancel">Cancel</button>
   `;
@@ -113,7 +161,19 @@ function showTranslationEditor(code, data) {
       label_comment: document.getElementById("tr_comment").value,
       btn_generate: document.getElementById("tr_generate").value,
       btn_download: document.getElementById("tr_download").value,
-      aspects: document.getElementById("tr_aspectlist").value.split(/,\s*/)
+      aspects: document.getElementById("tr_aspectlist").value.split(/,\s*/),
+      signup_title: document.getElementById("tr_su_title").value,
+      signup_email: document.getElementById("tr_su_email").value,
+      signup_password: document.getElementById("tr_su_pw").value,
+      signup_btn: document.getElementById("tr_su_btn").value,
+      signup_placeholder_email: document.getElementById("tr_su_ph_email").value,
+      signup_placeholder_pw: document.getElementById("tr_su_ph_pw").value,
+      signup_invalid_email: document.getElementById("tr_su_invalid").value,
+      signup_unsupported: document.getElementById("tr_su_unsupported").value,
+      signup_pw_short: document.getElementById("tr_su_pwshort").value,
+      signup_saved: document.getElementById("tr_su_saved").value,
+      help_title: document.getElementById("tr_help_title").value,
+      help_items: document.getElementById("tr_help_items").value.split(/,\s*/)
     };
     savePendingLang(code, obj);
     uiTexts[code] = obj;


### PR DESCRIPTION
## Summary
- expand `ui-text.json` with signup and help translations
- translate signup page using user language choice
- extend translation manager to cover signup and help text

## Testing
- `node --test`