### PR TITLE
Add OP logo background and selectable theme

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -1,12 +1,30 @@
 
 /* ethicom-style.css – 4789-konform */
 
+
 :root {
   --bg-color: #1e1e1e;
   --text-color: #e0e0e0;
   --primary-color: #228B22;
   --card-bg: #2b2b2b;
   --accent-color: #ccaa22;
+}
+
+/* Theme classes override the CSS variables */
+.theme-dark {
+  --bg-color: #1e1e1e;
+  --text-color: #e0e0e0;
+  --primary-color: #228B22;
+  --card-bg: #2b2b2b;
+  --accent-color: #ccaa22;
+}
+
+.theme-tanna {
+  --bg-color: #eef6ee;
+  --text-color: #003300;
+  --primary-color: #228B22;
+  --card-bg: #ffffff;
+  --accent-color: #228B22;
 }
 
 body {
@@ -173,5 +191,22 @@ button:hover {
 }
 .accent-button:hover {
   background-color: #b58f1b;
+}
+
+/* Background grid showing all OP logos */
+#op_background {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  justify-items: center;
+  align-items: center;
+  opacity: 0.08;
+  pointer-events: none;
+}
+
+#op_background img {
+  max-width: 100px;
 }
 

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -12,8 +12,11 @@
   <script src="translation-manager.js"></script>
   <script src="accessibility.js"></script>
   <script src="dynamic-help.js"></script>
+  <script src="theme-manager.js"></script>
+  <script src="logo-background.js"></script>
 </head>
 <body>
+  <div id="op_background"></div>
   <header>
     <h1>Ethicom Evaluation</h1>
   </header>
@@ -40,6 +43,14 @@
       <span class="help-icon" title="Select the two-letter code for your preferred language.">?</span>
       <select id="lang_select">
         <option value="">--</option>
+      </select>
+    </div>
+
+    <div id="theme_selection" class="card">
+      <label for="theme_select">Farbschema:</label>
+      <select id="theme_select">
+        <option value="dark">Dark</option>
+        <option value="tanna">Tanna</option>
       </select>
     </div>
 

--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -1,0 +1,13 @@
+function loadOpLogos() {
+  const container = document.getElementById('op_background');
+  if (!container) return;
+  const levels = [0,1,2,3,4,5,6,7];
+  levels.forEach(lvl => {
+    const img = document.createElement('img');
+    img.src = `../op-logo/tanna_op${lvl}.png`;
+    img.alt = `OP-${lvl} logo`;
+    container.appendChild(img);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', loadOpLogos);

--- a/interface/theme-manager.js
+++ b/interface/theme-manager.js
@@ -1,0 +1,21 @@
+function applyTheme(theme) {
+  const body = document.body;
+  body.classList.remove('theme-dark', 'theme-tanna');
+  body.classList.add('theme-' + theme);
+}
+
+function initThemeSelection() {
+  const select = document.getElementById('theme_select');
+  let theme = localStorage.getItem('ethicom_theme') || 'dark';
+  applyTheme(theme);
+  if (select) {
+    select.value = theme;
+    select.addEventListener('change', e => {
+      theme = e.target.value;
+      localStorage.setItem('ethicom_theme', theme);
+      applyTheme(theme);
+    });
+  }
+}
+
+document.addEventListener('DOMContentLoaded', initThemeSelection);


### PR DESCRIPTION
## Summary
- show all OP logos on the page background
- add theme selection with dark and tanna schemes
- implement theme and background loaders

## Testing
- `node --test`