### PR TITLE
Add global theme manager with new schemes

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,11 @@
   <script src="interface/language-selector.js"></script>
   <script src="interface/dynamic-info.js"></script>
   <script src="interface/op-overview.js"></script>
+  <script src="interface/theme-manager.js"></script>
+  <script src="interface/logo-background.js"></script>
 </head>
 <body>
+  <div id="op_background"></div>
   <header>
     <h1>Ethicom Start</h1>
   </header>

--- a/interface/chat.html
+++ b/interface/chat.html
@@ -8,8 +8,11 @@
   <script src="signature-verifier.js"></script>
   <script src="language-selector.js"></script>
   <script src="color-auth.js"></script>
+  <script src="theme-manager.js"></script>
+  <script src="logo-background.js"></script>
 </head>
 <body>
+  <div id="op_background"></div>
   <header>
     <h1>OP Chat</h1>
   </header>

--- a/interface/erstkontakt.html
+++ b/interface/erstkontakt.html
@@ -9,11 +9,14 @@
   <script src="ratings.js"></script>
   <script src="interface-loader.js"></script>
   <script src="color-auth.js"></script>
+  <script src="theme-manager.js"></script>
+  <script src="logo-background.js"></script>
   <style>
     #op_interface { margin-top: 1em; }
   </style>
 </head>
 <body>
+  <div id="op_background"></div>
   <header>
     <h1>Willkommen</h1>
   </header>

--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -42,6 +42,36 @@
   --accent-color: #228B22;
 }
 
