### PR TITLE
Add dynamic OP-8+ logo generation

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -265,3 +265,7 @@ button:hover {
   filter: hue-rotate(-80deg) saturate(0.7);
 }
 
+.op-logo-group {
+  white-space: nowrap;
+}
+

--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -2,20 +2,35 @@ function loadOpLogos() {
   const container = document.getElementById('op_background');
   if (!container) return;
 
-  const levels = [0, 1, 2, 3, 4, 5, 6, 7];
+  const levels = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
   const width = container.clientWidth || window.innerWidth;
   const height = container.clientHeight || window.innerHeight;
 
   levels.forEach(lvl => {
-    const img = document.createElement('img');
-    img.src = `../op-logo/tanna_op${lvl}.png`;
-    img.alt = `OP-${lvl} logo`;
-    img.style.position = 'absolute';
+    const count = lvl >= 8 ? lvl - 6 : 1;
+    const hue = lvl >= 8 ? (lvl - 7) * 30 : 0;
+    const srcNum = lvl >= 8 ? 7 : lvl;
     const size = 30 + lvl * 4; // more subtle sizing
-    img.style.width = size + 'px';
-    img.style.left = Math.random() * (width - size) + 'px';
-    img.style.top = Math.random() * (height - size) + 'px';
-    container.appendChild(img);
+    const groupWidth = (size + 4) * count;
+    const left = Math.random() * (width - groupWidth);
+    const top = Math.random() * (height - size);
+
+    const group = document.createElement('div');
+    group.style.position = 'absolute';
+    group.style.left = left + 'px';
+    group.style.top = top + 'px';
+
+    for (let i = 0; i < count; i++) {
+      const img = document.createElement('img');
+      img.src = `../op-logo/tanna_op${srcNum}.png`;
+      img.alt = `OP-${lvl} logo`;
+      img.style.width = size + 'px';
+      if (hue) img.style.filter = `hue-rotate(${hue}deg)`;
+      img.style.marginRight = '4px';
+      group.appendChild(img);
+    }
+
+    container.appendChild(group);
   });
 }
 

--- a/interface/op-permissions-expanded.json
+++ b/interface/op-permissions-expanded.json
@@ -88,6 +88,18 @@
     "can_accept_donations": false,
     "can_override_op6": true
   },
+  "OP-7.5": {
+    "can_rate": true,
+    "can_sign": true,
+    "can_comment": true,
+    "can_nominate": true,
+    "can_vote": true,
+    "can_override": false,
+    "can_retract": true,
+    "can_consensus": true,
+    "can_accept_donations": false,
+    "can_override_op6": false
+  },
   "OP-7.9": {
     "can_rate": true,
     "can_sign": true,

--- a/interface/op-permissions.json
+++ b/interface/op-permissions.json
@@ -48,6 +48,10 @@
   "OP-7": {
     "can_override_op6": true
   },
+  "OP-7.5": {
+    "can_nominate": true,
+    "can_vote": true
+  },
   "OP-7.9": {
     "can_accept_donations": true,
     "can_vote_on_op79": true,

--- a/interface/ratings.js
+++ b/interface/ratings.js
@@ -24,6 +24,19 @@ async function initRatings() {
     table.appendChild(thead);
     const tbody = document.createElement('tbody');
 
+    function makeOpLogo(level) {
+      const base = parseInt(String(level).replace('OP-', '').split('.')[0], 10);
+      const count = base >= 8 ? base - 6 : 1;
+      const hue = base >= 8 ? (base - 7) * 30 : 0;
+      const srcNum = base >= 8 ? 7 : base;
+      let html = '<span class="op-logo-group">';
+      for (let i = 0; i < count; i++) {
+        html += `<img class="citation-logo" src="../op-logo/tanna_op${srcNum}.png" alt="Logo ${level}" style="filter: hue-rotate(-80deg) saturate(0.7) hue-rotate(${hue}deg);">`;
+      }
+      html += '</span>';
+      return html;
+    }
+
     const srcMap = {
       'SRC-0': 0, 'SRC-1': 1, 'SRC-2': 2, 'SRC-3': 3,
       'SRC-4': 4, 'SRC-5': 5, 'SRC-6': 6, 'SRC-7': 7, 'SRC-8+': 8
@@ -34,8 +47,7 @@ async function initRatings() {
 
     ratings.forEach(r => {
       const row = document.createElement('tr');
-      const opNum = parseInt(String(r.op_level).replace('OP-', '').split('.')[0], 10);
-      const logo = `<img class="citation-logo" src="../op-logo/tanna_op${opNum}.png" alt="Logo ${r.op_level}">`;
+      const logo = makeOpLogo(r.op_level);
       row.innerHTML = `<td>${r.timestamp}</td><td>${r.source_id}</td><td>${r.src_lvl}</td><td>${r.op_level}</td><td>${logo}</td><td>${r.comment || ''}</td>`;
       tbody.appendChild(row);
 

--- a/op-logo/README_TANNA_OP0-OP7.md
+++ b/op-logo/README_TANNA_OP0-OP7.md
@@ -2,9 +2,10 @@
 
 ## Project Overview
 
-This folder contains PNG files representing the geometrically and visually refined development stages  
-of the TANNA symbol from OP-0 to OP-7. Each stage represents an abstract layer or growth level  
-in a logical, graphical, or systemic tree schema.
+This folder contains PNG files representing the geometrically and visually refined development stages
+of the TANNA symbol from OP-0 to OP-7. Each stage represents an abstract layer or growth level
+in a logical, graphical, or systemic tree schema. For OP-8 and higher the design reuses the OP-7 logo,
+repeating it horizontally and shifting the hue to indicate progression.
 
 ---
 
@@ -35,7 +36,8 @@ in a logical, graphical, or systemic tree schema.
 
 ## Notes
 
-- OP-8 (not included) will mark the conceptual/technological departure beyond biological stages.
+- Starting with OP-8 the logo repeats the OP-7 symbol multiple times and shifts the hue for each higher level.
+- OP-8 shows two OP-7 logos side by side, OP-9 shows three, and so on.
 - Designed with **color-contrast accessibility** in mind (color-blind friendly).
 - Structure is suitable for use in **SVG, animation, and generative logic**.
 

--- a/operator/operator_levels.md
+++ b/operator/operator_levels.md
@@ -10,6 +10,8 @@
 | OP-5 | Leads without directing  
 | OP-6 | Creates origin-level modules  
 | OP-7 | Structural authority
+| OP-7.5 | Nomination preparation, review OP-8
+| OP-7.9 | Donation verification, confirm nominations
 | OP-8 | Candidate stage for OP-9 (system self-stabilizes)
 | OP-9 | Yokozuna-Schwingerkönig-Mode
 | OP-10 | First non-human development stage

--- a/permissions/op-permissions-expanded.json
+++ b/permissions/op-permissions-expanded.json
@@ -88,6 +88,18 @@
     "can_accept_donations": false,
     "can_override_op6": true
   },
+  "OP-7.5": {
+    "can_rate": true,
+    "can_sign": true,
+    "can_comment": true,
+    "can_nominate": true,
+    "can_vote": true,
+    "can_override": false,
+    "can_retract": true,
+    "can_consensus": true,
+    "can_accept_donations": false,
+    "can_override_op6": false
+  },
   "OP-7.9": {
     "can_rate": true,
     "can_sign": true,


### PR DESCRIPTION
## Summary
- document repeated logo pattern for OP-8 and higher
- support rendering stacked OP-7 logos with hue shift
- show multi-logo groups in ratings table and page background

## Testing
- `node --test`
