### PR TITLE
Implement accessibility setup

### DIFF
--- a/i18n/ui-text.json
+++ b/i18n/ui-text.json
@@ -35,7 +35,15 @@
       "Create signatures locally and confirm them structurally.",
       "Withdrawals or corrections are part of the process, not weakness.",
       "Maintain transparency at every step, even with anonymous use."
-    ]
+    ],
+    "access_title": "Accessibility Setup",
+    "access_label_vision": "Can you see the screen?",
+    "access_label_hearing": "Can you hear from this device?",
+    "access_label_speech": "Can you speak?",
+    "access_save_btn": "Save Setup",
+    "access_opt_yes": "Yes",
+    "access_opt_no": "No",
+    "access_opt_yes_nospeech": "Yes, but cannot speak"
   },
   "de": {
     "title": "Ethicom: Bewertung durch Menschen",
@@ -73,7 +81,15 @@
       "Erstelle Signaturen lokal und bestätige sie strukturell.",
       "Rückzüge oder Korrekturen sind Teil des Prozesses, keine Schwäche.",
       "Wahre Transparenz in jedem Schritt, auch bei anonymer Nutzung."
-    ]
+    ],
+    "access_title": "Zugänglichkeits-Einstellungen",
+    "access_label_vision": "Kannst du den Bildschirm sehen?",
+    "access_label_hearing": "Kannst du dieses Gerät hören?",
+    "access_label_speech": "Kannst du sprechen?",
+    "access_save_btn": "Einstellungen speichern",
+    "access_opt_yes": "Ja",
+    "access_opt_no": "Nein",
+    "access_opt_yes_nospeech": "Ja, aber ohne sprechen"
   },
   "fr": {
     "title": "Ethicom : Évaluation humaine",

--- a/interface/accessibility.js
+++ b/interface/accessibility.js
@@ -1,0 +1,49 @@
+function initAccessibilitySetup() {
+  const container = document.getElementById("access_setup");
+  if (!container) return;
+
+  const saved = JSON.parse(localStorage.getItem("ethicom_access") || "{}");
+  const vision = saved.vision || "yes";
+  const hearing = saved.hearing || "yes";
+  const speech = saved.speech || "no";
+
+  container.innerHTML = `
+    <h3 data-ui="access_title">Accessibility Setup</h3>
+    <label for="vision_select" data-ui="access_label_vision">Can you see the screen?</label>
+    <select id="vision_select">
+      <option value="yes" data-ui="access_opt_yes">Yes</option>
+      <option value="no" data-ui="access_opt_no">No</option>
+    </select>
+
+    <label for="hearing_select" data-ui="access_label_hearing">Can you hear from this device?</label>
+    <select id="hearing_select">
+      <option value="yes_nospeech" data-ui="access_opt_yes_nospeech">Yes, but cannot speak</option>
+      <option value="yes" data-ui="access_opt_yes">Yes</option>
+      <option value="no" data-ui="access_opt_no">No</option>
+    </select>
+
+    <label for="speech_select" data-ui="access_label_speech">Can you speak?</label>
+    <select id="speech_select">
+      <option value="no" data-ui="access_opt_no">No</option>
+      <option value="yes" data-ui="access_opt_yes">Yes</option>
+    </select>
+
+    <button id="access_save" data-ui="access_save_btn">Save Setup</button>
+  `;
+
+  document.getElementById("vision_select").value = vision;
+  document.getElementById("hearing_select").value = hearing;
+  document.getElementById("speech_select").value = speech;
+
+  document.getElementById("access_save").addEventListener("click", () => {
+    const data = {
+      vision: document.getElementById("vision_select").value,
+      hearing: document.getElementById("hearing_select").value,
+      speech: document.getElementById("speech_select").value
+    };
+    localStorage.setItem("ethicom_access", JSON.stringify(data));
+    alert("Accessibility preferences saved.");
+  });
+}
+
+window.addEventListener("DOMContentLoaded", initAccessibilitySetup);

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -10,6 +10,7 @@
   <script src="interface-loader.js"></script>
   <script src="language-selector.js"></script>
   <script src="translation-manager.js"></script>
+  <script src="accessibility.js"></script>
 </head>
 <body>
   <header>
@@ -27,6 +28,8 @@
         <option value="">--</option>
       </select>
     </div>
+
+    <div id="access_setup" class="card"></div>
 
     <div class="card" id="signature_area">
       <label for="sig_input">Your signature ID:</label>

--- a/interface/translation-manager.js
+++ b/interface/translation-manager.js
@@ -62,6 +62,27 @@ function applyTexts(t) {
   if (emailInput && t.signup_placeholder_email) emailInput.placeholder = t.signup_placeholder_email;
   const pwInput = document.getElementById('pw_input');
   if (pwInput && t.signup_placeholder_pw) pwInput.placeholder = t.signup_placeholder_pw;
+
+  const acTitle = document.querySelector('[data-ui="access_title"]');
+  if (acTitle) acTitle.textContent = t.access_title || acTitle.textContent;
+  const acVision = document.querySelector('[data-ui="access_label_vision"]');
+  if (acVision) acVision.textContent = t.access_label_vision || acVision.textContent;
+  const acHearing = document.querySelector('[data-ui="access_label_hearing"]');
+  if (acHearing) acHearing.textContent = t.access_label_hearing || acHearing.textContent;
+  const acSpeech = document.querySelector('[data-ui="access_label_speech"]');
+  if (acSpeech) acSpeech.textContent = t.access_label_speech || acSpeech.textContent;
+  const acSave = document.getElementById('access_save');
+  if (acSave) acSave.textContent = t.access_save_btn || acSave.textContent;
+
+  document.querySelectorAll('option[data-ui="access_opt_yes"]').forEach(o => {
+    if (t.access_opt_yes) o.textContent = t.access_opt_yes;
+  });
+  document.querySelectorAll('option[data-ui="access_opt_no"]').forEach(o => {
+    if (t.access_opt_no) o.textContent = t.access_opt_no;
+  });
+  document.querySelectorAll('option[data-ui="access_opt_yes_nospeech"]').forEach(o => {
+    if (t.access_opt_yes_nospeech) o.textContent = t.access_opt_yes_nospeech;
+  });
 }
 
 function initTranslationManager() {
@@ -97,6 +118,14 @@ function initTranslationManager() {
       signup_unsupported: "",
       signup_pw_short: "",
       signup_saved: "",
+      access_title: "",
+      access_label_vision: "",
+      access_label_hearing: "",
+      access_label_speech: "",
+      access_save_btn: "",
+      access_opt_yes: "",
+      access_opt_no: "",
+      access_opt_yes_nospeech: "",
       help_title: "",
       help_items: ["", "", "", "", "", "", "", "", "", ""]
     };
@@ -142,6 +171,15 @@ function showTranslationEditor(code, data) {
     <label>Msg Unsupported:<br><input id="tr_su_unsupported" value="${data.signup_unsupported || ""}"></label><br>
     <label>Msg Short Password:<br><input id="tr_su_pwshort" value="${data.signup_pw_short || ""}"></label><br>
     <label>Msg Saved:<br><input id="tr_su_saved" value="${data.signup_saved || ""}"></label><br>
+    <h4>Accessibility</h4>
+    <label>Title:<br><input id="tr_ac_title" value="${data.access_title || ""}"></label><br>
+    <label>Label Vision:<br><input id="tr_ac_vision" value="${data.access_label_vision || ""}"></label><br>
+    <label>Label Hearing:<br><input id="tr_ac_hearing" value="${data.access_label_hearing || ""}"></label><br>
+    <label>Label Speech:<br><input id="tr_ac_speech" value="${data.access_label_speech || ""}"></label><br>
+    <label>Button Text:<br><input id="tr_ac_save" value="${data.access_save_btn || ""}"></label><br>
+    <label>Opt Yes:<br><input id="tr_ac_yes" value="${data.access_opt_yes || ""}"></label><br>
+    <label>Opt No:<br><input id="tr_ac_no" value="${data.access_opt_no || ""}"></label><br>
+    <label>Opt Hear+NoSpeak:<br><input id="tr_ac_yes_nospeech" value="${data.access_opt_yes_nospeech || ""}"></label><br>
     <h4>Help Section</h4>
     <label>Help Title:<br><input id="tr_help_title" value="${data.help_title || ""}"></label><br>
     <label>Help Items (comma separated):<br><input id="tr_help_items" value="${(data.help_items || []).join(', ')}"></label><br>
@@ -172,6 +210,14 @@ function showTranslationEditor(code, data) {
       signup_unsupported: document.getElementById("tr_su_unsupported").value,
       signup_pw_short: document.getElementById("tr_su_pwshort").value,
       signup_saved: document.getElementById("tr_su_saved").value,
+      access_title: document.getElementById("tr_ac_title").value,
+      access_label_vision: document.getElementById("tr_ac_vision").value,
+      access_label_hearing: document.getElementById("tr_ac_hearing").value,
+      access_label_speech: document.getElementById("tr_ac_speech").value,
+      access_save_btn: document.getElementById("tr_ac_save").value,
+      access_opt_yes: document.getElementById("tr_ac_yes").value,
+      access_opt_no: document.getElementById("tr_ac_no").value,
+      access_opt_yes_nospeech: document.getElementById("tr_ac_yes_nospeech").value,
       help_title: document.getElementById("tr_help_title").value,
       help_items: document.getElementById("tr_help_items").value.split(/,\s*/)
     };


### PR DESCRIPTION
## Summary
- add accessibility.js for user capability configuration
- embed the setup card and script in `ethicom.html`
- extend translation system and translations to include accessibility labels
- update translation manager to handle new fields

## Testing
- `node --test`