### PR TITLE
Add README generator and fix permissions data

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ No manipulation. No simulation. No flattening of responsibility.
 - [Evaluated Sources (as examples)](#evaluated-sources-as-examples)
 - [File Integrity](#file-integrity)
 - [Adding Languages](#adding-languages)
+- [Generating Interface README](#generating-interface-readme)
 - [Gatekeeper Control](#gatekeeper-control)
 - [Roadmap](#roadmap)
 - [Local Deployment](#local-deployment)
@@ -82,6 +83,19 @@ entry. The interface will automatically recognize the new language.
 Word collections for additional languages can be gathered with
 `tools/language-corpus.js`. The script updates `i18n/language-corpus.json`
 based on plain text input.
+
+### Generating Interface README [⇧](#contents)
+
+Create a localized README for the interface by running:
+
+```bash
+node tools/generate-haupt-readme.js <lang>
+```
+
+Replace `<lang>` with a two-letter ISO code (e.g. `de` or `fr`).
+The script copies the matching `i18n/README.<lang>.md` into
+`interface/haupt-readme.md`. If no translation exists, the English
+README is used.
 
 ### Gatekeeper Control [⇧](#contents)
 

--- a/interface/haupt-readme.md
+++ b/interface/haupt-readme.md
@@ -1,26 +1,143 @@
-# Haupt-README – Ethicom Struktur 4789
+## Ethics Structure 4789 [⇧](#contents)
 
-Dieses Dokument fasst den Ansatz des Ethicom-Frameworks in einer kompakten Form zusammen. Es richtet sich an alle, die die Oberfläche nutzen und den Kern der Struktur verstehen möchten.
+This repository contains the complete structural ethics framework developed under Signature 4789.  
+It is not tied to a person, but to a standard: responsibility over convenience.
 
-**Grundgedanke**
+**What this is:**
+- A full operator model (OP 0–10)
+- A self-reflection system (Signature 9874)
+- An ethics-first framework for digital systems, education, governance, and AI use
 
-- Verantwortung vor Bequemlichkeit
-- OP-Level 0 bis 10
-- Signaturen und Hash-Prüfung nach Standard 4789
-- Keine Benutzerkonten und kein Tracking
+**What this is not:**
+- A belief system
+- A rulebook
+- A tool for control or moralism
 
-## Verzeichnisüberblick
+This structure must be carried – not quoted.
+Use it only if you reflect, respond, and act with consequence.
 
-| Ordner | Zweck |
-|-------|-------|
-| `app/` | Einstellungen, Sprachregeln und Benutzerstatus |
-| `ethics_modules/` | Zentrale YAML- und Markdown-Module |
-| `interface/` | Diese Oberfläche |
-| `i18n/` | Übersetzungen der Benutzeroberfläche |
-| `manifests/` | Manifeste und Integritätsdaten |
-| `permissions/` | Operator-Berechtigungen |
-| `sources/` | Bewertete Quellen und Kandidaten |
+For a brief tour of the main files, see [GET_STARTED.md](GET_STARTED.md).
 
-Weitere Details findet ihr im vollständigen README ([../README.md](../README.md)).
+**License:** Open-Ethics (see `LICENSE.txt`)
+No manipulation. No simulation. No flattening of responsibility.
 
-Lizenz: Open-Ethics (siehe `LICENSE.txt`)
+## Contents
+
+- [Ethics Structure 4789](#ethics-structure-4789)
+- [Repository Structure](#repository-structure)
+- [OP-Permissions](#op-permissions)
+- [Evaluated Sources (as examples)](#evaluated-sources-as-examples)
+- [File Integrity](#file-integrity)
+- [Adding Languages](#adding-languages)
+- [Generating Interface README](#generating-interface-readme)
+- [Gatekeeper Control](#gatekeeper-control)
+- [Roadmap](#roadmap)
+- [Local Deployment](#local-deployment)
+- [Running Tests](#running-tests)
+- [Contributing](#contributing)
+
+## Repository Structure [⇧](#contents)
+
+| Directory | Purpose |
+|-----------|---------|
+| `app/` | Application settings, language rules, and user state |
+| `ethics_modules/` | Core YAML and markdown modules for the ethics framework |
+| `interface/` | Front-end files for the evaluation interface |
+| `i18n/` | UI translations referenced by the interface |
+| `manifests/` | Structural manifests and integrity data |
+| `operator/` | Operator qualification guides and personal data |
+| `permissions/` | Operator permission definitions |
+| `releases/` | Release notes and integrity hashes |
+| `sources/` | Evaluated sources and candidate lists |
+| `test/` | Node.js test suite |
+| `tools/` | Utility scripts (e.g., trust-demotion engine) |
+| `use_cases/` | Example scenarios and dissemination ideas |
+
+### OP-Permissions [⇧](#contents)
+Operator actions by ethical level are defined in:
+→ [`permissions/op-permissions-expanded.json`](permissions/op-permissions-expanded.json)
+
+### Evaluated Sources (as examples) [⇧](#contents)
+- [src-0001: Fairphone](sources/src-0001.json) → [`SRC-4`](manifests/op-eval-4789-src-0001.json)
+- [src-0002: Ecosia](https://www.ecosia.org/) → [`SRC-4`](manifests/op-eval-4789-src-0002.json)
+
+### File Integrity [⇧](#contents)
+
+**ethicom.html**
+SHA-256: 9a961e40cdafdd1314eb648b49ed6fcfbd97b173c0e1f708b6e0efc029589b19  
+Verified 2025-05-21 by Signature 4789
+
+**ethicom-consensus.js**
+SHA-256: 37dbef63d04615fc30c369f636738375279368c63ce4016e6f6c43b282590e64  
+Verified 2025-05-21 by Signature 4789
+
+> Ethics is not explained. It is carried.
+> – Signature 4789
+
+### Adding Languages [⇧](#contents)
+
+Translations for the evaluation interface are defined in `i18n/ui-text.json`. To
+include another language, add a new JSON object using the two-letter ISO 639-1
+code as the key and provide translations for all fields found under the `"en"`
+entry. The interface will automatically recognize the new language.
+Word collections for additional languages can be gathered with
+`tools/language-corpus.js`. The script updates `i18n/language-corpus.json`
+based on plain text input.
+
+### Generating Interface README [⇧](#contents)
+
+Create a localized README for the interface by running:
+
+```bash
+node tools/generate-haupt-readme.js <lang>
+```
+
+Replace `<lang>` with a two-letter ISO code (e.g. `de` or `fr`).
+The script copies the matching `i18n/README.<lang>.md` into
+`interface/haupt-readme.md`. If no translation exists, the English
+README is used.
+
+### Gatekeeper Control [⇧](#contents)
+
+Local control can be toggled via `tools/gatekeeper.js`. The script reads
+`app/gatekeeper_config.yaml` and only allows actions when `allow_control` is set
+to `true` for the controller `RL@RLpi`. This keeps remote commands gated and
+limited to the local environment.
+
+
+## Roadmap [⇧](#contents)
+
+The roadmap keeps development transparent according to Signature 4789.
+
+1. **v1.1 – Anonymous Ethics Tier**
+   - Replace the pass/ID system with an optional anonymous level.
+   - Merge modules that belong together but are not yet unified.
+2. **v1.2 – Source Consolidation**
+   - Align evaluated sources with the anonymous tier.
+   - Standardize transfer protocols for cross-module use.
+3. **v2.0 – Global Rollout**
+   - Publish multi-language guides for all operator levels.
+   - Finalize open training data licensing.
+
+### Local Deployment [⇧](#contents)
+
+Serve the Ethicom interface locally with:
+
+```bash
+node tools/serve-interface.js
+```
+
+Then open `http://localhost:8080/ethicom.html` in your browser.
+
+### Running Tests [⇧](#contents)
+
+Ensure Node.js 18 or later is installed, then run:
+
+```bash
+node --test
+```
+
+
+### Contributing [⇧](#contents)
+
+To suggest improvements or translations, read `CONTRIBUTING.md`. All changes must follow the Open-Ethics License and be made with intention.

--- a/interface/op-permissions-expanded.json
+++ b/interface/op-permissions-expanded.json
@@ -88,18 +88,17 @@
     "can_accept_donations": false,
     "can_override_op6": true
   },
-  "OP-11": {
   "OP-7.5": {
     "can_rate": true,
     "can_sign": true,
     "can_comment": true,
     "can_nominate": true,
     "can_vote": true,
-    "can_override": false,
+    "can_override": true,
     "can_retract": true,
     "can_consensus": true,
     "can_accept_donations": false,
-    "can_override_op6": false
+    "can_override_op6": true
   },
   "OP-7.9": {
     "can_rate": true,
@@ -115,7 +114,7 @@
     "can_vote_on_op9": true,
     "can_vote_on_op10": true
   },
-  "OP-12": {
+  "OP-10": {
     "can_rate": true,
     "can_sign": true,
     "can_comment": true,
@@ -124,7 +123,7 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": true,
-    "can_accept_donations": false,
+    "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
@@ -140,7 +139,7 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": true,
-    "can_accept_donations": false,
+    "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
@@ -149,6 +148,21 @@
     "can_finalize_system": true
   },
   "OP-12": {
+    "can_rate": true,
+    "can_sign": true,
+    "can_comment": true,
+    "can_nominate": true,
+    "can_vote": true,
+    "can_override": true,
+    "can_retract": true,
+    "can_consensus": true,
+    "can_accept_donations": true,
+    "can_override_op6": true,
+    "can_vote_on_op9": true,
+    "can_vote_on_op10": true,
+    "can_act_as_structure": true,
+    "can_execute_evaluations": true,
+    "can_finalize_system": true,
     "can_observe_only": true
   }
 }

--- a/interface/op-permissions.json
+++ b/interface/op-permissions.json
@@ -48,7 +48,6 @@
   "OP-7": {
     "can_override_op6": true
   },
-  "OP-9": {
   "OP-7.5": {
     "can_nominate": true,
     "can_vote": true

--- a/permissions/op-permissions-expanded.json
+++ b/permissions/op-permissions-expanded.json
@@ -88,18 +88,17 @@
     "can_accept_donations": false,
     "can_override_op6": true
   },
-  "OP-11": {
   "OP-7.5": {
     "can_rate": true,
     "can_sign": true,
     "can_comment": true,
     "can_nominate": true,
     "can_vote": true,
-    "can_override": false,
+    "can_override": true,
     "can_retract": true,
     "can_consensus": true,
     "can_accept_donations": false,
-    "can_override_op6": false
+    "can_override_op6": true
   },
   "OP-7.9": {
     "can_rate": true,
@@ -115,7 +114,7 @@
     "can_vote_on_op9": true,
     "can_vote_on_op10": true
   },
-  "OP-12": {
+  "OP-10": {
     "can_rate": true,
     "can_sign": true,
     "can_comment": true,
@@ -124,7 +123,7 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": true,
-    "can_accept_donations": false,
+    "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
@@ -140,7 +139,7 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": true,
-    "can_accept_donations": false,
+    "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
@@ -149,6 +148,21 @@
     "can_finalize_system": true
   },
   "OP-12": {
+    "can_rate": true,
+    "can_sign": true,
+    "can_comment": true,
+    "can_nominate": true,
+    "can_vote": true,
+    "can_override": true,
+    "can_retract": true,
+    "can_consensus": true,
+    "can_accept_donations": true,
+    "can_override_op6": true,
+    "can_vote_on_op9": true,
+    "can_vote_on_op10": true,
+    "can_act_as_structure": true,
+    "can_execute_evaluations": true,
+    "can_finalize_system": true,
     "can_observe_only": true
   }
 }

--- a/tools/generate-haupt-readme.js
+++ b/tools/generate-haupt-readme.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+const lang = process.argv[2] || 'en';
+const repoRoot = path.join(__dirname, '..');
+const src = lang === 'en'
+  ? path.join(repoRoot, 'README.md')
+  : path.join(repoRoot, 'i18n', `README.${lang}.md`);
+
+if (!fs.existsSync(src)) {
+  console.error(`No README translation found for '${lang}'.`);
+  process.exit(1);
+}
+
+const dest = path.join(repoRoot, 'interface', 'haupt-readme.md');
+fs.copyFileSync(src, dest);
+console.log(`Generated ${dest} from ${src}`);
+

--- a/tools/generate-permissions.js
+++ b/tools/generate-permissions.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const basePath = path.join(root, 'interface', 'op-permissions.json');
+const outputPaths = [
+  path.join(root, 'interface', 'op-permissions-expanded.json'),
+  path.join(root, 'permissions', 'op-permissions-expanded.json'),
+];
+
+const base = JSON.parse(fs.readFileSync(basePath, 'utf8'));
+const levelKeys = Object.keys(base).sort((a, b) => parseFloat(a.slice(3)) - parseFloat(b.slice(3)));
+let prev = {};
+const expanded = {};
+for (const key of levelKeys) {
+  prev = Object.assign({}, prev, base[key]);
+  expanded[key] = prev;
+}
+const content = JSON.stringify(expanded, null, 2) + '\n';
+for (const out of outputPaths) {
+  fs.writeFileSync(out, content);
+  console.log('generated', out);
+}


### PR DESCRIPTION
## Summary
- fix broken permissions JSON files and generate them from a single source
- add scripts `generate-permissions.js` and `generate-haupt-readme.js`
- document README generation in main README
- update interface `haupt-readme.md`

## Testing
- `node tools/generate-permissions.js`
- `node tools/generate-haupt-readme.js en`
- `node --test`