### PR TITLE
Implement animated OP loading badge

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -238,6 +238,24 @@ button:hover {
   font-weight: bold;
 }
 
+#loading_badge {
+  display: none;
+  text-align: center;
+  margin-bottom: 1em;
+}
+
+@keyframes opBadgeSpin {
+  0% { transform: rotate(0deg) scale(1); }
+  50% { transform: rotate(180deg) scale(0.6); }
+  100% { transform: rotate(360deg) scale(1); }
+}
+
+.loading-badge {
+  display: inline-block;
+  transform-origin: center;
+  animation: opBadgeSpin 1s linear infinite;
+}
+
 @media (max-width: 600px) {
   main {
     padding: 1em;

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -107,7 +107,26 @@ function opLevelToNumber(level) {
   return isNaN(n) ? 0 : n;
 }
 
+function showLoadingBadge(level) {
+  const container = document.getElementById("loading_badge");
+  if (!container) return;
+  const span = container.querySelector("span");
+  const lvl = level || "OP-0";
+  if (span) {
+    span.textContent = lvl;
+    span.className = `badge op-${lvl.replace("OP-", "").replace(/\./g, "")} loading-badge`;
+  }
+  container.style.display = "block";
+}
+
+function hideLoadingBadge() {
+  const container = document.getElementById("loading_badge");
+  if (container) container.style.display = "none";
+}
+
 window.getStoredOpLevel = getStoredOpLevel;
 window.opLevelToNumber = opLevelToNumber;
 window.getReadmePath = getReadmePath;
+window.showLoadingBadge = showLoadingBadge;
+window.hideLoadingBadge = hideLoadingBadge;
 

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -97,6 +97,9 @@
 
 
     <div id="status" class="card" style="display:none;"></div>
+    <div id="loading_badge">
+      <span class="badge op-0 loading-badge">OP-0</span>
+    </div>
 
     <div id="op_interface">
       <p class="info" data-info="ethicom"></p>
@@ -128,12 +131,14 @@
       const status = document.getElementById("status");
       status.style.display = "block";
       status.textContent = uiText.status_verifying_sig || "Verifying signature...";
+      showLoadingBadge("OP-0");
 
       const sigId = document.getElementById("sig_input").value.trim();
       const pw = document.getElementById("sig_pass").value;
       const stored = JSON.parse(localStorage.getItem("ethicom_signature") || "{}");
 
       if (!sigId || !pw || !stored.hash || !stored.created || !stored.id) {
+        hideLoadingBadge();
         status.textContent = uiText.status_sig_missing || "Signature not found or incomplete.";
         return;
       }
@@ -142,10 +147,12 @@
       const hash = await sha256(raw);
 
       if (hash !== stored.hash || sigId !== stored.id) {
+        hideLoadingBadge();
         status.textContent = uiText.status_sig_invalid || "Signature invalid or password incorrect.";
         return;
       }
 
+      hideLoadingBadge();
       status.textContent = (uiText.status_sig_valid || "Signature valid: {level}").replace('{level}', stored.op_level);
       renderBadge(stored.op_level, stored.op_level);
       loadInterfaceForOP(stored.op_level);
@@ -155,6 +162,7 @@
       const status = document.getElementById("status");
       status.style.display = "block";
       status.textContent = uiText.status_loading_op0 || "OP-0 wird geladen...";
+      showLoadingBadge("OP-0");
       renderBadge("OP-0", "OP-0");
       loadInterfaceForOP("OP-0");
     }

--- a/interface/interface-loader.js
+++ b/interface/interface-loader.js
@@ -38,10 +38,12 @@ function loadInterfaceForOP(op_level) {
   if (!file) {
     target.innerHTML = "<p>OP-level not recognized or unsupported.</p>";
     if (status) status.textContent = "Unknown OP level";
+    if (window.hideLoadingBadge) window.hideLoadingBadge();
     return;
   }
 
   if (status) status.textContent = "Loading module...";
+  if (window.showLoadingBadge) window.showLoadingBadge(op_level);
 
   script.src = `modules/${file}`;
   script.onload = () => {
@@ -78,6 +80,7 @@ function loadInterfaceForOP(op_level) {
       }
     }
     if (status) status.textContent = "Module loaded";
+    if (window.hideLoadingBadge) window.hideLoadingBadge();
   };
   document.body.appendChild(script);
 }

--- a/interface/modules/interface-loader.js
+++ b/interface/modules/interface-loader.js
@@ -36,10 +36,12 @@ function loadInterfaceForOP(op_level) {
   if (!file) {
     target.innerHTML = "<p>OP-level not recognized or unsupported.</p>";
     if (status) status.textContent = "Unknown OP level";
+    if (window.hideLoadingBadge) window.hideLoadingBadge();
     return;
   }
 
   if (status) status.textContent = "Loading module...";
+  if (window.showLoadingBadge) window.showLoadingBadge(op_level);
 
   script.src = `modules/${file}`;
   script.onload = () => {
@@ -63,6 +65,7 @@ function loadInterfaceForOP(op_level) {
 
     }
     if (status) status.textContent = "Module loaded";
+    if (window.hideLoadingBadge) window.hideLoadingBadge();
   };
   document.body.appendChild(script);
 }


### PR DESCRIPTION
## Summary
- add loading badge element to `ethicom.html`
- animate spinner via `opBadgeSpin` in `ethicom-style.css`
- expose `showLoadingBadge` and `hideLoadingBadge` helpers
- show and hide loader during signature verification
- show and hide loader while modules load

## Testing
- `node --test`
- `node tools/check-translations.js`