### PR TITLE
Improve language dropdown and translations

### DIFF
--- a/i18n/ui-text.json
+++ b/i18n/ui-text.json
@@ -43,7 +43,14 @@
     "access_save_btn": "Save Setup",
     "access_opt_yes": "Yes",
     "access_opt_no": "No",
-    "access_opt_yes_nospeech": "Yes, but cannot speak"
+    "access_opt_yes_nospeech": "Yes, but cannot speak",
+    "nav_start": "Start",
+    "nav_ratings": "Ratings",
+    "nav_signup": "Signup",
+    "nav_readme": "README",
+    "preview_msg": "Curious? Click \"Preview Start\" to try OP-0 without logging in.",
+    "preview_btn": "Preview Start (OP-0)",
+    "label_choose_language": "Choose your language (ISO 639-1):"
   },
   "de": {
     "title": "Ethicom: Bewertung durch Menschen",
@@ -89,7 +96,14 @@
     "access_save_btn": "Einstellungen speichern",
     "access_opt_yes": "Ja",
     "access_opt_no": "Nein",
-    "access_opt_yes_nospeech": "Ja, aber ohne sprechen"
+    "access_opt_yes_nospeech": "Ja, aber ohne sprechen",
+    "nav_start": "Start",
+    "nav_ratings": "Bewertungen",
+    "nav_signup": "Signup",
+    "nav_readme": "README",
+    "preview_msg": "Schnupper gefällig? Klicke auf \"Schnupper-Start\" und teste OP-0 ohne Login.",
+    "preview_btn": "Schnupper-Start (OP-0)",
+    "label_choose_language": "Sprache wählen (ISO 639-1):"
   },
   "fr": {
     "title": "Ethicom : Évaluation humaine",
@@ -127,7 +141,14 @@
       "Créez les signatures localement et confirmez-les structurellement.",
       "Les retraits ou corrections font partie du processus, pas une faiblesse.",
       "Maintenez la transparence à chaque étape, même en utilisation anonyme."
-    ]
+    ],
+    "nav_start": "Accueil",
+    "nav_ratings": "Évaluations",
+    "nav_signup": "Inscription",
+    "nav_readme": "README",
+    "preview_msg": "Curieux ? Cliquez sur \"Aperçu\" pour tester OP-0 sans vous connecter.",
+    "preview_btn": "Aperçu (OP-0)",
+    "label_choose_language": "Choisissez votre langue (ISO 639-1):"
   },
   "es": {
     "title": "Ethicom: Evaluación Humana",
@@ -143,7 +164,14 @@
       "Reflexión del Sistema",
       "Manejo de Errores",
       "Claridad de Propósito"
-    ]
+    ],
+    "nav_start": "Inicio",
+    "nav_ratings": "Valoraciones",
+    "nav_signup": "Registro",
+    "nav_readme": "README",
+    "preview_msg": "¿Curioso? Haz clic en \"Inicio de prueba\" para probar OP-0 sin iniciar sesión.",
+    "preview_btn": "Inicio de prueba (OP-0)",
+    "label_choose_language": "Elige tu idioma (ISO 639-1):"
   },
   "pt": {
     "title": "Ethicom: Avaliação Humana",

--- a/interface/erstkontakt.html
+++ b/interface/erstkontakt.html
@@ -16,13 +16,13 @@
     <h1>Willkommen</h1>
   </header>
   <nav>
-    <a href="ethicom.html">Start</a>
-    <a href="ratings.html">Bewertungen</a>
-    <a href="signup.html">Signup</a>
+    <a href="ethicom.html" data-ui="nav_start">Start</a>
+    <a href="ratings.html" data-ui="nav_ratings">Bewertungen</a>
+    <a href="signup.html" data-ui="nav_signup">Signup</a>
   </nav>
   <main class="card">
     <div id="lang_selection" class="card" style="margin-bottom:1em;">
-      <label for="lang_select">Language:</label>
+      <label for="lang_select" data-ui="choose_language_label">Language:</label>
       <select id="lang_select"></select>
     </div>
     <section class="card">

--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -175,3 +175,9 @@ button:hover {
   background-color: #b58f1b;
 }
 
+/* larger language selector */
+#lang_select {
+  font-size: 1.2em;
+  padding: 0.4em;
+}
+

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -18,17 +18,17 @@
     <h1>Ethicom Evaluation</h1>
   </header>
   <nav>
-    <a href="ethicom.html">Start</a>
-    <a href="ratings.html">Bewertungen</a>
-    <a href="signup.html">Signup</a>
-    <a href="haupt-readme.md" target="_blank">README</a>
+    <a href="ethicom.html" data-ui="nav_start">Start</a>
+    <a href="ratings.html" data-ui="nav_ratings">Bewertungen</a>
+    <a href="signup.html" data-ui="nav_signup">Signup</a>
+    <a href="haupt-readme.md" target="_blank" data-ui="nav_readme">README</a>
   </nav>
   <main class="card">
     <h2 id="title">Ethicom Evaluation</h2>
 
     <section id="welcome" class="card">
