### PR TITLE
Add signature strength helper

### DIFF
--- a/interface/erstkontakt.html
+++ b/interface/erstkontakt.html
@@ -5,6 +5,7 @@
   <title>Erstkontakt</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>
+  <script src="signature-strength.js"></script>
   <script src="ratings.js"></script>
   <script src="interface-loader.js"></script>
   <style>

--- a/interface/ratings.html
+++ b/interface/ratings.html
@@ -5,6 +5,7 @@
   <title>Gesamtbewertungen</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>
+  <script src="signature-strength.js"></script>
   <script src="ratings.js"></script>
 </head>
 <body>

--- a/interface/ratings.js
+++ b/interface/ratings.js
@@ -26,7 +26,9 @@ async function initRatings() {
 
     function makeOpLogo(level) {
       const base = parseInt(String(level).replace('OP-', '').split('.')[0], 10);
-      const count = base >= 8 ? base - 6 : 1;
+      const count = typeof getSignatureStrength === 'function'
+        ? getSignatureStrength(level)
+        : (base >= 8 ? base - 6 : 1);
       const hue = base >= 8 ? (base - 7) * 30 : 0;
       const srcNum = base >= 8 ? 7 : base;
       let html = '<span class="op-logo-group">';

--- a/interface/signature-strength.js
+++ b/interface/signature-strength.js
@@ -1,0 +1,12 @@
+(function(global){
+  function getSignatureStrength(level) {
+    const base = parseInt(String(level).replace('OP-', '').split('.')[0], 10);
+    return base >= 8 ? base - 6 : 1;
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { getSignatureStrength };
+  } else {
+    global.getSignatureStrength = getSignatureStrength;
+  }
+})(this);

--- a/test/signature-strength.test.js
+++ b/test/signature-strength.test.js
@@ -1,0 +1,14 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { getSignatureStrength } = require('../interface/signature-strength.js');
+
+test('signature strength defaults to 1 below OP-8', () => {
+  assert.strictEqual(getSignatureStrength('OP-3'), 1);
+  assert.strictEqual(getSignatureStrength('OP-7'), 1);
+});
+
+test('signature strength increases for high OP levels', () => {
+  assert.strictEqual(getSignatureStrength('OP-8'), 2);
+  assert.strictEqual(getSignatureStrength('OP-9'), 3);
+  assert.strictEqual(getSignatureStrength('OP-10'), 4);
+});


### PR DESCRIPTION
## Summary
- support measuring signature strength of OP levels
- use it in ratings page
- include helper script on ratings pages
- test signature strength logic

## Testing
- `node --test`