### PR TITLE
Add language-aware README links

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <a href="interface/chat.html">Chat</a>
     <a href="interface/settings.html">Settings</a>
     <a href="wings/index.html">Wings</a>
-    <a href="README.md" target="_blank">README</a>
+    <a href="README.md" target="_blank" class="readme-link">README</a>
   </nav>
   <main>
     <section class="card">
@@ -55,3 +55,4 @@
   </script>
 </body>
 </html>
+

--- a/interface/chat.html
+++ b/interface/chat.html
@@ -25,7 +25,7 @@
     <a href="tools.html" data-ui="nav_tools">Tools</a>
     <a href="chat.html">Chat</a>
     <a href="../wings/index.html">Wings</a>
-    <a href="../README.md" target="_blank">README</a>
+    <a href="../README.md" target="_blank" class="readme-link">README</a>
   </nav>
   <main>
     <div id="lang_selection" class="card" style="margin-bottom:1em;">

--- a/interface/erstkontakt.html
+++ b/interface/erstkontakt.html
@@ -29,7 +29,7 @@
     <a href="tools.html" data-ui="nav_tools">Tools</a>
     <a href="settings.html" data-ui="nav_settings">Settings</a>
     <a href="../wings/index.html">Wings</a>
-    <a href="../README.md" target="_blank">README</a>
+    <a href="../README.md" target="_blank" class="readme-link">README</a>
   </nav>
   <main class="card">
     <div id="lang_selection" class="card" style="margin-bottom:1em;">

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -1,6 +1,13 @@
 
 // ethicom-utils.js – Hilfsfunktionen für Interface-Anzeige
 
+function getReadmePath(lang) {
+  const prefix = window.location.pathname.includes('/interface/') ? '..' : '.';
+  return lang === 'en'
+    ? `${prefix}/README.md`
+    : `${prefix}/i18n/README.${lang}.md`;
+}
+
 function renderBadge(currentRank, maxRank) {
   const badgeDisplay = document.getElementById("badge_display");
   if (!badgeDisplay) return;
@@ -9,9 +16,9 @@ function renderBadge(currentRank, maxRank) {
   mainSpan.className = `badge op-${currentRank.replace("OP-", "").replace(".", "")}`;
   mainSpan.textContent = currentRank;
 
+  const lang = localStorage.getItem('ethicom_lang') || document.documentElement.lang || 'en';
   const mainLink = document.createElement("a");
-  mainLink.href = `README.html#${currentRank.toLowerCase().replace(/\./g, '-')}`;
-  mainLink.href = `README.md#${currentRank.toLowerCase().replace(/\./g, '-')}`;
+  mainLink.href = `${getReadmePath(lang)}#${currentRank.toLowerCase().replace(/\./g, '-')}`;
   mainLink.appendChild(mainSpan);
 
   badgeDisplay.innerHTML = "";
@@ -46,14 +53,14 @@ function renderAllBadges() {
     "OP-12"
   ];
 
+  const lang = localStorage.getItem('ethicom_lang') || document.documentElement.lang || 'en';
   gallery.innerHTML = "";
   levels.forEach(lvl => {
     const span = document.createElement("span");
     span.className = `badge op-${lvl.replace("OP-", "").replace(/\./g, "")}`;
     span.textContent = lvl;
     const link = document.createElement("a");
-    link.href = `README.html#${lvl.toLowerCase().replace(/\./g, '-')}`;
-    link.href = `README.md#${lvl.toLowerCase().replace(/\./g, '-')}`;
+    link.href = `${getReadmePath(lang)}#${lvl.toLowerCase().replace(/\./g, '-')}`;
     link.appendChild(span);
     gallery.appendChild(link);
   });
@@ -102,3 +109,5 @@ function opLevelToNumber(level) {
 
 window.getStoredOpLevel = getStoredOpLevel;
 window.opLevelToNumber = opLevelToNumber;
+window.getReadmePath = getReadmePath;
+

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -37,7 +37,7 @@
     <a href="tools.html" data-ui="nav_tools">Tools</a>
     <a href="settings.html" data-ui="nav_settings">Settings</a>
     <a href="../wings/index.html">Wings</a>
-    <a href="../README.md" target="_blank" data-ui="nav_readme">README</a>
+    <a href="../README.md" target="_blank" data-ui="nav_readme" class="readme-link">README</a>
   </nav>
   <main>
     <h2 id="title">Ethicom Evaluation</h2>

--- a/interface/language-selector.js
+++ b/interface/language-selector.js
@@ -18,6 +18,7 @@ function getLanguage() {
   const stored = localStorage.getItem("ethicom_lang");
   const lang = stored || askLanguageChoice();
   if (lang) document.documentElement.lang = lang;
+  if (typeof updateReadmeLinks === 'function') updateReadmeLinks(lang);
   return lang;
 }
 
@@ -25,6 +26,17 @@ function getUiTextPath() {
   return window.location.pathname.includes("/interface/")
     ? "../i18n/ui-text.json"
     : "i18n/ui-text.json";
+}
+
+function updateReadmeLinks(lang) {
+  const prefix = window.location.pathname.includes('/interface/') ? '..' : '.';
+  const base = lang === 'en'
+    ? `${prefix}/README.md`
+    : `${prefix}/i18n/README.${lang}.md`;
+  document.querySelectorAll('a.readme-link').forEach(a => {
+    const anchor = a.getAttribute('href').split('#')[1];
+    a.href = anchor ? `${base}#${anchor}` : base;
+  });
 }
 
 // Initialize a language dropdown and reload on change
@@ -66,6 +78,8 @@ function initLanguageDropdown(selectId = "lang_select", textPath = getUiTextPath
           window.uiText = t;
           applySignupTexts();
         }
+        if (typeof updateReadmeLinks === 'function') updateReadmeLinks(lang);
       });
     });
 }
