### PR TITLE
Add citation logos to ratings page

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -245,3 +245,10 @@ button:hover {
   max-width: none;
 }
 
+/* Modified logo used in citation view */
+.citation-logo {
+  width: 28px;
+  vertical-align: middle;
+  filter: hue-rotate(-80deg) saturate(0.7);
+}
+

--- a/interface/ratings.html
+++ b/interface/ratings.html
@@ -41,6 +41,11 @@
     </section>
 
     <section class="card">
+      <h2>Zitierhinweis</h2>
+      <p>Diese Übersicht kann für Quellenangaben herangezogen werden. Die Logos neben den Bewertungen sind farblich angepasst, um klarzustellen, dass keine offiziellen OP-Stufen gemeint sind.</p>
+    </section>
+
+    <section class="card">
       <h2>Selbst bewerten</h2>
       <p>Nimm an der offenen Bewertung teil und erstelle deine eigene Einschätzung über <a href="ethicom.html">Ethicom</a>.</p>
     </section>

--- a/interface/ratings.js
+++ b/interface/ratings.js
@@ -20,7 +20,7 @@ async function initRatings() {
     caption.textContent = 'Bewertungsverlauf';
     table.appendChild(caption);
     const thead = document.createElement('thead');
-    thead.innerHTML = '<tr><th>Zeitstempel</th><th>Quelle</th><th>SRC</th><th>OP</th><th>Kommentar</th></tr>';
+    thead.innerHTML = '<tr><th>Zeitstempel</th><th>Quelle</th><th>SRC</th><th>OP</th><th>Logo</th><th>Kommentar</th></tr>';
     table.appendChild(thead);
     const tbody = document.createElement('tbody');
 
@@ -34,7 +34,9 @@ async function initRatings() {
 
     ratings.forEach(r => {
       const row = document.createElement('tr');
-      row.innerHTML = `<td>${r.timestamp}</td><td>${r.source_id}</td><td>${r.src_lvl}</td><td>${r.op_level}</td><td>${r.comment || ''}</td>`;
+      const opNum = parseInt(String(r.op_level).replace('OP-', '').split('.')[0], 10);
+      const logo = `<img class="citation-logo" src="../op-logo/tanna_op${opNum}.png" alt="Logo ${r.op_level}">`;
+      row.innerHTML = `<td>${r.timestamp}</td><td>${r.source_id}</td><td>${r.src_lvl}</td><td>${r.op_level}</td><td>${logo}</td><td>${r.comment || ''}</td>`;
       tbody.appendChild(row);
 
       const num = srcMap[r.src_lvl] || 0;


### PR DESCRIPTION
## Summary
- update ratings table to show a logo for every OP level
- add a note that the rating list is meant for citation
- tint rating logos with CSS so they differ from official OP logos

## Testing
- `node --test`