### PR TITLE
Fix Tanna header visibility

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -5,6 +5,8 @@
 :root {
   --bg-color: #1e1e1e;
   --text-color: #e0e0e0;
+  --header-text-color: var(--text-color);
+  --nav-text-color: var(--text-color);
   --primary-color: #228B22;
   --card-bg: #2b2b2b;
   --header-bg: rgba(34, 34, 34, 0.9);
@@ -17,6 +19,8 @@
 .theme-dark {
   --bg-color: #1e1e1e;
   --text-color: #e0e0e0;
+  --header-text-color: #e0e0e0;
+  --nav-text-color: #e0e0e0;
   --primary-color: #228B22;
   --card-bg: #2b2b2b;
   --header-bg: rgba(34, 34, 34, 0.9);
@@ -28,6 +32,8 @@
 .theme-tanna {
   --bg-color: #eef6ee;
   --text-color: #003300;
+  --header-text-color: #ffffff;
+  --nav-text-color: #ffffff;
   --primary-color: #228B22;
   --card-bg: #ffffff;
   --header-bg: rgba(34, 34, 34, 0.9);
@@ -67,7 +73,7 @@ nav {
 }
 
 nav a {
-  color: var(--text-color);
+  color: var(--nav-text-color);
   margin: 0 0.8em;
   text-decoration: none;
 }
@@ -79,7 +85,7 @@ nav a:focus {
 
 header h1 {
   margin: 0;
-  color: var(--text-color);
+  color: var(--header-text-color);
   font-size: 1.4em;
 }
 


### PR DESCRIPTION
## Summary
- improve theme variables so the `tanna` theme stays readable
- use header-text-color and nav-text-color variables for a visible heading

## Testing
- `node --test`