### PR TITLE
Add transparent theme

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -68,6 +68,19 @@
   --accent-color: #e6b800;
 }
 
+.theme-transparent {
+  --bg-color: transparent;
+  --text-color: #e0e0e0;
+  --header-text-color: #e0e0e0;
+  --nav-text-color: #e0e0e0;
+  --primary-color: #228B22;
+  --card-bg: #2b2b2b;
+  --header-bg: rgba(34, 34, 34, 0.7);
+  --nav-bg: rgba(51, 51, 51, 0.7);
+  --card-alpha-bg: rgba(43, 43, 43, 0.75);
+  --accent-color: #ccaa22;
+}
+
 .theme-custom {
   /* values will be set dynamically */
 }

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -67,6 +67,7 @@
         <option value="tanna">Tanna</option>
         <option value="ocean">Ocean</option>
         <option value="desert">Desert</option>
+        <option value="transparent">Transparent</option>
         <option value="custom">Custom</option>
       </select>
       <button id="custom_theme_btn" style="display:none;margin-top:0.5em;" class="accent-button">Create Custom Scheme</button>

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -45,6 +45,7 @@
         <option value="tanna">Tanna</option>
         <option value="ocean">Ocean</option>
         <option value="desert">Desert</option>
+        <option value="transparent">Transparent</option>
         <option value="custom">Custom</option>
       </select>
       <button id="custom_theme_btn" style="display:none;margin-top:0.5em;" class="accent-button">Create Custom Scheme</button>

--- a/interface/theme-manager.js
+++ b/interface/theme-manager.js
@@ -1,6 +1,6 @@
 function applyTheme(theme) {
   const body = document.body;
-  body.classList.remove('theme-dark', 'theme-tanna', 'theme-ocean', 'theme-desert', 'theme-custom');
+  body.classList.remove('theme-dark', 'theme-tanna', 'theme-ocean', 'theme-desert', 'theme-transparent', 'theme-custom');
   if (theme === 'custom') {
     const custom = JSON.parse(localStorage.getItem('ethicom_custom_theme') || '{}');
     Object.keys(custom).forEach(k => document.documentElement.style.setProperty(k, custom[k]));


### PR DESCRIPTION
## Summary
- support a new `theme-transparent` in the style sheet
- update theme manager to handle the new class
- allow choosing the transparent scheme in settings and Ethicom pages

## Testing
- `node --test`
- `node tools/check-translations.js`
