### PR TITLE
Improve translation completeness checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,7 @@ missing translations, run:
 node tools/check-translations.js
 ```
 
-This prints a list of language codes and the fields that still require
-translation. In the interface dropdown, languages with missing fields show an
-asterisk (`*`) so users know the translation is not complete.
+This prints a list of language codes and the fields that still require translation or are unchanged from English. In the interface dropdown, languages with missing fields show an asterisk (`*`) so users know the translation is not complete.
 
 ### Generating Interface README [⇧](#contents)
 

--- a/interface/language-selector.js
+++ b/interface/language-selector.js
@@ -60,7 +60,7 @@ function initLanguageDropdown(selectId = "lang_select", textPath = getUiTextPath
           const opt = document.createElement("option");
           opt.value = code;
           const obj = texts[code] || {};
-          const incomplete = keys.some(k => !Object.prototype.hasOwnProperty.call(obj, k) || isEmpty(obj[k]));
+          const incomplete = keys.some(k => !Object.prototype.hasOwnProperty.call(obj, k) || isEmpty(obj[k]) || JSON.stringify(obj[k]) === JSON.stringify(base[k]));
           opt.textContent = incomplete ? `${code}*` : code;
           if (incomplete) opt.title = "Translation incomplete";
           select.appendChild(opt);

--- a/tools/check-translations.js
+++ b/tools/check-translations.js
@@ -13,17 +13,24 @@ function isEmpty(val) {
 
 const results = {};
 for (const [lang, obj] of Object.entries(data)) {
+  if (lang === 'en') continue;
   const missing = [];
+  const same = [];
   for (const k of keys) {
     if (!Object.prototype.hasOwnProperty.call(obj, k) || isEmpty(obj[k])) {
       missing.push(k);
+    } else if (JSON.stringify(obj[k]) === JSON.stringify(base[k])) {
+      same.push(k);
     }
   }
-  if (missing.length) results[lang] = missing;
+  if (missing.length || same.length) results[lang] = { missing, same };
 }
 
-for (const lang of Object.keys(results)) {
-  console.log(`${lang} missing: ${results[lang].join(', ')}`);
+for (const [lang, info] of Object.entries(results)) {
+  const msgs = [];
+  if (info.missing.length) msgs.push(`missing: ${info.missing.join(', ')}`);
+  if (info.same.length) msgs.push(`likely untranslated: ${info.same.join(', ')}`);
+  console.log(`${lang} ${msgs.join('; ')}`);
 }
 
 if (!Object.keys(results).length) {


### PR DESCRIPTION
## Summary
- detect untranslated strings in `check-translations.js`
- mark dropdown languages as incomplete when text equals English
- clarify README about identical English text

## Testing
- `node --test`
- `node tools/check-translations.js`