### PR TITLE
Implement dynamic module help boxes

### DIFF
--- a/interface/dynamic-help.js
+++ b/interface/dynamic-help.js
@@ -1,0 +1,105 @@
+const helpMap = {
+  default: {
+    title: 'Help – Operator Conduct',
+    items: [
+      'Always check if your actions meet the ethics of responsibility.',
+      'Use only the tools assigned to your OP level.',
+      'Document decisions in the manifest for verification.',
+      'Nominations and feedback are structured and without personal pressure.',
+      'Consult a higher structure (from OP-7) if unsure.',
+      'Responsibility outweighs convenience.',
+      'Create signatures locally and confirm them structurally.',
+      'Withdrawals or corrections are part of the process, not weakness.',
+      'Maintain transparency at every step, even with anonymous use.'
+    ]
+  },
+  'OP-0': { title: 'OP-0 Tips', items: [
+    'Anonymous ratings have minimal influence.',
+    'Move to OP-1 to sign your evaluations.'
+  ] },
+  'OP-1': { title: 'OP-1 Tips', items: [
+    'Signed evaluations store your signature ID.',
+    'Explain why the chosen SRC fits.'
+  ] },
+  'OP-2': { title: 'OP-2 Tips', items: [
+    'Add aspect tags to highlight angles of your evaluation.',
+    'Private references stay internal only.'
+  ] },
+  'OP-3': { title: 'OP-3 Tips', items: [
+    'Structured reasoning is required.',
+    'Use visual selectors for SRC levels.'
+  ] },
+  'OP-4': { title: 'OP-4 Tips', items: [
+    'Revisions become possible after 21 days.',
+    'Your evaluation is traceable.'
+  ] },
+  'OP-5': { title: 'OP-5 Tips', items: [
+    'You may retract previous evaluations.',
+    'Explain the reason for each withdrawal.'
+  ] },
+  'OP-6': { title: 'OP-6 Tips', items: [
+    'You can calculate consensus from anonymous ratings.'
+  ] },
+  'OP-7': { title: 'OP-7 Tips', items: [
+    'You hold structural authority for nominations.'
+  ] },
+  'OP-7.5': { title: 'OP-7.5 Tips', items: [
+    'Prepare nominations and review OP-8 observations.'
+  ] },
+  'OP-7.9': { title: 'OP-7.9 Tips', items: [
+    'Nominate operators and verify donations.'
+  ] },
+  'OP-8': { title: 'OP-8 Tips', items: [
+    'System-driven structural analysis level.'
+  ] },
+  'OP-9': { title: 'OP-9 Tips', items: [
+    'Yokozuna-level responsibilities apply.'
+  ] },
+  'OP-10': { title: 'OP-10 Tips', items: [
+    'First non-human development stage.'
+  ] }
+};
+
+function isDevMode() {
+  const params = new URLSearchParams(window.location.search);
+  if (params.has('dev')) return true;
+  return localStorage.getItem('ethicom_dev') === 'true';
+}
+
+function buildDetails(title, items) {
+  const details = document.createElement('details');
+  details.open = true;
+  const summary = document.createElement('summary');
+  summary.textContent = title;
+  details.appendChild(summary);
+  const list = document.createElement('ol');
+  items.forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = item;
+    list.appendChild(li);
+  });
+  details.appendChild(list);
+  return details;
+}
+
+function setHelpSection(opLevel) {
+  const section = document.getElementById('help_section');
+  if (!section) return;
+  section.innerHTML = '';
+
+  if (isDevMode()) {
+    Object.keys(helpMap)
+      .filter(k => k !== 'default')
+      .forEach(key => {
+        const info = helpMap[key];
+        section.appendChild(buildDetails(info.title, info.items));
+      });
+    return;
+  }
+
+  const data = helpMap[opLevel] || helpMap.default;
+  section.appendChild(buildDetails(data.title, data.items));
+}
+
+window.addEventListener('DOMContentLoaded', () => setHelpSection('default'));
+window.setHelpSection = setHelpSection;

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -11,6 +11,7 @@
   <script src="language-selector.js"></script>
   <script src="translation-manager.js"></script>
   <script src="accessibility.js"></script>
+  <script src="dynamic-help.js"></script>
 </head>
 <body>
   <header>
@@ -59,22 +60,7 @@
 
     <pre id="output" class="card" style="background:#2b2b2b; white-space:pre-wrap; color:#ccc;"></pre>
 
-    <section id="help_section" class="card">
-      <details open>
-        <summary>Hilfe – Operator-Verhalten</summary>
-        <ol>
-          <li>Prüfe jederzeit, ob dein Handeln der Verantwortungsethik entspricht.</li>
-          <li>Nutze nur die Mittel, die deinem OP-Level zugeordnet sind.</li>
-          <li>Dokumentiere Entscheidungen im Manifest, damit sie überprüfbar bleiben.</li>
-          <li>Nominierungen und Rückmeldungen erfolgen strukturiert und ohne persönlichen Druck.</li>
-          <li>Bei Unsicherheit konsultiere eine höhere Struktur (ab OP‑7).</li>
-          <li>Verantwortung geht stets vor Bequemlichkeit.</li>
-          <li>Erstelle Signaturen lokal und bestätige sie strukturell.</li>
-          <li>Rückzüge oder Korrekturen sind Teil des Prozesses, keine Schwäche.</li>
-          <li>Wahre Transparenz in jedem Schritt, auch bei anonymer Nutzung.</li>
-        </ol>
-      </details>
-    </section>
+    <section id="help_section" class="card"></section>
   </main>
 
   <script>

--- a/interface/interface-loader.js
+++ b/interface/interface-loader.js
@@ -62,6 +62,9 @@ function loadInterfaceForOP(op_level) {
       initLanguageManager();
 
     }
+    if (typeof window.setHelpSection === "function") {
+      window.setHelpSection(op_level);
+    }
     if (status) status.textContent = "Module loaded";
   };
   document.body.appendChild(script);

--- a/interface/translation-manager.js
+++ b/interface/translation-manager.js
@@ -43,11 +43,13 @@ function applyTexts(t) {
   const verifyBtn = document.querySelector('#signature_area button');
   if (verifyBtn) verifyBtn.textContent = t.btn_generate || verifyBtn.textContent;
 
-  const helpTitle = document.querySelector('#help_section summary');
-  if (helpTitle) helpTitle.textContent = t.help_title || helpTitle.textContent;
-  const helpList = document.querySelector('#help_section ol');
-  if (helpList && Array.isArray(t.help_items)) {
-    helpList.innerHTML = t.help_items.map(i => `<li>${i}</li>`).join('');
+  if (typeof window.setHelpSection !== 'function') {
+    const helpTitle = document.querySelector('#help_section summary');
+    if (helpTitle) helpTitle.textContent = t.help_title || helpTitle.textContent;
+    const helpList = document.querySelector('#help_section ol');
+    if (helpList && Array.isArray(t.help_items)) {
+      helpList.innerHTML = t.help_items.map(i => `<li>${i}</li>`).join('');
+    }
   }
 
   const suTitle = document.querySelector('[data-ui="signup_title"]');


### PR DESCRIPTION
## Summary
- create `dynamic-help.js` to manage per-module tips
- load dynamic help in `ethicom.html`
- call `setHelpSection()` from `interface-loader.js`
- skip help text translation when dynamic help is active
- support `dev` mode to display help for all modules at once

## Testing
- `node --test`
