### PR TITLE
Update README with local server note

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ node tools/serve-interface.js
 ```
 
 Then open `http://localhost:8080/ethicom.html` in your browser.
+Opening the HTML file directly (e.g. via `file://`) bypasses the local server and
+causes the language list to remain empty. Always access the interface through
+the provided `localhost` address so that translation files load correctly.
 
 ### Running Tests [⇧](#contents)
 


### PR DESCRIPTION
## Summary
- note that opening ethicom.html via `file://` hides the language list

## Testing
- `node --test`