### PR TITLE
Fix language selector on all pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <title>4789 Start</title>
   <link rel="stylesheet" href="interface/ethicom-style.css" />
   <script src="interface/color-auth.js"></script>
+  <script src="interface/language-selector.js"></script>
 </head>
 <body>
   <header>
@@ -41,5 +42,10 @@
       <p>Starte die Bewertung über <a href="interface/ethicom.html">Ethicom</a>. Eine Vorschau für OP‑0 ist ohne Anmeldung möglich.</p>
     </section>
   </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      getLanguage();
+    });
+  </script>
 </body>
 </html>

--- a/interface/language-selector.js
+++ b/interface/language-selector.js
@@ -16,12 +16,20 @@ function askLanguageChoice() {
 
 function getLanguage() {
   const stored = localStorage.getItem("ethicom_lang");
-  return stored || askLanguageChoice();
+  const lang = stored || askLanguageChoice();
+  if (lang) document.documentElement.lang = lang;
+  return lang;
+}
+
+function getUiTextPath() {
+  return window.location.pathname.includes("/interface/")
+    ? "../i18n/ui-text.json"
+    : "i18n/ui-text.json";
 }
 
 // Initialize a language dropdown and reload on change
-function initLanguageDropdown(selectId = "lang_select") {
-  fetch("../i18n/ui-text.json")
+function initLanguageDropdown(selectId = "lang_select", textPath = getUiTextPath()) {
+  fetch(textPath)
     .then(r => r.json())
     .then(texts => {
       const select = document.getElementById(selectId);


### PR DESCRIPTION
## Summary
- set document language from stored selection in `language-selector.js`
- auto-detect path to translation texts
- load `language-selector.js` on the start page and apply stored language

## Testing
- `node --test`