### PR TITLE
Add OP-7.5 permissions and clarify operator levels

### DIFF
--- a/interface/op-permissions-expanded.json
+++ b/interface/op-permissions-expanded.json
@@ -88,6 +88,18 @@
     "can_accept_donations": false,
     "can_override_op6": true
   },
+  "OP-7.5": {
+    "can_rate": true,
+    "can_sign": true,
+    "can_comment": true,
+    "can_nominate": true,
+    "can_vote": true,
+    "can_override": false,
+    "can_retract": true,
+    "can_consensus": true,
+    "can_accept_donations": false,
+    "can_override_op6": false
+  },
   "OP-7.9": {
     "can_rate": true,
     "can_sign": true,

--- a/interface/op-permissions.json
+++ b/interface/op-permissions.json
@@ -48,6 +48,10 @@
   "OP-7": {
     "can_override_op6": true
   },
+  "OP-7.5": {
+    "can_nominate": true,
+    "can_vote": true
+  },
   "OP-7.9": {
     "can_accept_donations": true,
     "can_vote_on_op79": true,

--- a/operator/operator_levels.md
+++ b/operator/operator_levels.md
@@ -10,6 +10,8 @@
 | OP-5 | Leads without directing  
 | OP-6 | Creates origin-level modules  
 | OP-7 | Structural authority
+| OP-7.5 | Nomination preparation, review OP-8
+| OP-7.9 | Donation verification, confirm nominations
 | OP-8 | Candidate stage for OP-9 (system self-stabilizes)
 | OP-9 | Yokozuna-Schwingerkönig-Mode
 | OP-10 | First non-human development stage

--- a/permissions/op-permissions-expanded.json
+++ b/permissions/op-permissions-expanded.json
@@ -88,6 +88,18 @@
     "can_accept_donations": false,
     "can_override_op6": true
   },
+  "OP-7.5": {
+    "can_rate": true,
+    "can_sign": true,
+    "can_comment": true,
+    "can_nominate": true,
+    "can_vote": true,
+    "can_override": false,
+    "can_retract": true,
+    "can_consensus": true,
+    "can_accept_donations": false,
+    "can_override_op6": false
+  },
   "OP-7.9": {
     "can_rate": true,
     "can_sign": true,


### PR DESCRIPTION
## Summary
- include OP-7.5 permissions alongside OP-7.9
- update interface copy of permissions
- document OP-7.5 and OP-7.9 in `operator_levels.md`

## Testing
- `node --test`