### PR TITLE
Add semantic language tools

### DIFF
--- a/i18n/semantic-words.json
+++ b/i18n/semantic-words.json
@@ -1,0 +1,10 @@
+{
+  "en": {
+    "positive": ["good", "happy", "excellent", "love", "great"],
+    "negative": ["bad", "sad", "terrible", "hate", "awful"]
+  },
+  "de": {
+    "positive": ["gut", "glücklich", "hervorragend", "liebe", "toll"],
+    "negative": ["schlecht", "traurig", "schrecklich", "hasse", "furchtbar"]
+  }
+}

--- a/interface/README.md
+++ b/interface/README.md
@@ -31,6 +31,7 @@ Just structured responsibility.
 - `revision-overview.js` → list withdrawn or revised manifests
 - `permissions-viewer.js` → visualize OP permissions
 - `language-manager.js` → generate snippets for new translations
+- `semantic-manager.js` → manage emotion word lists for sentiment
 - `signup.html` → signup form
 - `signup.js` → handles signup logic
 - `ratings.html` → external overview of overall ratings

--- a/interface/modules/semantic-manager.js
+++ b/interface/modules/semantic-manager.js
@@ -1,0 +1,37 @@
+// semantic-manager.js – Add or modify emotion word lists for languages
+
+function initSemanticManager() {
+  const container = document.getElementById("op_interface");
+  if (!container) return;
+  container.innerHTML = `
+    <div class="card">
+      <h3>Semantic Word Management</h3>
+      <p class="info">Generate JSON snippets for positive and negative words.</p>
+      <label for="sem_code">Language Code (ISO 639-1):</label>
+      <input type="text" id="sem_code" maxlength="2" />
+      <label for="sem_pos">Positive words (comma separated):</label>
+      <input type="text" id="sem_pos" />
+      <label for="sem_neg">Negative words (comma separated):</label>
+      <input type="text" id="sem_neg" />
+      <button onclick="generateSemanticSnippet()">Generate Snippet</button>
+      <pre id="sem_output" style="white-space:pre-wrap;"></pre>
+    </div>
+  `;
+}
+
+function generateSemanticSnippet() {
+  const code = document.getElementById("sem_code").value.trim();
+  const pos = document.getElementById("sem_pos").value.trim();
+  const neg = document.getElementById("sem_neg").value.trim();
+  if (!code || !pos || !neg) {
+    alert("Please fill in all fields.");
+    return;
+  }
+  const snippet = {
+    [code]: {
+      positive: pos.split(/,\s*/),
+      negative: neg.split(/,\s*/)
+    }
+  };
+  document.getElementById("sem_output").textContent = JSON.stringify(snippet, null, 2);
+}

--- a/test/semantic-words.test.js
+++ b/test/semantic-words.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const lexPath = path.join(__dirname, '..', 'i18n', 'semantic-words.json');
+const lexicon = JSON.parse(fs.readFileSync(lexPath, 'utf8'));
+
+test('semantic word lists contain required fields', () => {
+  for (const [lang, obj] of Object.entries(lexicon)) {
+    assert.ok(Array.isArray(obj.positive), `${lang} positive missing`);
+    assert.ok(Array.isArray(obj.negative), `${lang} negative missing`);
+    assert.ok(obj.positive.length >= 3, `${lang} positive length`);
+    assert.ok(obj.negative.length >= 3, `${lang} negative length`);
+  }
+});

--- a/tools/semantic-analyzer.js
+++ b/tools/semantic-analyzer.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadLexicon() {
+  const p = path.join(__dirname, '..', 'i18n', 'semantic-words.json');
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function analyzeSentiment(lang, text) {
+  const lexicon = loadLexicon();
+  const data = lexicon[lang] || { positive: [], negative: [] };
+  const words = text.toLowerCase().split(/\W+/);
+  let score = 0;
+  let counts = { positive: 0, negative: 0 };
+  for (const w of words) {
+    if (data.positive.includes(w)) {
+      counts.positive++;
+      score++;
+    }
+    if (data.negative.includes(w)) {
+      counts.negative++;
+      score--;
+    }
+  }
+  return { score, counts };
+}
+
+if (require.main === module) {
+  const [lang, ...words] = process.argv.slice(2);
+  if (!lang || words.length === 0) {
+    console.error('Usage: node semantic-analyzer.js <lang> <text>');
+    process.exit(1);
+  }
+  const result = analyzeSentiment(lang, words.join(' '));
+  console.log(JSON.stringify(result, null, 2));
+}
+
+module.exports = analyzeSentiment;


### PR DESCRIPTION
## Summary
- add basic emotional lexicon in `i18n/semantic-words.json`
- provide a script `semantic-analyzer.js` to compute simple sentiment scores
- allow UI snippet generation through new `semantic-manager.js`
- document new module in interface README
- test semantic data integrity

## Testing
- `node --test test/*.js`