### PR TITLE
Add evidence recording utilities

### DIFF
--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -5,6 +5,7 @@
   <title>Ethicom Interface</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="ethicom-utils.js"></script>
+  <script src="evidence-recorder.js"></script>
   <script src="signature-verifier.js"></script>
   <script src="interface-loader.js"></script>
   <script src="language-selector.js"></script>

--- a/interface/evidence-recorder.js
+++ b/interface/evidence-recorder.js
@@ -1,0 +1,13 @@
+// evidence-recorder.js - store hashed evidence in localStorage
+async function recordEvidence(data, actor = 'user') {
+  const timestamp = new Date().toISOString();
+  const hash = await sha256(data);
+  const entry = { actor, timestamp, hash, data };
+  const existing = JSON.parse(localStorage.getItem('ethicom_evidence') || '[]');
+  existing.push(entry);
+  localStorage.setItem('ethicom_evidence', JSON.stringify(existing));
+}
+
+function listEvidence() {
+  return JSON.parse(localStorage.getItem('ethicom_evidence') || '[]');
+}

--- a/interface/modules/op-0-interface.js
+++ b/interface/modules/op-0-interface.js
@@ -46,4 +46,8 @@ function generateAnonymousManifest() {
 
   const output = document.getElementById("output");
   output.textContent = JSON.stringify(evalData, null, 2);
+
+  if (typeof recordEvidence === "function") {
+    recordEvidence(JSON.stringify(evalData), "user");
+  }
 }

--- a/interface/modules/op-5-interface.js
+++ b/interface/modules/op-5-interface.js
@@ -44,4 +44,8 @@ function generateWithdrawal() {
 
   const output = document.getElementById("output");
   output.textContent = JSON.stringify(withdrawalData, null, 2);
+
+  if (typeof recordEvidence === "function") {
+    recordEvidence(JSON.stringify(withdrawalData), "operator");
+  }
 }

--- a/test/evidence-recorder.test.js
+++ b/test/evidence-recorder.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const saveEvidence = require('../tools/evidence-recorder');
+
+const evidenceDir = path.join(__dirname, '..', 'evidence');
+
+function cleanup(file) {
+  try {
+    fs.unlinkSync(path.join(evidenceDir, file));
+  } catch (err) {
+    // ignore
+  }
+}
+
+test('saveEvidence creates evidence file', () => {
+  const data = 'test-evidence';
+  const file = saveEvidence(data, 'dev');
+  const p = path.join(evidenceDir, file);
+  assert.ok(fs.existsSync(p));
+  const obj = JSON.parse(fs.readFileSync(p, 'utf8'));
+  assert.strictEqual(obj.data, data);
+  assert.strictEqual(obj.actor, 'dev');
+  assert.ok(obj.hash && obj.hash.length === 64);
+  cleanup(file);
+});

--- a/tools/evidence-recorder.js
+++ b/tools/evidence-recorder.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+function saveEvidence(data, actor = 'user') {
+  const evidenceDir = path.join(__dirname, '..', 'evidence');
+  if (!fs.existsSync(evidenceDir)) {
+    fs.mkdirSync(evidenceDir, { recursive: true });
+  }
+
+  const timestamp = new Date().toISOString();
+  const hash = crypto.createHash('sha256').update(data).digest('hex');
+
+  const entry = { actor, timestamp, hash, data };
+  const nameSafeTime = timestamp.replace(/[:.]/g, '-');
+  const filename = `${actor}-${nameSafeTime}.json`;
+  fs.writeFileSync(path.join(evidenceDir, filename), JSON.stringify(entry, null, 2));
+  return filename;
+}
+
+if (require.main === module) {
+  const [actor, file] = process.argv.slice(2);
+  if (!file) {
+    console.error('Usage: node evidence-recorder.js <actor> <file>');
+    process.exit(1);
+  }
+  const content = fs.readFileSync(file, 'utf8');
+  const out = saveEvidence(content, actor || 'user');
+  console.log('Saved evidence:', out);
+}
+
+module.exports = saveEvidence;


### PR DESCRIPTION
## Summary
- add node-based evidence recorder under tools/
- enable browser evidence recorder and load in HTML
- record anonymous and withdrawal manifests as evidence
- store evidence files
- test evidence recorder works

## Testing
- `node --test`