### PR TITLE
Add incomplete language indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ node tools/check-translations.js
 ```
 
 This prints a list of language codes and the fields that still require
-translation.
+translation. In the interface dropdown, languages with missing fields show an
+asterisk (`*`) so users know the translation is not complete.
 
 ### Generating Interface README [⇧](#contents)
 

--- a/interface/language-selector.js
+++ b/interface/language-selector.js
@@ -34,18 +34,29 @@ function initLanguageDropdown(selectId = "lang_select", textPath = getUiTextPath
     .then(texts => {
       const select = document.getElementById(selectId);
       if (!select) return;
+
+      const base = texts.en || {};
+      const keys = Object.keys(base);
+      function isEmpty(v) {
+        if (Array.isArray(v)) return v.length === 0 || v.every(x => !x);
+        return v === undefined || v === null || v === "";
+      }
+
       Object.keys(texts)
         .sort()
         .forEach(code => {
           const opt = document.createElement("option");
           opt.value = code;
-          opt.textContent = code;
+          const obj = texts[code] || {};
+          const incomplete = keys.some(k => !Object.prototype.hasOwnProperty.call(obj, k) || isEmpty(obj[k]));
+          opt.textContent = incomplete ? `${code}*` : code;
+          if (incomplete) opt.title = "Translation incomplete";
           select.appendChild(opt);
         });
       const current = getLanguage();
       select.value = current;
       select.addEventListener("change", e => {
-        const lang = e.target.value;
+        const lang = e.target.value.replace(/\*$/, "");
         localStorage.setItem("ethicom_lang", lang);
         const t = texts[lang] || texts.en || {};
         if (typeof applyTexts === "function") {


### PR DESCRIPTION
## Summary
- mark languages missing UI text with an asterisk in the dropdown
- document the indicator in the README
- run tests

## Testing
- `node --test`
- `node tools/check-translations.js`