+.theme-ocean {
+  --bg-color: #e8f3fa;
+  --text-color: #00334d;
+  --header-text-color: #ffffff;
+  --nav-text-color: #ffffff;
+  --primary-color: #0077aa;
+  --card-bg: #ffffff;
+  --header-bg: rgba(0, 85, 119, 0.9);
+  --nav-bg: rgba(0, 85, 119, 0.9);
+  --card-alpha-bg: rgba(255, 255, 255, 0.95);
+  --accent-color: #0099cc;
+}
+
+.theme-desert {
+  --bg-color: #faf5e6;
+  --text-color: #4d3300;
+  --header-text-color: #ffffff;
+  --nav-text-color: #ffffff;
+  --primary-color: #cc9900;
+  --card-bg: #ffffff;
+  --header-bg: rgba(153, 102, 0, 0.9);
+  --nav-bg: rgba(153, 102, 0, 0.9);
+  --card-alpha-bg: rgba(255, 255, 255, 0.95);
+  --accent-color: #e6b800;
+}
+
+.theme-custom {
+  /* values will be set dynamically */
+}
+
 @keyframes fadeInPage {
   from { opacity: 0; }
   to   { opacity: 1; }

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -64,7 +64,11 @@
       <select id="theme_select">
         <option value="dark">Dark</option>
         <option value="tanna">Tanna</option>
+        <option value="ocean">Ocean</option>
+        <option value="desert">Desert</option>
+        <option value="custom">Custom</option>
       </select>
+      <button id="custom_theme_btn" style="display:none;margin-top:0.5em;" class="accent-button">Create Custom Scheme</button>
     </div>
 
     <div id="simple_mode_toggle" class="card">

--- a/interface/page-flow-demo.html
+++ b/interface/page-flow-demo.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <title>Page Flow Demo</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="theme-manager.js"></script>
+  <script src="logo-background.js"></script>
   <style>
     #flow {
       display: flex;
@@ -26,6 +28,7 @@
   <script src="page-flow.js"></script>
 </head>
 <body>
+  <div id="op_background"></div>
   <nav><a href="ethicom.html">Back</a></nav>
   <div id="flow">
     <div class="page">Page One</div>

--- a/interface/ratings.html
+++ b/interface/ratings.html
@@ -8,8 +8,11 @@
   <script src="signature-strength.js"></script>
   <script src="ratings.js"></script>
   <script src="color-auth.js"></script>
+  <script src="theme-manager.js"></script>
+  <script src="logo-background.js"></script>
 </head>
 <body>
+  <div id="op_background"></div>
   <header>
     <h1>Ethicom – Gesamtbewertungen</h1>
   </header>

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -11,8 +11,10 @@
   <script src="op0-testmode.js"></script>
   <script src="accessibility.js"></script>
   <script src="color-auth.js"></script>
+  <script src="logo-background.js"></script>
 </head>
 <body>
+  <div id="op_background"></div>
   <header>
     <h1 data-ui="nav_settings">Settings</h1>
   </header>
@@ -40,7 +42,11 @@
       <select id="theme_select">
         <option value="dark">Dark</option>
         <option value="tanna">Tanna</option>
+        <option value="ocean">Ocean</option>
+        <option value="desert">Desert</option>
+        <option value="custom">Custom</option>
       </select>
+      <button id="custom_theme_btn" style="display:none;margin-top:0.5em;" class="accent-button">Create Custom Scheme</button>
     </div>
     <div id="dev_toggle" class="card">
       <button onclick="toggleDevMode()" class="accent-button">Toggle Dev Mode</button>

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -7,8 +7,11 @@
   <script src="language-selector.js"></script>
   <script src="signup.js"></script>
   <script src="color-auth.js"></script>
+  <script src="theme-manager.js"></script>
+  <script src="logo-background.js"></script>
 </head>
 <body>
+  <div id="op_background"></div>
   <header>
     <h1>Ethicom Signup</h1>
   </header>

--- a/interface/theme-manager.js
+++ b/interface/theme-manager.js
@@ -1,11 +1,18 @@
 function applyTheme(theme) {
   const body = document.body;
-  body.classList.remove('theme-dark', 'theme-tanna');
-  body.classList.add('theme-' + theme);
+  body.classList.remove('theme-dark', 'theme-tanna', 'theme-ocean', 'theme-desert', 'theme-custom');
+  if (theme === 'custom') {
+    const custom = JSON.parse(localStorage.getItem('ethicom_custom_theme') || '{}');
+    Object.keys(custom).forEach(k => document.documentElement.style.setProperty(k, custom[k]));
+    body.classList.add('theme-custom');
+  } else {
+    body.classList.add('theme-' + theme);
+  }
 }
 
 function initThemeSelection() {
   const select = document.getElementById('theme_select');
+  const customBtn = document.getElementById('custom_theme_btn');
   let theme = localStorage.getItem('ethicom_theme') || 'dark';
   applyTheme(theme);
   if (select) {
@@ -16,6 +23,32 @@ function initThemeSelection() {
       applyTheme(theme);
     });
   }
+  if (customBtn) {
+    const opLevel = window.opLevelToNumber ? window.opLevelToNumber(window.getStoredOpLevel()) : 0;
+    if (opLevel >= 4) {
+      customBtn.style.display = 'block';
+      customBtn.addEventListener('click', createCustomTheme);
+    }
+  }
 }
+
+function createCustomTheme() {
+  const primary = prompt('Primary color (hex or name):');
+  if (!primary) return;
+  const accent = prompt('Accent color (hex or name):');
+  if (!accent) return;
+  const custom = {
+    '--primary-color': primary,
+    '--accent-color': accent
+  };
+  localStorage.setItem('ethicom_custom_theme', JSON.stringify(custom));
+  localStorage.setItem('ethicom_theme', 'custom');
+  applyTheme('custom');
+  const select = document.getElementById('theme_select');
+  if (select) select.value = 'custom';
+}
+
+window.applyTheme = applyTheme;
+window.createCustomTheme = createCustomTheme;
 
 document.addEventListener('DOMContentLoaded', initThemeSelection);

--- a/interface/tools.html
+++ b/interface/tools.html
@@ -8,8 +8,11 @@
   <script src="language-selector.js"></script>
   <script src="translation-manager.js"></script>
   <script src="color-auth.js"></script>
+  <script src="theme-manager.js"></script>
+  <script src="logo-background.js"></script>
 </head>
 <body>
+  <div id="op_background"></div>
   <header>
     <h1 data-ui="nav_tools">Tools</h1>
   </header>


### PR DESCRIPTION
## Summary
- include theme manager and logo background on all pages
- add Ocean, Desert, and Custom themes
- allow OP-4+ users to create custom color schemes
- persist selected theme across pages

## Testing
- `node --test`
- `node tools/check-translations.js`