### PR TITLE
Add log helper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,12 @@ ethical intent.
 
 ### OP Function Bundles [⇧](#contents)
 
-`tools/op-functions.js` exposes small helper functions that unlock
-only when the necessary operator level and ethical confirmation are present.
-Each function is associated with a minimum OP level and the
+`tools/op-functions.js` exposes small helper functions that only
+run when the necessary operator level and ethical confirmation are
+present. Each function is associated with a minimum OP level and the
 module checks permission via `api-access.js` before returning it.
+Available helpers include `info`, `analyze`, `optimize` and `log` – the
+last one prints the recent Git commit history.
 
 ### Currency Synchronization [⇧](#contents)
 

--- a/test/op-functions.test.js
+++ b/test/op-functions.test.js
@@ -27,3 +27,14 @@ test('grants function when level meets requirement', () => {
   assert.strictEqual(fn(), 'Optimization done.');
   fs.rmSync(dir, { recursive: true, force: true });
 });
+
+test('log function returns recent commits', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opfunc-'));
+  const file = path.join(dir, 'user_state.yaml');
+  fs.writeFileSync(file, createState('OP-2', true));
+  const fn = getOpFunction('log', file);
+  assert.strictEqual(typeof fn, 'function');
+  const out = fn();
+  assert.ok(out.includes('\n'));
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/tools/op-functions.js
+++ b/tools/op-functions.js
@@ -12,6 +12,17 @@ const OP_FUNCTIONS = {
   optimize: {
     minLevel: 'OP-7',
     fn: () => 'Optimization done.'
+  },
+  log: {
+    minLevel: 'OP-2',
+    fn: () => {
+      try {
+        const { execSync } = require('child_process');
+        return execSync('git log --oneline -n 5', { encoding: 'utf8' });
+      } catch (err) {
+        return 'Log could not be retrieved.';
+      }
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- add a `log` helper in `tools/op-functions.js` that returns the last five commits
- document the helper in README
- test the new helper

## Testing
- `node --test`