### PR TITLE
Fix background logos behind content

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -39,12 +39,16 @@ header {
   background: #222;
   padding: 1em;
   text-align: center;
+  position: relative;
+  z-index: 1;
 }
 
 nav {
   background: #333;
   text-align: center;
   padding: 0.5em 0;
+  position: relative;
+  z-index: 1;
 }
 
 nav a {
@@ -68,6 +72,8 @@ main {
   max-width: 900px;
   margin: 0 auto;
   padding: 2em;
+  position: relative;
+  z-index: 1;
 }
 
 .card {
@@ -202,7 +208,7 @@ button:hover {
 #op_background {
   position: fixed;
   inset: 0;
-  z-index: -1;
+  z-index: 0;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
   justify-items: center;


### PR DESCRIPTION
## Summary
- ensure OP logos stay in the background by adjusting z-index values
- give header, nav and main their own stacking context

## Testing
- `node --test`
