### PR TITLE
Implement gatekeeper function

### DIFF
--- a/test/gatekeeper.test.js
+++ b/test/gatekeeper.test.js
@@ -1,0 +1,26 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { gateCheck } = require('../tools/gatekeeper.js');
+
+function createConfig(allow) {
+  return `gatekeeper:\n  controller: "RL@RLpi"\n  allow_control: ${allow}\n  local_only: true`;
+}
+
+test('denies control when allow_control is false', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-'));
+  const file = path.join(dir, 'config.yaml');
+  fs.writeFileSync(file, createConfig('false'));
+  assert.strictEqual(gateCheck(file), false);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('allows control when config permits', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-'));
+  const file = path.join(dir, 'config.yaml');
+  fs.writeFileSync(file, createConfig('true'));
+  assert.strictEqual(gateCheck(file), true);
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/tools/gatekeeper.js
+++ b/tools/gatekeeper.js
@@ -1,8 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 
-function parseConfig() {
-  const configPath = path.join(__dirname, '..', 'app', 'gatekeeper_config.yaml');
+function parseConfig(filePath) {
+  const configPath = filePath || path.join(__dirname, '..', 'app', 'gatekeeper_config.yaml');
   if (!fs.existsSync(configPath)) {
     return null;
   }
@@ -17,8 +17,8 @@ function parseConfig() {
   return cfg;
 }
 
-function gateCheck() {
-  const cfg = parseConfig();
+function gateCheck(configPath) {
+  const cfg = parseConfig(configPath);
   if (!cfg) {
     console.log('Gatekeeper: configuration missing.');
     return false;
@@ -29,10 +29,14 @@ function gateCheck() {
   return allowed && controllerOK && local;
 }
 
-if (gateCheck()) {
-  console.log('Gatekeeper: RL@RLpi control allowed (local only).');
-  process.exit(0);
-} else {
-  console.log('Gatekeeper: control denied.');
-  process.exit(1);
+if (require.main === module) {
+  if (gateCheck()) {
+    console.log('Gatekeeper: RL@RLpi control allowed (local only).');
+    process.exit(0);
+  } else {
+    console.log('Gatekeeper: control denied.');
+    process.exit(1);
+  }
 }
+
+module.exports = { gateCheck };


### PR DESCRIPTION
## Summary
- export `gateCheck` in `tools/gatekeeper.js`
- allow tests to supply a config path
- add new gatekeeper tests

## Testing
- `node --test`
- `node tools/check-translations.js`