### PR TITLE
Add OP-0 test mode

### DIFF
--- a/interface/README.md
+++ b/interface/README.md
@@ -107,6 +107,10 @@ loaded dynamically so the system can scale from OP-0 through OP-10.
 
 Activate dev mode via the toggle button on `ethicom.html` or add `?dev` to the URL. When enabled, help and info sections reveal additional details for development and debugging. The state is stored in your browser's localStorage under `ethicom_dev`.
 
+## OP-0 Test Mode
+
+Use the "Toggle OP-0 Test Mode" button to try anonymous evaluations without storing them as evidence. When enabled, a notice appears in the OP‑0 interface and generated data is **not** recorded in `localStorage`.
+
 ## Designprinzipien
 
 Siehe [shneiderman-rules.md](shneiderman-rules.md) für die acht Gestaltungsrichtlinien, die im Interface berücksichtigt werden.

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -16,6 +16,7 @@
   <script src="theme-manager.js"></script>
   <script src="disclaimer.js"></script>
   <script src="dev-mode.js"></script>
+  <script src="op0-testmode.js"></script>
   <script src="logo-background.js"></script>
   <script src="color-auth.js"></script>
 </head>
@@ -69,6 +70,9 @@
 
     <div id="dev_toggle" class="card">
       <button onclick="toggleDevMode()" class="accent-button">Toggle Dev Mode</button>
+    </div>
+    <div id="test_toggle" class="card">
+      <button onclick="toggleOP0TestMode()" class="accent-button">Toggle OP-0 Test Mode</button>
     </div>
     <div id="access_setup" class="card"></div>
 

--- a/interface/modules/op-0-interface.js
+++ b/interface/modules/op-0-interface.js
@@ -7,6 +7,7 @@ function initOP0Interface() {
   container.innerHTML = `
     <div class="card">
       <h3>Anonymous Rating (OP-0)</h3>
+      ${typeof isOP0TestMode === 'function' && isOP0TestMode() ? '<p class="warn">Test Mode: Results are not recorded.</p>' : ''}
       <p class="info" data-info="op-0"></p>
 
       <label for="src_lvl">Select a general ethical level (SRC):</label>
@@ -49,7 +50,9 @@ function generateAnonymousManifest() {
   const output = document.getElementById("output");
   output.textContent = JSON.stringify(evalData, null, 2);
 
-  if (typeof recordEvidence === "function") {
+  if (typeof isOP0TestMode === 'function' && isOP0TestMode()) {
+    output.textContent += "\n(Test mode active: data not saved)";
+  } else if (typeof recordEvidence === "function") {
     recordEvidence(JSON.stringify(evalData), "user");
   }
 }

--- a/interface/op0-testmode.js
+++ b/interface/op0-testmode.js
@@ -1,0 +1,37 @@
+const storage = typeof localStorage === 'undefined'
+  ? {
+      data: {},
+      setItem(k, v) { this.data[k] = String(v); },
+      getItem(k) { return this.data[k]; },
+      removeItem(k) { delete this.data[k]; }
+    }
+  : localStorage;
+
+function enableOP0TestMode() {
+  storage.setItem('op0_test', 'true');
+}
+
+function disableOP0TestMode() {
+  storage.removeItem('op0_test');
+}
+
+function toggleOP0TestMode() {
+  if (isOP0TestMode()) {
+    disableOP0TestMode();
+  } else {
+    enableOP0TestMode();
+  }
+}
+
+function isOP0TestMode() {
+  return storage.getItem('op0_test') === 'true';
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { enableOP0TestMode, disableOP0TestMode, toggleOP0TestMode, isOP0TestMode };
+}
+
+if (typeof window !== 'undefined') {
+  window.toggleOP0TestMode = toggleOP0TestMode;
+  window.isOP0TestMode = isOP0TestMode;
+}

--- a/test/op0-testmode.test.js
+++ b/test/op0-testmode.test.js
@@ -1,0 +1,12 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { enableOP0TestMode, disableOP0TestMode, isOP0TestMode } = require('../interface/op0-testmode.js');
+
+test('OP-0 test mode toggle', () => {
+  disableOP0TestMode();
+  assert.strictEqual(isOP0TestMode(), false);
+  enableOP0TestMode();
+  assert.strictEqual(isOP0TestMode(), true);
+  disableOP0TestMode();
+  assert.strictEqual(isOP0TestMode(), false);
+});


### PR DESCRIPTION
## Summary
- implement toggle for OP‑0 test mode and expose functions to window
- show test status in OP‑0 interface and avoid evidence recording
- allow test mode toggle in Ethicom interface
- document the feature in `interface/README.md`
- test the new module with `node:test`

## Testing
- `node --test`