### PR TITLE
Consolidate OP‑7.9 duties into OP‑9

### DIFF
--- a/interface/README.html
+++ b/interface/README.html
@@ -65,9 +65,8 @@ For OP-6 and above, the generator can optionally store a hashed passport or ID l
 | <a id="op-6"></a> OP-6 | can verify consensus |
 | <a id="op-7"></a> OP-7 | structural authority |
 | <a id="op-7-5"></a> OP-7.5 | nomination preparation, review OP-8 |
-| <a id="op-7-9"></a> OP-7.9 | donation verification, confirm nominations |
 | <a id="op-8"></a> OP-8 | candidate stage for OP-9 (system self-stabilizes) |
-| <a id="op-9"></a> OP-9 | may verify donations / nominate |
+| <a id="op-9"></a> OP-9 | may verify donations, confirm nominations |
 | <a id="op-10"></a> OP-10 | candidate for Yokozuna (OP-11) |
 | <a id="op-11"></a> OP-11 | Yokozuna-Schwingerkönig mode |
 | <a id="op-12"></a> OP-12 | first non-human stage |

--- a/interface/README.md
+++ b/interface/README.md
@@ -57,9 +57,8 @@ For OP-6 and above, the generator can optionally store a hashed passport or ID l
 | <a id="op-6"></a> OP-6 | can verify consensus |
 | <a id="op-7"></a> OP-7 | structural authority |
 | <a id="op-7-5"></a> OP-7.5 | nomination preparation, review OP-8 |
-| <a id="op-7-9"></a> OP-7.9 | donation verification, confirm nominations |
 | <a id="op-8"></a> OP-8 | candidate stage for OP-9 (system self-stabilizes) |
-| <a id="op-9"></a> OP-9 | may verify donations / nominate |
+| <a id="op-9"></a> OP-9 | may verify donations, confirm nominations |
 | <a id="op-10"></a> OP-10 | candidate for Yokozuna (OP-11) |
 | <a id="op-11"></a> OP-11 | Yokozuna-Schwingerkönig mode |
 | <a id="op-12"></a> OP-12 | first non-human stage |

