### PR TITLE
Fix language dropdown width

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -231,6 +231,7 @@ button:hover {
 #lang_select {
   font-size: 1.2em;
   padding: 0;
+  width: 5ch; /* dropdown only needs to show two-letter codes */
 }
 
 /* Background grid showing all OP logos */


### PR DESCRIPTION
## Summary
- keep the language selector narrow by adding a fixed width

## Testing
- `node --test`