### PR TITLE
Improve first visit handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       getLanguage();
+      localStorage.setItem('visited_start', 'true');
     });
   </script>
 </body>

--- a/interface/erstkontakt.html
+++ b/interface/erstkontakt.html
@@ -8,6 +8,8 @@
   <script src="signature-strength.js"></script>
   <script src="ratings.js"></script>
   <script src="interface-loader.js"></script>
+  <script src="translation-manager.js"></script>
+  <script src="disclaimer.js"></script>
   <script src="color-auth.js"></script>
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>
@@ -51,8 +53,18 @@
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
+      if (!localStorage.getItem('visited_start')) {
+        window.location.replace('../index.html');
+        return;
+      }
       initLanguageDropdown('lang_select');
       initRatings();
+      loadUiTexts().then(texts => {
+        const uiText = texts[getLanguage()] || texts.en || {};
+        if (typeof showDisclaimers === 'function') {
+          showDisclaimers(uiText);
+        }
+      });
     });
     function showOP0() {
       const container = document.getElementById('op_interface');


### PR DESCRIPTION
## Summary
- set a local `visited_start` flag when opening the home page
- redirect to `index.html` on first contact if the flag is missing
- show disclaimers on the Erstkontakt page

## Testing
- `node --test`
- `node tools/check-translations.js`
