### PR TITLE
Implement gatekeeper configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ include another language, add a new JSON object using the two-letter ISO 639-1
 code as the key and provide translations for all fields found under the `"en"`
 entry. The interface will automatically recognize the new language.
 
+### Gatekeeper Control
+
+Local control can be toggled via `tools/gatekeeper.js`. The script reads
+`app/gatekeeper_config.yaml` and only allows actions when `allow_control` is set
+to `true` for the controller `RL@RLpi`. This keeps remote commands gated and
+limited to the local environment.
+
 
 
 ### Running Tests

--- a/app/gatekeeper_config.yaml
+++ b/app/gatekeeper_config.yaml
@@ -1,0 +1,4 @@
+gatekeeper:
+  controller: "RL@RLpi"
+  allow_control: false
+  local_only: true

--- a/tools/gatekeeper.js
+++ b/tools/gatekeeper.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+function parseConfig() {
+  const configPath = path.join(__dirname, '..', 'app', 'gatekeeper_config.yaml');
+  if (!fs.existsSync(configPath)) {
+    return null;
+  }
+  const lines = fs.readFileSync(configPath, 'utf8').split(/\r?\n/);
+  const cfg = {};
+  lines.forEach(line => {
+    const m = line.trim().match(/^(controller|allow_control|local_only):\s*(.*)$/);
+    if (m) {
+      cfg[m[1]] = m[2].replace(/['"]/g, '');
+    }
+  });
+  return cfg;
+}
+
+function gateCheck() {
+  const cfg = parseConfig();
+  if (!cfg) {
+    console.log('Gatekeeper: configuration missing.');
+    return false;
+  }
+  const allowed = cfg.allow_control === 'true';
+  const controllerOK = cfg.controller === 'RL@RLpi';
+  const local = cfg.local_only === 'true';
+  return allowed && controllerOK && local;
+}
+
+if (gateCheck()) {
+  console.log('Gatekeeper: RL@RLpi control allowed (local only).');
+  process.exit(0);
+} else {
+  console.log('Gatekeeper: control denied.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- document gatekeeper control usage
- add gatekeeper config file
- create a simple script to enforce local gatekeeping for RL@RLpi

## Testing
- `node --test`
- `node tools/gatekeeper.js` (expect "control denied" by default)