### PR TITLE
Add API access control module

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Humor ist willkommen, wenn er Verantwortung und Klarheit unterstützt.
 - [Adding Languages](#adding-languages)
 - [Generating Interface README](#generating-interface-readme)
 - [Gatekeeper Control](#gatekeeper-control)
+- [API Access Control](#api-access-control)
 - [Currency Synchronization](#currency-synchronization)
 - [Roadmap](#roadmap)
 - [Local Deployment](#local-deployment)
@@ -107,6 +108,13 @@ Local control can be toggled via `tools/gatekeeper.js`. The script reads
 `app/gatekeeper_config.yaml` and only allows actions when `allow_control` is set
 to `true` for the controller `RL@RLpi`. This keeps remote commands gated and
 limited to the local environment.
+
+### API Access Control [⇧](#contents)
+
+`tools/api-access.js` checks whether API features may be used. The script reads
+the operator level and confirmation flags from `app/user_state.yaml` and grants
+access only when the specified OP level is met and the user has confirmed
+ethical intent.
 
 ### Currency Synchronization [⇧](#contents)
 

--- a/test/api-access.test.js
+++ b/test/api-access.test.js
@@ -1,0 +1,26 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const apiAccessAllowed = require('../tools/api-access.js');
+
+function createState(op, confirmed) {
+  return `user:\n  op_level: ${op}\n  progress:\n    ethics_test_passed: ${confirmed}\n  memory:\n    ethics_confirmed: ${confirmed}`;
+}
+
+test('denies access for low OP level', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'api-'));
+  const file = path.join(dir, 'user_state.yaml');
+  fs.writeFileSync(file, createState('OP-1', true));
+  assert.strictEqual(apiAccessAllowed('OP-3', file), false);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('allows access when level and confirmation meet', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'api-'));
+  const file = path.join(dir, 'user_state.yaml');
+  fs.writeFileSync(file, createState('OP-4', true));
+  assert.strictEqual(apiAccessAllowed('OP-3', file), true);
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/tools/api-access.js
+++ b/tools/api-access.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+
+function parseUserState(filePath) {
+  const p = filePath || path.join(__dirname, '..', 'app', 'user_state.yaml');
+  if (!fs.existsSync(p)) return null;
+  const data = fs.readFileSync(p, 'utf8').split(/\r?\n/);
+  let opLevel = null;
+  let ethicsConfirmed = null;
+  let ethicsTest = null;
+  data.forEach(line => {
+    const op = line.match(/^\s*op_level:\s*(.*)$/);
+    if (op) opLevel = op[1].replace(/['"]/g, '');
+    const ec = line.match(/^\s*ethics_confirmed:\s*(.*)$/);
+    if (ec) ethicsConfirmed = ec[1].replace(/['"]/g, '') === 'true';
+    const et = line.match(/^\s*ethics_test_passed:\s*(.*)$/);
+    if (et) ethicsTest = et[1].replace(/['"]/g, '') === 'true';
+  });
+  return { op_level: opLevel, ethics_confirmed: ethicsConfirmed, ethics_test_passed: ethicsTest };
+}
+
+function opLevelToNumber(level) {
+  if (!level) return 0;
+  const n = parseFloat(String(level).replace('OP-', ''));
+  return isNaN(n) ? 0 : n;
+}
+
+function apiAccessAllowed(minLevel = 'OP-3', userStatePath) {
+  const state = parseUserState(userStatePath);
+  if (!state) return false;
+  const userLevel = opLevelToNumber(state.op_level);
+  const required = opLevelToNumber(minLevel);
+  const ethicsOk = state.ethics_confirmed === true || state.ethics_test_passed === true;
+  return userLevel >= required && ethicsOk;
+}
+
+if (require.main === module) {
+  const min = process.argv[2] || 'OP-3';
+  const allowed = apiAccessAllowed(min);
+  if (allowed) {
+    console.log('API access granted for', min);
+  } else {
+    console.log('API access denied for', min);
+  }
+}
+
+module.exports = apiAccessAllowed;


### PR DESCRIPTION
## Summary
- create `api-access.js` to gate API usage based on OP level and ethical confirmation
- document API access control in README
- test the access logic

## Testing
- `node --test`