### PR TITLE
Limit color auth prompt frequency

### DIFF
--- a/interface/README.md
+++ b/interface/README.md
@@ -32,6 +32,7 @@ Just structured responsibility.
 - `permissions-viewer.js` → visualize OP permissions
 - `language-manager.js` → generate snippets for new translations
 - `semantic-manager.js` → manage emotion word lists for sentiment (OP-5+)
+- `color-auth.js` → authentication via Grundfarbe (fragt höchstens alle 24h)
 - `signup.html` → signup form
 - `signup.js` → handles signup logic
 - `ratings.html` → external overview of overall ratings

--- a/interface/color-auth.js
+++ b/interface/color-auth.js
@@ -1,4 +1,11 @@
 function verifyColorAuth() {
+  const lastTime = parseInt(localStorage.getItem('ethicom_color_time') || '0', 10);
+  const now = Date.now();
+  const twentyFourHours = 24 * 60 * 60 * 1000;
+  if (now - lastTime < twentyFourHours) return;
+
+  localStorage.setItem('ethicom_color_time', String(now));
+
   const stored = localStorage.getItem('ethicom_color');
   const colors = ['rot', 'gruen', 'grün', 'blau', 'gelb'];
   let question = stored


### PR DESCRIPTION
## Summary
- store the last prompt time in `color-auth.js`
- avoid prompting again until 24 hours have passed
- document new behaviour in `interface/README.md`

## Testing
- `node --test`