### PR TITLE
Show all badges on initial load

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -107,6 +107,7 @@ button:hover {
 .badge.op-5   { background: #66aa33; }
 .badge.op-6   { background: #228B22; }
 .badge.op-7   { background: #146b1f; }
+.badge.op-75  { background: #0f5a1a; }
 .badge.op-79  { background: #0e4712; }
 .badge.op-8   { background: #4a6670; }
 .badge.op-9   { background: #3c3744; }
@@ -126,6 +127,13 @@ button:hover {
   align-items: center;
   margin-top: 0.5em;
   margin-bottom: 1em;
+}
+
+.badge-gallery {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4em;
+  margin-bottom: 1.5em;
 }
 
 #status {

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -20,6 +20,36 @@ function renderBadge(currentRank, maxRank) {
   }
 }
 
+// Display all available badges in a gallery
+function renderAllBadges() {
+  const gallery = document.getElementById("badge_gallery");
+  if (!gallery) return;
+
+  const levels = [
+    "OP-0",
+    "OP-1",
+    "OP-2",
+    "OP-3",
+    "OP-4",
+    "OP-5",
+    "OP-6",
+    "OP-7",
+    "OP-7.5",
+    "OP-7.9",
+    "OP-8",
+    "OP-9",
+    "OP-10"
+  ];
+
+  gallery.innerHTML = "";
+  levels.forEach(lvl => {
+    const span = document.createElement("span");
+    span.className = `badge op-${lvl.replace("OP-", "").replace(/\./g, "")}`;
+    span.textContent = lvl;
+    gallery.appendChild(span);
+  });
+}
+
 // Calculate a SHA-256 hash in both browser and Node.js environments
 async function sha256(message) {
   if (typeof window !== "undefined" && window.crypto && window.crypto.subtle) {

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -24,6 +24,8 @@
   <main class="card">
     <h2 id="title">Ethicom Evaluation</h2>
 
+    <div id="badge_gallery" class="badge-gallery"></div>
+
     <div id="badge_display" class="badge-row"></div>
 
     <div id="lang_selection" class="card">
@@ -97,6 +99,7 @@
         });
 
         initTranslationManager();
+        renderAllBadges();
       });
 
     async function beginSignatureVerification() {


### PR DESCRIPTION
## Summary
- add color for OP-7.5 badge and layout for badge gallery
- add `renderAllBadges` helper
- show a gallery of all badges on `ethicom.html` at first load

## Testing
- `node --test`