### PR TITLE
Add README links for OP badges

### DIFF
--- a/interface/README.md
+++ b/interface/README.md
@@ -45,31 +45,23 @@ For OP-6 and above, the generator can optionally store a hashed passport or ID l
 
 ## Ethical Conditions
 
-| Level      | Description                         |
-|------------|-------------------------------------|
-| OP-0       | anonymous observer                  |
-| OP-1       | first signed rating                 |
-| OP-3+      | rating requires justification       |
-| OP-4+      | can revise after 3 weeks            |
-| OP-5+      | may withdraw previous evaluations   |
-| OP-6+      | can verify consensus                |
-| OP-9     | may verify donations / nominate     |
-| OP-10       | candidate for Yokozuna (OP-11)       |
-| OP-11       | Yokozuna-Schwingerkönig mode        |
-| OP-12      | first non-human stage               |
-| OP-0   | anonymous observer                                      |
-| OP-1   | first signed rating                                     |
-| OP-2   | provides feedback responsibly                            |
-| OP-3   | rating requires justification                            |
-| OP-4   | can revise after 3 weeks                                 |
-| OP-5   | may withdraw previous evaluations                        |
-| OP-6   | can verify consensus                                     |
-| OP-7   | structural authority                                     |
-| OP-7.5 | nomination preparation, review OP-8                      |
-| OP-7.9 | donation verification, confirm nominations                |
-| OP-8   | candidate stage for OP-9 (system self-stabilizes)         |
-| OP-9   | Yokozuna-Schwingerkönig mode                              |
-| OP-10  | first non-human stage                                     |
+| Level | Description |
+|-------|-------------|
+| <a id="op-0"></a> OP-0 | anonymous observer |
+| <a id="op-1"></a> OP-1 | first signed rating |
+| <a id="op-2"></a> OP-2 | provides feedback responsibly |
+| <a id="op-3"></a> OP-3 | rating requires justification |
+| <a id="op-4"></a> OP-4 | can revise after 3 weeks |
+| <a id="op-5"></a> OP-5 | may withdraw previous evaluations |
+| <a id="op-6"></a> OP-6 | can verify consensus |
+| <a id="op-7"></a> OP-7 | structural authority |
+| <a id="op-7-5"></a> OP-7.5 | nomination preparation, review OP-8 |
+| <a id="op-7-9"></a> OP-7.9 | donation verification, confirm nominations |
+| <a id="op-8"></a> OP-8 | candidate stage for OP-9 (system self-stabilizes) |
+| <a id="op-9"></a> OP-9 | may verify donations / nominate |
+| <a id="op-10"></a> OP-10 | candidate for Yokozuna (OP-11) |
+| <a id="op-11"></a> OP-11 | Yokozuna-Schwingerkönig mode |
+| <a id="op-12"></a> OP-12 | first non-human stage |
 
 ---
 

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -5,12 +5,16 @@ function renderBadge(currentRank, maxRank) {
   const badgeDisplay = document.getElementById("badge_display");
   if (!badgeDisplay) return;
 
-  const main = document.createElement("span");
-  main.className = `badge op-${currentRank.replace("OP-", "").replace(".", "")}`;
-  main.textContent = currentRank;
+  const mainSpan = document.createElement("span");
+  mainSpan.className = `badge op-${currentRank.replace("OP-", "").replace(".", "")}`;
+  mainSpan.textContent = currentRank;
+
+  const mainLink = document.createElement("a");
+  mainLink.href = `README.md#${currentRank.toLowerCase().replace(/\./g, '-')}`;
+  mainLink.appendChild(mainSpan);
 
   badgeDisplay.innerHTML = "";
-  badgeDisplay.appendChild(main);
+  badgeDisplay.appendChild(mainLink);
 
   if (parseFloat(maxRank.replace("OP-", "")) > parseFloat(currentRank.replace("OP-", ""))) {
     const shadow = document.createElement("span");
@@ -46,7 +50,10 @@ function renderAllBadges() {
     const span = document.createElement("span");
     span.className = `badge op-${lvl.replace("OP-", "").replace(/\./g, "")}`;
     span.textContent = lvl;
-    gallery.appendChild(span);
+    const link = document.createElement("a");
+    link.href = `README.md#${lvl.toLowerCase().replace(/\./g, '-')}`;
+    link.appendChild(span);
+    gallery.appendChild(link);
   });
 }
 


### PR DESCRIPTION
## Summary
- link OP-level badges in `ethicom-utils.js` to README sections
- consolidate OP-level table in `interface/README.md` and add anchors for linking

## Testing
- `node --test`
- `node tools/check-translations.js`