### PR TITLE
Enable language switching

### DIFF
--- a/interface/erstkontakt.html
+++ b/interface/erstkontakt.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <title>Erstkontakt</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="language-selector.js"></script>
   <script src="ratings.js"></script>
   <script src="interface-loader.js"></script>
   <style>
@@ -20,6 +21,10 @@
     <a href="signup.html">Signup</a>
   </nav>
   <main class="card">
+    <div id="lang_selection" class="card" style="margin-bottom:1em;">
+      <label for="lang_select">Language:</label>
+      <select id="lang_select"></select>
+    </div>
     <section class="card">
       <h2>Erste Einblicke</h2>
       <p>Hier siehst du die bisherigen Bewertungen und kannst dir einen Eindruck verschaffen.</p>
@@ -30,7 +35,10 @@
     <div id="op_interface" class="card" style="display:none;"></div>
   </main>
   <script>
-    document.addEventListener('DOMContentLoaded', initRatings);
+    document.addEventListener('DOMContentLoaded', () => {
+      initLanguageDropdown('lang_select');
+      initRatings();
+    });
     function showOP0() {
       const container = document.getElementById('op_interface');
       container.style.display = 'block';

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -65,29 +65,15 @@
   </main>
 
   <script>
-    let userLang = null;
-
-    loadUiTexts().then(texts => {
-        const select = document.getElementById("lang_select");
-        Object.keys(texts)
-          .sort()
-          .forEach(code => {
-            const opt = document.createElement("option");
-            opt.value = code;
-            opt.textContent = code;
-            select.appendChild(opt);
-          });
-
-        select.addEventListener("change", e => {
-          userLang = e.target.value;
-          localStorage.setItem("ethicom_lang", userLang);
-          const t = texts[userLang] || {};
-          applyTexts(t);
-        });
-
+    document.addEventListener("DOMContentLoaded", () => {
+      initLanguageDropdown("lang_select");
+      loadUiTexts().then(texts => {
+        const t = texts[getLanguage()] || {};
+        applyTexts(t);
         initTranslationManager();
         renderAllBadges();
       });
+    });
 
     async function beginSignatureVerification() {
       const status = document.getElementById("status");

--- a/interface/language-selector.js
+++ b/interface/language-selector.js
@@ -18,3 +18,27 @@ function getLanguage() {
   const stored = localStorage.getItem("ethicom_lang");
   return stored || askLanguageChoice();
 }
+
+// Initialize a language dropdown and reload on change
+function initLanguageDropdown(selectId = "lang_select") {
+  fetch("i18n/ui-text.json")
+    .then(r => r.json())
+    .then(texts => {
+      const select = document.getElementById(selectId);
+      if (!select) return;
+      Object.keys(texts)
+        .sort()
+        .forEach(code => {
+          const opt = document.createElement("option");
+          opt.value = code;
+          opt.textContent = code;
+          select.appendChild(opt);
+        });
+      const current = getLanguage();
+      select.value = current;
+      select.addEventListener("change", e => {
+        localStorage.setItem("ethicom_lang", e.target.value);
+        location.reload();
+      });
+    });
+}

--- a/interface/ratings.html
+++ b/interface/ratings.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <title>Gesamtbewertungen</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="language-selector.js"></script>
   <script src="ratings.js"></script>
 </head>
 <body>
@@ -16,6 +17,10 @@
     <a href="signup.html">Signup</a>
   </nav>
   <main class="card">
+    <div id="lang_selection" class="card" style="margin-bottom:1em;">
+      <label for="lang_select">Language:</label>
+      <select id="lang_select"></select>
+    </div>
     <section class="card">
       <h2>Wie entstehen Gesamtbewertungen?</h2>
       <p>Jede einzelne Bewertung wird mit einem SRC‑Level versehen. Aus allen signierten Bewertungen einer Quelle wird ein Durchschnittswert gebildet. Dieser Durchschnitt bestimmt die Gesamtbewertung.</p>
@@ -37,5 +42,11 @@
       <p>Nimm an der offenen Bewertung teil und erstelle deine eigene Einschätzung über <a href="ethicom.html">Ethicom</a>.</p>
     </section>
   </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      initLanguageDropdown('lang_select');
+      initRatings();
+    });
+  </script>
 </body>
 </html>

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -17,6 +17,10 @@
     <a href="signup.html">Signup</a>
   </nav>
   <main class="card">
+    <div id="lang_selection" class="card" style="margin-bottom:1em;">
+      <label for="lang_select">Language:</label>
+      <select id="lang_select"></select>
+    </div>
     <h2 data-ui="signup_title">Sign up</h2>
     <label for="email_input" data-ui="signup_email">Email:</label>
     <input type="email" id="email_input" placeholder="name@provider.com" />
@@ -27,5 +31,11 @@
     <button id="signup_btn" onclick="handleSignup()">Create Account</button>
     <pre id="signup_status" style="white-space:pre-wrap;margin-top:1em;"></pre>
   </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      initLanguageDropdown('lang_select');
+      initSignup();
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `initLanguageDropdown` helper
- reload page and reapply translation when switching languages
- show language dropdown on signup, ratings, and erstkontakt pages

## Testing
- `node --test`