### PR TITLE
Add dynamic info boxes with dev mode preview

### DIFF
--- a/interface/dynamic-info.js
+++ b/interface/dynamic-info.js
@@ -1,0 +1,56 @@
+const infoTexts = {
+  'ethicom': 'Your interface will load here once verified.',
+  'language-manager': 'Generate JSON snippets for new UI translations.',
+  'semantic-manager': 'Generate JSON snippets for positive and negative words.',
+  'op-0': 'You are submitting an anonymous evaluation. It will have no lasting influence and cannot be revised.',
+  'op-1': 'You are submitting your first signed evaluation. It will be stored with your signature.',
+  'op-2': 'You are submitting a signed evaluation with visible SRC level and internal identity option.',
+  'op-3': 'You are submitting a signed evaluation with structured reasoning and visual level selection.',
+  'op-4': 'You are submitting a structured and traceable evaluation. A revision will become possible after 21 days.',
+  'op-5': 'You can withdraw a previous evaluation. The original will be archived with your withdrawal reason.',
+  'op-6': 'You are allowed to calculate a consensus rating from anonymous evaluations.',
+  'op-7': 'You are authorized to override previous evaluations if your OP-level is higher and justified.',
+  'op-7.5': 'You are recognized as a structurally consistent operator. You may prepare nominations and review OP-8 observations, but not execute structural changes.',
+  'op-7.9': 'You may nominate operators and verify donations. Every action is binding and will be logged structurally.',
+  'op-8': 'This is a system-driven structural view of sources. No human input is allowed at this level.',
+  'op-9': 'Full structural autonomy. Finalize OP-8 evaluations and trigger self-sustaining loops.',
+  'op-10': 'Observation only. Systems operate beyond human control.',
+  'translation_challenge': 'Challenge: gather two OP signatures to confirm a language.',
+  'translation_sig_count': 'Current signatures: {count}/2'
+};
+
+function getInfoText(key, data = {}) {
+  let text = infoTexts[key] || '';
+  for (const [k, v] of Object.entries(data)) {
+    text = text.replace(new RegExp(`{${k}}`, 'g'), v);
+  }
+  return text;
+}
+
+function applyInfoTexts(root = document) {
+  const elements = Array.from(root.querySelectorAll('[data-info]'));
+  if (root.dataset && root.dataset.info) {
+    elements.push(root);
+  }
+  elements.forEach(el => {
+    const { info, ...vars } = el.dataset;
+    const text = getInfoText(info, vars);
+    el.textContent = text;
+  });
+
+  if (typeof isDevMode === 'function' && isDevMode()) {
+    if (!document.getElementById('dev_info_box')) {
+      const box = document.createElement('div');
+      box.id = 'dev_info_box';
+      box.className = 'card';
+      box.innerHTML = '<h3>Info Texts</h3><ul>' +
+        Object.entries(infoTexts)
+          .map(([k, v]) => `<li><strong>${k}</strong>: ${v}</li>`)
+          .join('') + '</ul>';
+      document.body.prepend(box);
+    }
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => applyInfoTexts());
+window.applyInfoTexts = applyInfoTexts;

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -12,6 +12,7 @@
   <script src="translation-manager.js"></script>
   <script src="accessibility.js"></script>
   <script src="dynamic-help.js"></script>
+  <script src="dynamic-info.js"></script>
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>
 </head>
@@ -72,7 +73,7 @@
     <div id="status" class="card" style="display:none;"></div>
 
     <div id="op_interface">
-      <p class="info">Your interface will load here once verified.</p>
+      <p class="info" data-info="ethicom"></p>
     </div>
 
     <pre id="output" class="card" style="background:#2b2b2b; white-space:pre-wrap; color:#ccc;"></pre>

--- a/interface/modules/language-manager.js
+++ b/interface/modules/language-manager.js
@@ -6,7 +6,7 @@ function initLanguageManager() {
   container.innerHTML = `
     <div class="card">
       <h3>Language Management</h3>
-      <p class="info">Generate JSON snippets for new UI translations.</p>
+      <p class="info" data-info="language-manager"></p>
       <label for="lang_code">Language Code (ISO 639-1):</label>
       <input type="text" id="lang_code" maxlength="2" />
       <label for="lang_title">Title Text:</label>
@@ -21,6 +21,7 @@ function initLanguageManager() {
       <pre id="lang_output" style="white-space:pre-wrap;"></pre>
     </div>
   `;
+  applyInfoTexts(container);
 }
 
 function generateLangSnippet() {

--- a/interface/modules/op-0-interface.js
+++ b/interface/modules/op-0-interface.js
@@ -7,7 +7,7 @@ function initOP0Interface() {
   container.innerHTML = `
     <div class="card">
       <h3>Anonymous Rating (OP-0)</h3>
-      <p class="info">You are submitting an anonymous evaluation. It will have no lasting influence and cannot be revised.</p>
+      <p class="info" data-info="op-0"></p>
 
       <label for="src_lvl">Select a general ethical level (SRC):</label>
       ${help('SRC describes the ethical consciousness of the evaluated source.')}
@@ -26,6 +26,7 @@ function initOP0Interface() {
       <button onclick="generateAnonymousManifest()">Evaluate</button>
     </div>
   `;
+  applyInfoTexts(container);
 }
 
 function generateAnonymousManifest() {

--- a/interface/modules/op-1-interface.js
+++ b/interface/modules/op-1-interface.js
@@ -7,7 +7,7 @@ function initOP1Interface() {
   container.innerHTML = `
     <div class="card">
       <h3>Signed Evaluation (OP-1)</h3>
-      <p class="info">You are submitting your first signed evaluation. It will be stored with your signature.</p>
+      <p class="info" data-info="op-1"></p>
 
       <label for="src_lvl">Select the SRC level:</label>
       ${help('SRC describes the ethical consciousness of the evaluated source.')}
@@ -26,6 +26,7 @@ function initOP1Interface() {
       <button onclick="generateSignedManifest()">Submit Evaluation</button>
     </div>
   `;
+  applyInfoTexts(container);
 }
 
 function generateSignedManifest() {

--- a/interface/modules/op-10-interface.js
+++ b/interface/modules/op-10-interface.js
@@ -7,7 +7,8 @@ function initOP10Interface() {
   container.innerHTML = `
     <div class="card">
       <h3>Post-Human Stage (OP-10)</h3>
-      <p class="info">Observation only. Systems operate beyond human control.</p>
+      <p class="info" data-info="op-10"></p>
     </div>
   `;
+  applyInfoTexts(container);
 }

--- a/interface/modules/op-2-interface.js
+++ b/interface/modules/op-2-interface.js
@@ -7,7 +7,7 @@ function initOP2Interface() {
   container.innerHTML = `
     <div class="card">
       <h3>Structured Evaluation (OP-2)</h3>
-      <p class="info">You are submitting a signed evaluation with visible SRC level and internal identity option.</p>
+      <p class="info" data-info="op-2"></p>
 
       <label for="src_lvl">Select the SRC level:</label>
       ${help('SRC describes the ethical consciousness of the evaluated source.')}
@@ -34,6 +34,7 @@ function initOP2Interface() {
       <button onclick="generateStructuredManifest()">Submit Evaluation</button>
     </div>
   `;
+  applyInfoTexts(container);
 }
 
 function generateStructuredManifest() {

--- a/interface/modules/op-3-interface.js
+++ b/interface/modules/op-3-interface.js
@@ -7,7 +7,7 @@ function initOP3Interface() {
   container.innerHTML = `
     <div class="card">
       <h3>Ethical Evaluation (OP-3)</h3>
-      <p class="info">You are submitting a signed evaluation with structured reasoning and visual level selection.</p>
+      <p class="info" data-info="op-3"></p>
 
       <label>Select SRC level:</label>
       ${help('Use the buttons below to choose the ethical depth of this source.')}
@@ -20,6 +20,7 @@ function initOP3Interface() {
       <button onclick="generateVisualManifest()">Submit Evaluation</button>
     </div>
   `;
+  applyInfoTexts(container);
 
   initSRCBar(); // Lade visuelle SRC-Leiste
 }

--- a/interface/modules/op-4-interface.js
+++ b/interface/modules/op-4-interface.js
@@ -7,7 +7,7 @@ function initOP4Interface() {
   container.innerHTML = `
     <div class="card">
       <h3>Structured Evaluation (OP-4)</h3>
-      <p class="info">You are submitting a structured and traceable evaluation. A revision will become possible after 21 days.</p>
+      <p class="info" data-info="op-4"></p>
 
       <label for="src_lvl">SRC Level:</label>
       ${help('Choose how ethically aware the source is.')}
@@ -28,6 +28,7 @@ function initOP4Interface() {
       <button onclick="generateTraceableManifest()">Submit</button>
     </div>
   `;
+  applyInfoTexts(container);
 }
 
 function generateTraceableManifest() {

--- a/interface/modules/op-5-interface.js
+++ b/interface/modules/op-5-interface.js
@@ -7,7 +7,7 @@ function initOP5Interface() {
   container.innerHTML = `
     <div class="card">
       <h3>Withdraw Evaluation (OP-5)</h3>
-      <p class="info">You can withdraw a previous evaluation. The original will be archived with your withdrawal reason.</p>
+      <p class="info" data-info="op-5"></p>
 
       <label for="original_id">Original Manifest filename:</label>
       ${help('Name of the manifest file you previously generated.')}
@@ -20,6 +20,7 @@ function initOP5Interface() {
       <button onclick="generateWithdrawal()">Withdraw Evaluation</button>
     </div>
   `;
+  applyInfoTexts(container);
 }
 
 function generateWithdrawal() {

--- a/interface/modules/op-6-interface.js
+++ b/interface/modules/op-6-interface.js
@@ -7,7 +7,7 @@ function initOP6Interface() {
   container.innerHTML = `
     <div class="card">
       <h3>Anonymous Consensus Evaluation (OP-6)</h3>
-      <p class="info">You are allowed to calculate a consensus rating from anonymous evaluations.</p>
+      <p class="info" data-info="op-6"></p>
 
       <label for="anon_input">Paste anonymous evaluations (JSON array):</label>
       ${help('Use raw JSON from OP-0 evaluations to compute consensus.')}
@@ -16,6 +16,7 @@ function initOP6Interface() {
       <button onclick="runConsensusCalculation()">Calculate Consensus</button>
     </div>
   `;
+  applyInfoTexts(container);
 }
 
 function runConsensusCalculation() {

--- a/interface/modules/op-7-interface.js
+++ b/interface/modules/op-7-interface.js
@@ -7,7 +7,7 @@ function initOP7Interface() {
   container.innerHTML = `
     <div class="card">
       <h3>Override Evaluation (OP-7)</h3>
-      <p class="info">You are authorized to override previous evaluations if your OP-level is higher and justified.</p>
+      <p class="info" data-info="op-7"></p>
 
       <label for="original_id">Manifest to override:</label>
       ${help('Filename of the evaluation you want to replace.')}
@@ -30,6 +30,7 @@ function initOP7Interface() {
       <button onclick="generateOverride()">Create Override</button>
     </div>
   `;
+  applyInfoTexts(container);
 }
 
 function generateOverride() {

--- a/interface/modules/op-7.5-interface.js
+++ b/interface/modules/op-7.5-interface.js
@@ -7,7 +7,7 @@ function initOP75Interface() {
   container.innerHTML = `
     <div class="card">
       <h3>Responsibility Tier (OP-7.5)</h3>
-      <p class="info">You are recognized as a structurally consistent operator. You may prepare nominations and review OP-8 observations, but not execute structural changes.</p>
+      <p class="info" data-info="op-7.5"></p>
 
       <h4>Propose Nomination</h4>
       <label for="propose_id">Operator Signature:</label>
@@ -32,6 +32,7 @@ function initOP75Interface() {
       <button onclick="prepareNomination()">Create Nomination Proposal</button>
     </div>
   `;
+  applyInfoTexts(container);
 }
 
 function prepareNomination() {

--- a/interface/modules/op-7.9-interface.js
+++ b/interface/modules/op-7.9-interface.js
@@ -7,7 +7,7 @@ function initOP79Interface() {
   container.innerHTML = `
     <div class="card">
       <h3>High-Level Operator Actions (OP-7.9)</h3>
-      <p class="info">You may nominate operators and verify donations. Every action is binding and will be logged structurally.</p>
+      <p class="info" data-info="op-7.9"></p>
 
       <h4>NOMINATION</h4>
       <label for="nominee">Operator Signature (to nominate):</label>
@@ -49,6 +49,7 @@ function initOP79Interface() {
       <button onclick="verifyDonation()">Log Verified Donation</button>
     </div>
   `;
+  applyInfoTexts(container);
 }
 
 function generateNomination() {

--- a/interface/modules/op-8-analysis.js
+++ b/interface/modules/op-8-analysis.js
@@ -7,7 +7,7 @@ function initOP8Analysis() {
   container.innerHTML = `
     <div class="card">
       <h3>Structural Analysis (OP-8)</h3>
-      <p class="info">This is a system-driven structural view of sources. No human input is allowed at this level.</p>
+      <p class="info" data-info="op-8"></p>
 
       <label for="inspect_id">Source ID to analyze:</label>
       ${help('Provide the source identifier to see its structural summary.')}
@@ -16,6 +16,7 @@ function initOP8Analysis() {
       <button onclick="loadStructuralView()">Run Analysis</button>
     </div>
   `;
+  applyInfoTexts(container);
 }
 
 function loadStructuralView() {

--- a/interface/modules/op-9-interface.js
+++ b/interface/modules/op-9-interface.js
@@ -7,11 +7,12 @@ function initOP9Interface() {
   container.innerHTML = `
     <div class="card">
       <h3>Yokozuna-Schwingerkönig Mode (OP-9)</h3>
-      <p class="info">Full structural autonomy. Finalize OP-8 evaluations and trigger self-sustaining loops.</p>
+      <p class="info" data-info="op-9"></p>
       <button id="run_diagnostic">Run Final Diagnostic</button>
       ${help('Performs an integrity check before entering OP-10.')}
     </div>
   `;
+  applyInfoTexts(container);
 
   document.getElementById("run_diagnostic").addEventListener("click", () => {
     const out = document.getElementById("output");

--- a/interface/modules/semantic-manager.js
+++ b/interface/modules/semantic-manager.js
@@ -6,7 +6,7 @@ function initSemanticManager() {
   container.innerHTML = `
     <div class="card">
       <h3>Semantic Word Management</h3>
-      <p class="info">Generate JSON snippets for positive and negative words.</p>
+      <p class="info" data-info="semantic-manager"></p>
       <label for="sem_code">Language Code (ISO 639-1):</label>
       <input type="text" id="sem_code" maxlength="2" />
       <label for="sem_pos">Positive words (comma separated):</label>
@@ -17,6 +17,7 @@ function initSemanticManager() {
       <pre id="sem_output" style="white-space:pre-wrap;"></pre>
     </div>
   `;
+  applyInfoTexts(container);
 }
 
 function generateSemanticSnippet() {

--- a/interface/translation-manager.js
+++ b/interface/translation-manager.js
@@ -131,7 +131,8 @@ function initTranslationManager() {
   editBtn.textContent = "Add/Improve Translation";
   const challenge = document.createElement("p");
   challenge.className = "info";
-  challenge.textContent = "Challenge: gather two OP signatures to confirm a language.";
+  challenge.dataset.info = "translation_challenge";
+  applyInfoTexts(challenge);
   container.appendChild(challenge);
   container.appendChild(editBtn);
 
@@ -195,7 +196,7 @@ function showTranslationEditor(code, data) {
   const sigCount = pendingLangs[code]?.signatures?.length || 0;
   form.innerHTML = `
     <h3>Edit translation for ${code}</h3>
-    <p class="info">Current signatures: ${sigCount}/2</p>
+    <p class="info" data-info="translation_sig_count" data-count="${sigCount}"></p>
     <label>Title:<br><input id="tr_title" value="${data.title || ""}"></label><br>
     <label>Label Source:<br><input id="tr_src" value="${data.label_source || ""}"></label><br>
     <label>Label SRCLvl:<br><input id="tr_srclvl" value="${data.label_srclvl || ""}"></label><br>
@@ -231,6 +232,7 @@ function showTranslationEditor(code, data) {
     <button id="tr_cancel">Cancel</button>
   `;
   overlay.appendChild(form);
+  applyInfoTexts(form);
   document.body.appendChild(overlay);
 
   document.getElementById("tr_cancel").addEventListener("click", () => overlay.remove());


### PR DESCRIPTION
## Summary
- create `dynamic-info.js` to manage info texts
- mark existing info boxes with `data-info` keys
- populate info boxes dynamically and preview all info texts in dev mode
- load new script from `ethicom.html`
- update `translation-manager` to use dynamic info text

## Testing
- `node --test`