### PR TITLE
Add OP overview modules to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <link rel="stylesheet" href="interface/ethicom-style.css" />
   <script src="interface/color-auth.js"></script>
   <script src="interface/language-selector.js"></script>
+  <script src="interface/dynamic-info.js"></script>
+  <script src="interface/op-overview.js"></script>
 </head>
 <body>
   <header>
@@ -43,6 +45,7 @@
       <h2>Direkt loslegen</h2>
       <p>Starte die Bewertung über <a href="interface/ethicom.html">Ethicom</a>. Eine Vorschau für OP‑0 ist ohne Anmeldung möglich.</p>
     </section>
+    <section id="op_overview" class="card"></section>
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {

--- a/interface/op-overview.js
+++ b/interface/op-overview.js
@@ -1,0 +1,32 @@
+function renderOpOverview() {
+  const container = document.getElementById('op_overview');
+  if (!container) return;
+
+  fetch('permissions/op-permissions-expanded.json')
+    .then(r => r.json())
+    .then(data => {
+      const levels = [
+        'OP-0','OP-1','OP-2','OP-3','OP-4','OP-5','OP-6',
+        'OP-7','OP-7.5','OP-7.9','OP-8','OP-9','OP-10','OP-11','OP-12'
+      ];
+      container.innerHTML = '';
+      levels.forEach(level => {
+        const card = document.createElement('section');
+        card.className = 'card';
+        const infoKey = level.toLowerCase();
+        const perms = data[level] ? Object.keys(data[level]).filter(k => data[level][k]) : [];
+        const list = perms.map(p => `<li>${p}</li>`).join('');
+        card.innerHTML = `<h3>${level}</h3><p class="info" data-info="${infoKey}"></p>` +
+          (list ? `<ul>${list}</ul>` : '<p>Keine Daten vorhanden.</p>');
+        container.appendChild(card);
+      });
+      if (typeof applyInfoTexts === 'function') {
+        applyInfoTexts(container);
+      }
+    })
+    .catch(() => {
+      container.textContent = 'Konnte OP-Daten nicht laden.';
+    });
+}
+
+document.addEventListener('DOMContentLoaded', renderOpOverview);


### PR DESCRIPTION
## Summary
- show dynamic OP overview on home page via new script
- fetch permission info from `op-permissions-expanded.json`

## Testing
- `node --test`