### PR TITLE
Add Ethik Score tool and fix permissions JSON

### DIFF
--- a/interface/op-permissions-expanded.json
+++ b/interface/op-permissions-expanded.json
@@ -88,18 +88,17 @@
     "can_accept_donations": false,
     "can_override_op6": true
   },
-  "OP-11": {
   "OP-7.5": {
     "can_rate": true,
     "can_sign": true,
     "can_comment": true,
     "can_nominate": true,
     "can_vote": true,
-    "can_override": false,
+    "can_override": true,
     "can_retract": true,
     "can_consensus": true,
     "can_accept_donations": false,
-    "can_override_op6": false
+    "can_override_op6": true
   },
   "OP-7.9": {
     "can_rate": true,
@@ -115,7 +114,7 @@
     "can_vote_on_op9": true,
     "can_vote_on_op10": true
   },
-  "OP-12": {
+  "OP-10": {
     "can_rate": true,
     "can_sign": true,
     "can_comment": true,
@@ -124,7 +123,7 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": true,
-    "can_accept_donations": false,
+    "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
@@ -140,7 +139,7 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": true,
-    "can_accept_donations": false,
+    "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
@@ -149,6 +148,21 @@
     "can_finalize_system": true
   },
   "OP-12": {
+    "can_rate": true,
+    "can_sign": true,
+    "can_comment": true,
+    "can_nominate": true,
+    "can_vote": true,
+    "can_override": true,
+    "can_retract": true,
+    "can_consensus": true,
+    "can_accept_donations": true,
+    "can_override_op6": true,
+    "can_vote_on_op9": true,
+    "can_vote_on_op10": true,
+    "can_act_as_structure": true,
+    "can_execute_evaluations": true,
+    "can_finalize_system": true,
     "can_observe_only": true
   }
 }

--- a/interface/op-permissions.json
+++ b/interface/op-permissions.json
@@ -48,7 +48,6 @@
   "OP-7": {
     "can_override_op6": true
   },
-  "OP-9": {
   "OP-7.5": {
     "can_nominate": true,
     "can_vote": true

--- a/permissions/op-permissions-expanded.json
+++ b/permissions/op-permissions-expanded.json
@@ -88,18 +88,17 @@
     "can_accept_donations": false,
     "can_override_op6": true
   },
-  "OP-11": {
   "OP-7.5": {
     "can_rate": true,
     "can_sign": true,
     "can_comment": true,
     "can_nominate": true,
     "can_vote": true,
-    "can_override": false,
+    "can_override": true,
     "can_retract": true,
     "can_consensus": true,
     "can_accept_donations": false,
-    "can_override_op6": false
+    "can_override_op6": true
   },
   "OP-7.9": {
     "can_rate": true,
@@ -115,7 +114,7 @@
     "can_vote_on_op9": true,
     "can_vote_on_op10": true
   },
-  "OP-12": {
+  "OP-10": {
     "can_rate": true,
     "can_sign": true,
     "can_comment": true,
@@ -124,7 +123,7 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": true,
-    "can_accept_donations": false,
+    "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
@@ -140,7 +139,7 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": true,
-    "can_accept_donations": false,
+    "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
@@ -149,6 +148,21 @@
     "can_finalize_system": true
   },
   "OP-12": {
+    "can_rate": true,
+    "can_sign": true,
+    "can_comment": true,
+    "can_nominate": true,
+    "can_vote": true,
+    "can_override": true,
+    "can_retract": true,
+    "can_consensus": true,
+    "can_accept_donations": true,
+    "can_override_op6": true,
+    "can_vote_on_op9": true,
+    "can_vote_on_op10": true,
+    "can_act_as_structure": true,
+    "can_execute_evaluations": true,
+    "can_finalize_system": true,
     "can_observe_only": true
   }
 }

--- a/references/ethik-scores.json
+++ b/references/ethik-scores.json
@@ -1,0 +1,12 @@
+{
+  "src-0001": {
+    "score": 4,
+    "level": "SRC-4",
+    "evaluations": 1
+  },
+  "src-0002": {
+    "score": 4,
+    "level": "SRC-4",
+    "evaluations": 1
+  }
+}

--- a/test/ethik-score.test.js
+++ b/test/ethik-score.test.js
@@ -1,0 +1,13 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { computeScores } = require('../tools/ethik-score');
+
+test('computeScores averages correctly', () => {
+  const perSource = {
+    'src-001': [4, 4, 5],
+    'src-002': [2]
+  };
+  const result = computeScores(perSource);
+  assert.deepStrictEqual(result['src-001'], { score: 4.33, level: 'SRC-4', evaluations: 3 });
+  assert.deepStrictEqual(result['src-002'], { score: 2, level: 'SRC-2', evaluations: 1 });
+});

--- a/tools/ethik-score.js
+++ b/tools/ethik-score.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+
+const srcMap = {
+  'SRC-0': 0, 'SRC-1': 1, 'SRC-2': 2, 'SRC-3': 3,
+  'SRC-4': 4, 'SRC-5': 5, 'SRC-6': 6, 'SRC-7': 7, 'SRC-8+': 8
+};
+const reverseMap = Object.fromEntries(Object.entries(srcMap).map(([k,v]) => [v, k]));
+
+function loadRatings(manifestDir) {
+  const indexPath = path.join(manifestDir, 'index.json');
+  if (!fs.existsSync(indexPath)) throw new Error('index.json not found');
+  const index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+  const perSource = {};
+  for (const file of index) {
+    const p = path.join(manifestDir, file);
+    const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+    const num = srcMap[data.src_lvl] || 0;
+    if (!perSource[data.source_id]) perSource[data.source_id] = [];
+    perSource[data.source_id].push(num);
+  }
+  return perSource;
+}
+
+function computeScores(perSource) {
+  const result = {};
+  for (const [src, nums] of Object.entries(perSource)) {
+    const avg = nums.reduce((a,b)=>a+b,0) / nums.length;
+    result[src] = {
+      score: +avg.toFixed(2),
+      level: reverseMap[Math.round(avg)] || `SRC-${Math.round(avg)}`,
+      evaluations: nums.length
+    };
+  }
+  return result;
+}
+
+function main() {
+  const manifestDir = path.join(__dirname, '..', 'manifests');
+  const perSource = loadRatings(manifestDir);
+  const scores = computeScores(perSource);
+  const outDir = path.join(__dirname, '..', 'references');
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, 'ethik-scores.json');
+  fs.writeFileSync(outPath, JSON.stringify(scores, null, 2));
+  console.log('Ethik scores written to', outPath);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { loadRatings, computeScores };


### PR DESCRIPTION
## Summary
- add `tools/ethik-score.js` to compute Ethik Scores from manifests
- add tests for the new score calculation
- fix malformed `op-permissions` JSON files
- generate reference `ethik-scores.json`

## Testing
- `node --test`