### PR TITLE
Add Python API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Humor ist willkommen, wenn er Verantwortung und Klarheit unterstützt.
 | `releases/` | Release notes and integrity hashes |
 | `sources/` | Evaluated sources and candidate lists |
 | `test/` | Node.js test suite |
-| `tools/` | Utility scripts (e.g., trust-demotion engine) |
+| `tools/` | Utility scripts (e.g., trust-demotion engine, Python API example) |
 | `use_cases/` | Example scenarios and dissemination ideas |
 
 ### OP-Permissions [⇧](#contents)

--- a/tools/api_example.py
+++ b/tools/api_example.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Minimal API client using requests for the 4789 LLM."""
+import os
+import json
+import requests
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), '..', 'app', 'llm_config.yaml')
+
+
+def load_llm_config(path=CONFIG_PATH):
+    cfg = {}
+    level0 = None
+    level1 = None
+    with open(path, 'r', encoding='utf-8') as f:
+        for line in f:
+            if not line.strip() or line.strip().startswith('#'):
+                continue
+            indent = len(line) - len(line.lstrip(' '))
+            line = line.rstrip()
+            if indent == 0:
+                key = line.rstrip(':')
+                level0 = key
+                cfg[level0] = {}
+            elif indent == 2:
+                if line.strip().endswith(':'):
+                    key = line.strip()[:-1]
+                    cfg[level0][key] = {}
+                    level1 = key
+                else:
+                    k, v = line.strip().split(':', 1)
+                    val = v.strip().strip('"')
+                    if val == 'null':
+                        val = None
+                    cfg[level0][k.strip()] = val
+            elif indent == 4 and level1:
+                k, v = line.strip().split(':', 1)
+                val = v.strip().strip('"')
+                cfg[level0][level1][k.strip()] = val
+    return cfg.get('llm', cfg)
+
+
+def call_llm(prompt, config=None):
+    cfg = config or load_llm_config()
+    url = cfg.get('url')
+    headers = cfg.get('headers', {})
+    payload = {
+        'model': cfg.get('model'),
+        'prompt': prompt,
+    }
+    response = requests.post(url, json=payload, headers=headers, timeout=int(cfg.get('timeout', 10)))
+    response.raise_for_status()
+    return response.json()
+
+
+def main():
+    import sys
+    prompt = ' '.join(sys.argv[1:]) or 'Explain responsibility briefly.'
+    try:
+        result = call_llm(prompt)
+        print(json.dumps(result, indent=2))
+    except Exception as exc:
+        print('API request failed:', exc)
+
+
+if __name__ == '__main__':
+    main()

--- a/use_cases/api_example_python.md
+++ b/use_cases/api_example_python.md
@@ -1,0 +1,12 @@
+# API Example with Python Requests
+
+`tools/api_example.py` demonstrates how to send a prompt to the local 4789 LLM.
+It reads the endpoint from `app/llm_config.yaml` and prints the JSON response.
+
+Run:
+
+```bash
+python3 tools/api_example.py "Your prompt here"
+```
+
+Ensure the configured API server is reachable. Offline environments may skip network calls.


### PR DESCRIPTION
## Summary
- provide a minimal Python script demonstrating how to call the LLM API
- document the example usage
- mention Python API script in README

## Testing
- `node --test`
- `node tools/check-translations.js`
