### PR TITLE
Implement color-auth prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <title>4789 Start</title>
   <link rel="stylesheet" href="interface/ethicom-style.css" />
+  <script src="interface/color-auth.js"></script>
 </head>
 <body>
   <header>

--- a/interface/color-auth.js
+++ b/interface/color-auth.js
@@ -1,0 +1,27 @@
+function verifyColorAuth() {
+  const stored = localStorage.getItem('ethicom_color');
+  const colors = ['rot', 'gruen', 'grün', 'blau', 'gelb'];
+  let question = stored
+    ? 'War deine letzte Farbe gleich (beim letzten Start)? (rot, grün, blau, gelb)'
+    : 'Wähle eine Grundfarbe zur Authentifizierung (rot, grün, blau, gelb):';
+  const input = prompt(question);
+  if (!input) return;
+  const value = input.trim().toLowerCase();
+  if (!colors.includes(value)) {
+    alert('Nur Grundfarben rot, grün, blau, gelb wählbar.');
+    return;
+  }
+  const normalized = value === 'gruen' ? 'grün' : value; // allow ue
+  if (stored) {
+    if (normalized === stored) {
+      alert('Farbe bestätigt. Willkommen zurück.');
+    } else {
+      alert('Hinweis: falscher User, keine Bestätigung.');
+    }
+  } else {
+    localStorage.setItem('ethicom_color', normalized);
+    alert('Farbe gespeichert: ' + normalized);
+  }
+}
+
+window.addEventListener('DOMContentLoaded', verifyColorAuth);

--- a/interface/erstkontakt.html
+++ b/interface/erstkontakt.html
@@ -8,6 +8,7 @@
   <script src="signature-strength.js"></script>
   <script src="ratings.js"></script>
   <script src="interface-loader.js"></script>
+  <script src="color-auth.js"></script>
   <style>
     #op_interface { margin-top: 1em; }
   </style>

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -16,6 +16,7 @@
   <script src="theme-manager.js"></script>
   <script src="dev-mode.js"></script>
   <script src="logo-background.js"></script>
+  <script src="color-auth.js"></script>
 </head>
 <body>
   <div id="op_background"></div>

--- a/interface/ratings.html
+++ b/interface/ratings.html
@@ -7,6 +7,7 @@
   <script src="language-selector.js"></script>
   <script src="signature-strength.js"></script>
   <script src="ratings.js"></script>
+  <script src="color-auth.js"></script>
 </head>
 <body>
   <header>

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>
   <script src="signup.js"></script>
+  <script src="color-auth.js"></script>
 </head>
 <body>
   <header>


### PR DESCRIPTION
## Summary
- add a simple color-based auth prompt script
- load color-auth script on start and interface pages

## Testing
- `node test/json-validity.test.js`
- `node test/consensus.test.js`
- `node test/op-permissions.test.js`
