### PR TITLE
Add OP-5 semantic editor

### DIFF
--- a/interface/README.md
+++ b/interface/README.md
@@ -31,7 +31,7 @@ Just structured responsibility.
 - `revision-overview.js` → list withdrawn or revised manifests
 - `permissions-viewer.js` → visualize OP permissions
 - `language-manager.js` → generate snippets for new translations
-- `semantic-manager.js` → manage emotion word lists for sentiment
+- `semantic-manager.js` → manage emotion word lists for sentiment (OP-5+)
 - `signup.html` → signup form
 - `signup.js` → handles signup logic
 - `ratings.html` → external overview of overall ratings

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -73,3 +73,23 @@ function help(text) {
   const safe = String(text).replace(/"/g, "&quot;");
   return `<span class="help-icon" title="${safe}">?</span>`;
 }
+
+// Retrieve stored OP level from localStorage
+function getStoredOpLevel() {
+  try {
+    const sig = JSON.parse(localStorage.getItem("ethicom_signature") || "{}");
+    return sig.op_level || null;
+  } catch (err) {
+    return null;
+  }
+}
+
+// Convert OP-level string to numeric value (OP-7.5 → 7.5)
+function opLevelToNumber(level) {
+  if (!level) return 0;
+  const n = parseFloat(String(level).replace("OP-", ""));
+  return isNaN(n) ? 0 : n;
+}
+
+window.getStoredOpLevel = getStoredOpLevel;
+window.opLevelToNumber = opLevelToNumber;

--- a/interface/interface-loader.js
+++ b/interface/interface-loader.js
@@ -26,7 +26,8 @@ function loadInterfaceForOP(op_level) {
     "manifestviewer": "manifest-viewer.js",
     "revisionoverview": "revision-overview.js",
     "permissionsviewer": "permissions-viewer.js",
-    "languagemanager": "language-manager.js"
+    "languagemanager": "language-manager.js",
+    "semanticmanager": "semantic-manager.js"
   };
 
   const script = document.createElement("script");
@@ -60,6 +61,8 @@ function loadInterfaceForOP(op_level) {
       initPermissionsViewer();
     } else if (op_level.toLowerCase() === "language-manager") {
       initLanguageManager();
+    } else if (op_level.toLowerCase() === "semantic-manager") {
+      initSemanticManager();
 
     }
     if (typeof window.setHelpSection === "function") {

--- a/interface/translation-manager.js
+++ b/interface/translation-manager.js
@@ -134,6 +134,16 @@ function initTranslationManager() {
   container.appendChild(challenge);
   container.appendChild(editBtn);
 
+  const op = opLevelToNumber(getStoredOpLevel());
+  if (op >= 5) {
+    const semanticBtn = document.createElement("button");
+    semanticBtn.textContent = "New Languages Editor";
+    semanticBtn.addEventListener("click", () => {
+      loadInterfaceForOP("semantic-manager");
+    });
+    container.appendChild(semanticBtn);
+  }
+
   editBtn.addEventListener("click", () => {
     const code = langSelect.value.trim();
     if (!code) {


### PR DESCRIPTION
## Summary
- add helper functions to read stored OP level
- load `semantic-manager.js` via interface loader
- show "New Languages Editor" for OP-5+
- note semantic tool availability in docs

## Testing
- `node --test`