### PR TITLE
Improve low OP-level usability

### DIFF
--- a/i18n/ui-text.json
+++ b/i18n/ui-text.json
@@ -58,6 +58,9 @@
     "status_sig_invalid": "Signature invalid or password incorrect.",
     "status_sig_valid": "Signature valid: {level}",
     "status_loading_op0": "Loading OP-0...",
+    "simple_toggle_label": "Toggle Simple Mode",
+    "simple_mode_on": "Simple mode is active.",
+    "simple_mode_off": "Simple mode is off.",
     "disclaimer_title": "Disclaimers",
     "disclaimer_items": [
       "This structure is provided without warranty.",
@@ -128,6 +131,9 @@
     "status_sig_invalid": "Signatur ungültig oder Passwort falsch.",
     "status_sig_valid": "Signatur gültig: {level}",
     "status_loading_op0": "OP-0 wird geladen...",
+    "simple_toggle_label": "Einfach-Modus umschalten",
+    "simple_mode_on": "Einfach-Modus aktiv.",
+    "simple_mode_off": "Einfach-Modus deaktiviert.",
     "disclaimer_title": "Hinweise",
     "disclaimer_items": [
       "Diese Struktur wird ohne Gewährleistung bereitgestellt.",

--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -289,3 +289,20 @@ body.large-font button {
   padding: 1em;
 }
 
+/* Simple mode for lower OP levels */
+body.simple-mode {
+  font-size: 1.1em;
+}
+body.simple-mode .badge-gallery,
+body.simple-mode #theme_selection,
+body.simple-mode #dev_toggle {
+  display: none;
+}
+body.simple-mode input,
+body.simple-mode textarea,
+body.simple-mode select,
+body.simple-mode button {
+  font-size: 1em;
+  padding: 0.8em;
+}
+

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -67,6 +67,10 @@
       </select>
     </div>
 
+    <div id="simple_mode_toggle" class="card">
+      <button onclick="toggleSimpleMode()" class="accent-button" data-ui="simple_toggle_label">Toggle Simple Mode</button>
+    </div>
+
     <div id="dev_toggle" class="card">
       <button onclick="toggleDevMode()" class="accent-button">Toggle Dev Mode</button>
     </div>
@@ -103,6 +107,9 @@
       loadUiTexts().then(texts => {
         uiText = texts[getLanguage()] || texts.en || {};
         applyTexts(uiText);
+        if (localStorage.getItem('simple_mode') === 'true') {
+          document.body.classList.add('simple-mode');
+        }
         showDisclaimers(uiText);
         initTranslationManager();
         renderAllBadges();
@@ -162,6 +169,12 @@
           <button onclick="loadInterfaceForOP(document.getElementById('tool_select').value)">Load</button>
         </div>`;
       }
+    }
+
+    function toggleSimpleMode() {
+      const enabled = document.body.classList.toggle('simple-mode');
+      localStorage.setItem('simple_mode', enabled ? 'true' : 'false');
+      alert(enabled ? (uiText.simple_mode_on || 'Simple mode is active.') : (uiText.simple_mode_off || 'Simple mode is off.'));
     }
   </script>
 </body>

--- a/interface/interface-loader.js
+++ b/interface/interface-loader.js
@@ -68,6 +68,12 @@ function loadInterfaceForOP(op_level) {
     if (typeof window.setHelpSection === "function") {
       window.setHelpSection(op_level);
     }
+    if (["OP-0", "OP-1", "OP-2"].includes(op_level)) {
+      const section = document.getElementById("help_section");
+      if (section) {
+        section.querySelectorAll("details").forEach(d => (d.open = true));
+      }
+    }
     if (status) status.textContent = "Module loaded";
   };
   document.body.appendChild(script);


### PR DESCRIPTION
## Summary
- add 'Simple Mode' toggle to the main interface
- automatically enable simple mode based on local storage
- style simple mode for better readability and hide advanced features
- open help topics for OP-0 to OP-2 automatically
- extend translations for the new toggle

## Testing
- `node --test`