### PR TITLE
Align permission definitions

### DIFF
--- a/permissions/op-permissions-expanded.json
+++ b/permissions/op-permissions-expanded.json
@@ -117,5 +117,25 @@
     "can_vote_on_op8": true,
     "can_act_as_structure": true,
     "can_execute_evaluations": true
+  },
+  "OP-9": {
+    "can_rate": true,
+    "can_sign": true,
+    "can_comment": true,
+    "can_nominate": true,
+    "can_vote": true,
+    "can_override": true,
+    "can_retract": true,
+    "can_consensus": true,
+    "can_accept_donations": false,
+    "can_override_op6": true,
+    "can_vote_on_op79": true,
+    "can_vote_on_op8": true,
+    "can_act_as_structure": true,
+    "can_execute_evaluations": true,
+    "can_finalize_system": true
+  },
+  "OP-10": {
+    "can_observe_only": true
   }
 }

--- a/test/op-permissions.test.js
+++ b/test/op-permissions.test.js
@@ -1,0 +1,14 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootPath = path.join(__dirname, '..', 'permissions', 'op-permissions-expanded.json');
+const interfacePath = path.join(__dirname, '..', 'interface', 'op-permissions-expanded.json');
+
+const rootPerm = JSON.parse(fs.readFileSync(rootPath, 'utf8'));
+const interfacePerm = JSON.parse(fs.readFileSync(interfacePath, 'utf8'));
+
+test('op-permissions files match', () => {
+  assert.deepStrictEqual(rootPerm, interfacePerm);
+});


### PR DESCRIPTION
## Summary
- include OP-9 and OP-10 levels in `permissions/op-permissions-expanded.json`
- add test ensuring the interface and root permission files match

## Testing
- `node --test`
