### PR TITLE
Switch translation base to German

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Verified 2025-05-21 by Signature 4789
 
 Translations for the evaluation interface are defined in `i18n/ui-text.json`. To
 include another language, add a new JSON object using the two-letter ISO 639-1
-code as the key and provide translations for all fields found under the `"en"`
+code as the key and provide translations for all fields found under the `"de"`
 entry. The interface will automatically recognize the new language.
 Word collections for additional languages can be gathered with
 `tools/language-corpus.js`. The script updates `i18n/language-corpus.json`
@@ -97,7 +97,7 @@ missing translations, run:
 node tools/check-translations.js
 ```
 
-This prints a list of language codes and the fields that still require translation or are unchanged from English. In the interface dropdown, languages with missing fields show an asterisk (`*`) so users know the translation is not complete.
+This prints a list of language codes and the fields that still require translation or are unchanged from German. In the interface dropdown, languages with missing fields show an asterisk (`*`) so users know the translation is not complete.
 
 ### Generating Interface README [⇧](#contents)
 
@@ -109,7 +109,7 @@ node tools/generate-haupt-readme.js <lang>
 
 Replace `<lang>` with a two-letter ISO code (e.g. `de` or `fr`).
 The script copies the matching `i18n/README.<lang>.md` into
-`interface/haupt-readme.md`. If no translation exists, the English
+`interface/haupt-readme.md`. If no translation exists, the German
 README is used.
 
 ### Gatekeeper Control [⇧](#contents)

--- a/tools/check-translations.js
+++ b/tools/check-translations.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const file = path.join(__dirname, '..', 'i18n', 'ui-text.json');
 const data = JSON.parse(fs.readFileSync(file, 'utf8'));
-const base = data.en;
+const base = data.de;
 const keys = Object.keys(base);
 
 function isEmpty(val) {
@@ -13,7 +13,7 @@ function isEmpty(val) {
 
 const results = {};
 for (const [lang, obj] of Object.entries(data)) {
-  if (lang === 'en') continue;
+  if (lang === 'de') continue;
   const missing = [];
   const same = [];
   for (const k of keys) {

--- a/tools/fill-missing-translations.js
+++ b/tools/fill-missing-translations.js
@@ -2,9 +2,9 @@ const fs = require('fs');
 const path = require('path');
 const file = path.join(__dirname, '..', 'i18n', 'ui-text.json');
 const data = JSON.parse(fs.readFileSync(file, 'utf8'));
-const base = data.en;
+const base = data.de;
 for (const [lang, obj] of Object.entries(data)) {
-  if (lang === 'en') continue;
+  if (lang === 'de') continue;
   for (const [k, v] of Object.entries(base)) {
     if (!Object.prototype.hasOwnProperty.call(obj, k)) {
       obj[k] = v;

--- a/tools/generate-haupt-readme.js
+++ b/tools/generate-haupt-readme.js
@@ -1,11 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 
-const lang = process.argv[2] || 'en';
+const lang = process.argv[2] || 'de';
 const repoRoot = path.join(__dirname, '..');
-const src = lang === 'en'
-  ? path.join(repoRoot, 'README.md')
-  : path.join(repoRoot, 'i18n', `README.${lang}.md`);
+const src = path.join(repoRoot, 'i18n', `README.${lang}.md`);
 
 if (!fs.existsSync(src)) {
   console.error(`No README translation found for '${lang}'.`);


### PR DESCRIPTION
## Summary
- use German strings as the base for translation utilities
- update README instructions to reflect German as the reference language

## Testing
- `node --test`
- `node tools/check-translations.js`
