### PR TITLE
Randomize OP logo background size and placement

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -39,12 +39,16 @@ header {
   background: #222;
   padding: 1em;
   text-align: center;
+  position: relative;
+  z-index: 1;
 }
 
 nav {
   background: #333;
   text-align: center;
   padding: 0.5em 0;
+  position: relative;
+  z-index: 1;
 }
 
 nav a {
@@ -68,6 +72,8 @@ main {
   max-width: 900px;
   margin: 0 auto;
   padding: 2em;
+  position: relative;
+  z-index: 1;
 }
 
 .card {
@@ -202,16 +208,13 @@ button:hover {
 #op_background {
   position: fixed;
   inset: 0;
-  z-index: -1;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-  justify-items: center;
-  align-items: center;
+  z-index: 0;
   opacity: 0.08;
   pointer-events: none;
 }
 
 #op_background img {
-  max-width: 100px;
+  position: absolute;
+  max-width: none;
 }
 

--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -1,11 +1,20 @@
 function loadOpLogos() {
   const container = document.getElementById('op_background');
   if (!container) return;
-  const levels = [0,1,2,3,4,5,6,7];
+
+  const levels = [0, 1, 2, 3, 4, 5, 6, 7];
+  const width = container.clientWidth || window.innerWidth;
+  const height = container.clientHeight || window.innerHeight;
+
   levels.forEach(lvl => {
     const img = document.createElement('img');
     img.src = `../op-logo/tanna_op${lvl}.png`;
     img.alt = `OP-${lvl} logo`;
+    img.style.position = 'absolute';
+    const size = 40 + lvl * 8; // larger level -> larger logo
+    img.style.width = size + 'px';
+    img.style.left = Math.random() * (width - size) + 'px';
+    img.style.top = Math.random() * (height - size) + 'px';
     container.appendChild(img);
   });
 }


### PR DESCRIPTION
## Summary
- simplify background container styles and allow absolute positioned images
- size OP logos according to their level and place them randomly on each load

## Testing
- `node --test`