### PR TITLE
Enable local Ethicom deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ No manipulation. No simulation. No flattening of responsibility.
 - [Adding Languages](#adding-languages)
 - [Gatekeeper Control](#gatekeeper-control)
 - [Roadmap](#roadmap)
+- [Local Deployment](#local-deployment)
 - [Running Tests](#running-tests)
 - [Contributing](#contributing)
 
@@ -104,7 +105,15 @@ The roadmap keeps development transparent according to Signature 4789.
    - Publish multi-language guides for all operator levels.
    - Finalize open training data licensing.
 
+### Local Deployment [⇧](#contents)
 
+Serve the Ethicom interface locally with:
+
+```bash
+node tools/serve-interface.js
+```
+
+Then open `http://localhost:8080/ethicom.html` in your browser.
 
 ### Running Tests [⇧](#contents)
 

--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -1,0 +1,43 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..', 'interface');
+const port = process.env.PORT || 8080;
+
+const mime = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml'
+};
+
+function serveFile(filePath, res) {
+  const ext = path.extname(filePath).toLowerCase();
+  const type = mime[ext] || 'application/octet-stream';
+  res.writeHead(200, { 'Content-Type': type });
+  fs.createReadStream(filePath).pipe(res);
+}
+
+const server = http.createServer((req, res) => {
+  let urlPath = decodeURIComponent(req.url.split('?')[0]);
+  if (urlPath === '/' || urlPath === '') urlPath = '/ethicom.html';
+  const filePath = path.join(root, urlPath);
+
+  fs.stat(filePath, (err, stats) => {
+    if (!err && stats.isFile()) {
+      serveFile(filePath, res);
+    } else {
+      res.statusCode = 404;
+      res.end('Not found');
+    }
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Ethicom interface available at http://localhost:${port}/ethicom.html`);
+});


### PR DESCRIPTION
## Summary
- add `tools/serve-interface.js` to run the Ethicom web interface locally
- document the new script in `README.md`

## Testing
- `node --test`