-      <p>Bisch gluschtig? Lueg derzue, ganz locker. Drück uf "Schnupper-Start" und probier OP‑0 ganz ohne Login.</p>
-      <button onclick="previewOP0()" class="accent-button">Schnupper-Start (OP‑0)</button>
+      <p data-ui="preview_msg">Bisch gluschtig? Lueg derzue, ganz locker. Drück uf "Schnupper-Start" und probier OP‑0 ganz ohne Login.</p>
+      <button data-ui="preview_btn" onclick="previewOP0()" class="accent-button">Schnupper-Start (OP‑0)</button>
     </section>
 
     <div id="badge_gallery" class="badge-gallery"></div>
@@ -36,7 +36,7 @@
     <div id="badge_display" class="badge-row"></div>
 
     <div id="lang_selection" class="card">
-      <label for="lang_select">Choose your language (ISO 639-1):</label>
+      <label for="lang_select" data-ui="choose_language_label">Choose your language (ISO 639-1):</label>
       <span class="help-icon" title="Select the two-letter code for your preferred language.">?</span>
       <select id="lang_select">
         <option value="">--</option>

--- a/interface/ratings.html
+++ b/interface/ratings.html
@@ -12,13 +12,13 @@
     <h1>Ethicom – Gesamtbewertungen</h1>
   </header>
   <nav>
-    <a href="ethicom.html">Start</a>
-    <a href="ratings.html">Bewertungen</a>
-    <a href="signup.html">Signup</a>
+    <a href="ethicom.html" data-ui="nav_start">Start</a>
+    <a href="ratings.html" data-ui="nav_ratings">Bewertungen</a>
+    <a href="signup.html" data-ui="nav_signup">Signup</a>
   </nav>
   <main class="card">
     <div id="lang_selection" class="card" style="margin-bottom:1em;">
-      <label for="lang_select">Language:</label>
+      <label for="lang_select" data-ui="choose_language_label">Language:</label>
       <select id="lang_select"></select>
     </div>
     <section class="card">

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -12,13 +12,13 @@
     <h1>Ethicom Signup</h1>
   </header>
   <nav>
-    <a href="ethicom.html">Start</a>
-    <a href="ratings.html">Bewertungen</a>
-    <a href="signup.html">Signup</a>
+    <a href="ethicom.html" data-ui="nav_start">Start</a>
+    <a href="ratings.html" data-ui="nav_ratings">Bewertungen</a>
+    <a href="signup.html" data-ui="nav_signup">Signup</a>
   </nav>
   <main class="card">
     <div id="lang_selection" class="card" style="margin-bottom:1em;">
-      <label for="lang_select">Language:</label>
+      <label for="lang_select" data-ui="choose_language_label">Language:</label>
       <select id="lang_select"></select>
     </div>
     <h2 data-ui="signup_title">Sign up</h2>

--- a/interface/translation-manager.js
+++ b/interface/translation-manager.js
@@ -104,6 +104,23 @@ function applyTexts(t) {
   document.querySelectorAll('option[data-ui="access_opt_yes_nospeech"]').forEach(o => {
     if (t.access_opt_yes_nospeech) o.textContent = t.access_opt_yes_nospeech;
   });
+
+  const navStart = document.querySelector('[data-ui="nav_start"]');
+  if (navStart) navStart.textContent = t.nav_start || navStart.textContent;
+  const navRatings = document.querySelector('[data-ui="nav_ratings"]');
+  if (navRatings) navRatings.textContent = t.nav_ratings || navRatings.textContent;
+  const navSignup = document.querySelector('[data-ui="nav_signup"]');
+  if (navSignup) navSignup.textContent = t.nav_signup || navSignup.textContent;
+  const navReadme = document.querySelector('[data-ui="nav_readme"]');
+  if (navReadme) navReadme.textContent = t.nav_readme || navReadme.textContent;
+
+  const previewMsg = document.querySelector('[data-ui="preview_msg"]');
+  if (previewMsg) previewMsg.textContent = t.preview_msg || previewMsg.textContent;
+  const previewBtn = document.querySelector('[data-ui="preview_btn"]');
+  if (previewBtn) previewBtn.textContent = t.preview_btn || previewBtn.textContent;
+
+  const chooseLabel = document.querySelector('[data-ui="choose_language_label"]');
+  if (chooseLabel) chooseLabel.textContent = t.label_choose_language || chooseLabel.textContent;
 }
 
 function initTranslationManager() {


### PR DESCRIPTION
## Summary
- enlarge language selector styling
- wire nav links, language label, and preview text for translation
- extend translation manager to update nav and preview labels
- add new translation strings in multiple languages

## Testing
- `node --test`