### PR TITLE
Fix umlaut encoding in ratings

### DIFF
--- a/interface/ratings.html
+++ b/interface/ratings.html
@@ -19,12 +19,12 @@
     <section class="card">
       <h2>Wie entstehen Gesamtbewertungen?</h2>
       <p>Jede einzelne Bewertung wird mit einem SRC‑Level versehen. Aus allen signierten Bewertungen einer Quelle wird ein Durchschnittswert gebildet. Dieser Durchschnitt bestimmt die Gesamtbewertung.</p>
-      <p>Die Skala reicht von SRC‑0 (unbewusst) bis SRC‑8+ (vollst\u00e4ndig strukturethisch).</p>
+      <p>Die Skala reicht von SRC‑0 (unbewusst) bis SRC‑8+ (vollständig strukturethisch).</p>
     </section>
 
     <section id="rating_summary" class="card">
       <h2>Aktuelle Gesamtwerte</h2>
-      <p>Die folgenden Werte ergeben sich aus allen ver\u00f6ffentlichten Bewertungen.</p>
+      <p>Die folgenden Werte ergeben sich aus allen veröffentlichten Bewertungen.</p>
     </section>
 
     <section id="rating_library" class="card">
@@ -34,7 +34,7 @@
 
     <section class="card">
       <h2>Selbst bewerten</h2>
-      <p>Nimm an der offenen Bewertung teil und erstelle deine eigene Einsch\u00e4tzung \u00fcber <a href="ethicom.html">Ethicom</a>.</p>
+      <p>Nimm an der offenen Bewertung teil und erstelle deine eigene Einschätzung über <a href="ethicom.html">Ethicom</a>.</p>
     </section>
   </main>
 </body>


### PR DESCRIPTION
## Summary
- fix improperly encoded German umlauts in `interface/ratings.html`

## Testing
- `node --test`