+

--- a/interface/ratings.html
+++ b/interface/ratings.html
@@ -25,7 +25,7 @@
     <a href="tools.html" data-ui="nav_tools">Tools</a>
     <a href="settings.html" data-ui="nav_settings">Settings</a>
     <a href="../wings/index.html">Wings</a>
-    <a href="../README.md" target="_blank">README</a>
+    <a href="../README.md" target="_blank" class="readme-link">README</a>
   </nav>
   <main>
     <div id="lang_selection" class="card" style="margin-bottom:1em;">

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -28,7 +28,7 @@
     <a href="tools.html" data-ui="nav_tools">Tools</a>
     <a href="settings.html" data-ui="nav_settings">Settings</a>
     <a href="../wings/index.html">Wings</a>
-    <a href="../README.md" target="_blank" data-ui="nav_readme">README</a>
+    <a href="../README.md" target="_blank" data-ui="nav_readme" class="readme-link">README</a>
   </nav>
   <main>
     <div id="lang_selection" class="card" style="margin-bottom:1em;">

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -24,7 +24,7 @@
     <a href="tools.html" data-ui="nav_tools">Tools</a>
     <a href="settings.html" data-ui="nav_settings">Settings</a>
     <a href="../wings/index.html">Wings</a>
-    <a href="../README.md" target="_blank">README</a>
+    <a href="../README.md" target="_blank" class="readme-link">README</a>
   </nav>
   <main>
     <div id="lang_selection" class="card" style="margin-bottom:1em;">

--- a/interface/tools.html
+++ b/interface/tools.html
@@ -25,7 +25,7 @@
     <a href="tools.html" data-ui="nav_tools">Tools</a>
     <a href="settings.html" data-ui="nav_settings">Settings</a>
     <a href="../wings/index.html">Wings</a>
-    <a href="../README.md" target="_blank" data-ui="nav_readme">README</a>
+    <a href="../README.md" target="_blank" data-ui="nav_readme" class="readme-link">README</a>
   </nav>
   <main>
     <div id="lang_selection" class="card" style="margin-bottom:1em;">


### PR DESCRIPTION
## Summary
- update `language-selector.js` to adjust README links based on dropdown value
- add helper `getReadmePath` in `ethicom-utils.js`
- export `getReadmePath`
- mark README links in HTML pages so they update

## Testing
- `node --test`
- `node tools/check-translations.js`