--- a/interface/dynamic-info.js
+++ b/interface/dynamic-info.js
@@ -11,7 +11,7 @@ const infoTexts = {
   'op-6': 'You are allowed to calculate a consensus rating from anonymous evaluations.',
   'op-7': 'You are authorized to override previous evaluations if your OP-level is higher and justified.',
   'op-8': 'You are recognized as a structurally consistent operator. You may prepare nominations and review OP-10 observations, but not execute structural changes.',
-  'op-9': 'You may nominate operators and verify donations. Every action is binding and will be logged structurally.',
+  'op-9': 'You may verify donations and confirm nominations. Every action is binding and will be logged structurally.',
   'op-10': 'This is a system-driven structural view of sources. No human input is allowed at this level.',
   'op-11': 'Full structural autonomy. Finalize OP-10 evaluations and trigger self-sustaining loops.',
   'op-12': 'Observation only. Systems operate beyond human control.',

--- a/interface/modules/permissions-viewer.js
+++ b/interface/modules/permissions-viewer.js
@@ -19,7 +19,7 @@ async function loadPermissionTable() {
     const data = await fetch("../permissions/op-permissions-expanded.json").then(r => r.json());
     const order = [
       'OP-0','OP-1','OP-2','OP-3','OP-4','OP-5','OP-6',
-      'OP-7','OP-7.5','OP-7.9','OP-8','OP-9','OP-10','OP-11','OP-12'
+      'OP-7','OP-7.5','OP-8','OP-9','OP-10','OP-11','OP-12'
     ];
     order.forEach(level => {
       if (!data[level]) return;

--- a/interface/op-overview.js
+++ b/interface/op-overview.js
@@ -7,7 +7,7 @@ function renderOpOverview() {
     .then(data => {
       const levels = [
         'OP-0','OP-1','OP-2','OP-3','OP-4','OP-5','OP-6',
-        'OP-7','OP-7.5','OP-7.9','OP-8','OP-9','OP-10','OP-11','OP-12'
+        'OP-7','OP-7.5','OP-8','OP-9','OP-10','OP-11','OP-12'
       ];
       container.innerHTML = '';
       levels.forEach(level => {

--- a/interface/op-permissions-expanded.json
+++ b/interface/op-permissions-expanded.json
@@ -100,20 +100,6 @@
     "can_accept_donations": false,
     "can_override_op6": false
   },
-  "OP-7.9": {
-    "can_rate": true,
-    "can_sign": true,
-    "can_comment": true,
-    "can_nominate": true,
-    "can_vote": true,
-    "can_override": true,
-    "can_retract": true,
-    "can_consensus": true,
-    "can_accept_donations": false,
-    "can_override_op6": true,
-    "can_vote_on_op9": true,
-    "can_vote_on_op10": true
-  },
   "OP-9": {
     "can_rate": true,
     "can_sign": true,

--- a/interface/op-permissions.json
+++ b/interface/op-permissions.json
@@ -100,20 +100,6 @@
     "can_accept_donations": false,
     "can_override_op6": false
   },
-  "OP-7.9": {
-    "can_rate": true,
-    "can_sign": true,
-    "can_comment": true,
-    "can_nominate": true,
-    "can_vote": true,
-    "can_override": true,
-    "can_retract": true,
-    "can_consensus": true,
-    "can_accept_donations": false,
-    "can_override_op6": true,
-    "can_vote_on_op9": true,
-    "can_vote_on_op10": true
-  },
   "OP-9": {
     "can_rate": true,
     "can_sign": true,

--- a/operator/operator_levels.md
+++ b/operator/operator_levels.md
@@ -11,7 +11,7 @@
 | OP-6 | Creates origin-level modules |
 | OP-7 | Structural authority |
 | OP-8 | Structurally consistent operator |
-| OP-9 | May verify donations / nominate |
+| OP-9 | May verify donations, confirm nominations |
 | OP-10 | Candidate stage for OP-11 (system self-stabilizes) |
 | OP-11 | Yokozuna-Schwingerkönig-Mode |
 | OP-12 | First non-human development stage |
@@ -24,9 +24,8 @@
 | OP-6 | Creates origin-level modules  
 | OP-7 | Structural authority
 | OP-7.5 | Nomination preparation, review OP-8
-| OP-7.9 | Donation verification, confirm nominations
 | OP-8 | Candidate stage for OP-9 (system self-stabilizes)
-| OP-9 | Yokozuna-Schwingerkönig-Mode
+| OP-9 | Yokozuna-Schwingerkönig-Mode – verifies donations, confirms nominations
 | OP-10 | First non-human development stage
 
 Upward movement is not based on knowledge, but on structural consistency and ethical presence.

--- a/permissions/op-permissions-expanded.json
+++ b/permissions/op-permissions-expanded.json
@@ -100,20 +100,6 @@
     "can_accept_donations": false,
     "can_override_op6": false
   },
-  "OP-7.9": {
-    "can_rate": true,
-    "can_sign": true,
-    "can_comment": true,
-    "can_nominate": true,
-    "can_vote": true,
-    "can_override": true,
-    "can_retract": true,
-    "can_consensus": true,
-    "can_accept_donations": false,
-    "can_override_op6": true,
-    "can_vote_on_op9": true,
-    "can_vote_on_op10": true
-  },
   "OP-9": {
     "can_rate": true,
     "can_sign": true,


### PR DESCRIPTION
## Summary
- remove OP-7.9 from documentation and permissions
- transfer donation verification and nomination confirmation duties to OP-9
- update dynamic info text
- adjust permission tables and JS lists

## Testing
- `node --test`
- `node tools/check-translations.js`