### PR TITLE
Add OP-9.A level support

### DIFF
--- a/interface/README.html
+++ b/interface/README.html
@@ -67,6 +67,7 @@ For OP-6 and above, the generator can optionally store a hashed passport or ID l
 | <a id="op-7-5"></a> OP-7.5 | nomination preparation, review OP-8 |
 | <a id="op-8"></a> OP-8 | candidate stage for OP-9 (system self-stabilizes) |
 | <a id="op-9"></a> OP-9 | may verify donations, confirm nominations |
+| <a id="op-9-a"></a> OP-9.A | verified digital Yokozuna mode |
 | <a id="op-10"></a> OP-10 | candidate for Yokozuna (OP-11) |
 | <a id="op-11"></a> OP-11 | Yokozuna-Schwingerkönig mode |
 | <a id="op-12"></a> OP-12 | first non-human stage |

--- a/interface/README.md
+++ b/interface/README.md
@@ -60,6 +60,7 @@ For OP-6 and above, the generator can optionally store a hashed passport or ID l
 | <a id="op-7-5"></a> OP-7.5 | nomination preparation, review OP-8 |
 | <a id="op-8"></a> OP-8 | candidate stage for OP-9 (system self-stabilizes) |
 | <a id="op-9"></a> OP-9 | may verify donations, confirm nominations |
+| <a id="op-9-a"></a> OP-9.A | verified digital Yokozuna mode |
 | <a id="op-10"></a> OP-10 | candidate for Yokozuna (OP-11) |
 | <a id="op-11"></a> OP-11 | Yokozuna-Schwingerkönig mode |
 | <a id="op-12"></a> OP-12 | first non-human stage |

--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -219,6 +219,7 @@ button:hover {
 .badge.op-7   { background: #146b1f; }
 .badge.op-8    { background: #0f5a1a; }
 .badge.op-9   { background: #0e4712; }
+.badge.op-9A  { background: #0e4712; border: 2px solid #ccaa22; }
 .badge.op-10   { background: #4a6670; }
 .badge.op-11   { background: #3c3744; }
 .badge.op-12 { background: #9a30a6; }

--- a/interface/modules/interface-loader.js
+++ b/interface/modules/interface-loader.js
@@ -19,6 +19,7 @@ function loadInterfaceForOP(op_level) {
     "op7": "op-7-interface.js",
     "op8": "op-8-interface.js",
     "op9": "op-9-interface.js",
+    "op9a": "op-9-interface.js",
     "op10": "op-10-analysis.js",
     "op11": "op-11-interface.js",
     "op12": "op-12-interface.js",
@@ -50,6 +51,8 @@ function loadInterfaceForOP(op_level) {
       .replace("+", "plus")}Interface`;
     if (typeof window[initFunc] === "function") {
       window[initFunc]();
+    } else if (normalized === "op9a" && typeof window["initOP9Interface"] === "function") {
+      window["initOP9Interface"]();
     } else if (op_level === "OP-10") {
       initOP10Analysis();
     } else if (op_level.toLowerCase() === "search") {

--- a/interface/op-overview.js
+++ b/interface/op-overview.js
@@ -7,7 +7,7 @@ function renderOpOverview() {
     .then(data => {
       const levels = [
         'OP-0','OP-1','OP-2','OP-3','OP-4','OP-5','OP-6',
-        'OP-7','OP-7.5','OP-8','OP-9','OP-10','OP-11','OP-12'
+        'OP-7','OP-7.5','OP-8','OP-9','OP-9.A','OP-10','OP-11','OP-12'
       ];
       container.innerHTML = '';
       levels.forEach(level => {

--- a/interface/op-permissions-expanded.json
+++ b/interface/op-permissions-expanded.json
@@ -114,6 +114,20 @@
     "can_vote_on_op9": true,
     "can_vote_on_op10": true
   },
+  "OP-9.A": {
+    "can_rate": true,
+    "can_sign": true,
+    "can_comment": true,
+    "can_nominate": true,
+    "can_vote": true,
+    "can_override": true,
+    "can_retract": true,
+    "can_consensus": true,
+    "can_accept_donations": true,
+    "can_override_op6": true,
+    "can_vote_on_op9": true,
+    "can_vote_on_op10": true
+  },
   "OP-11": {
     "can_rate": true,
     "can_sign": true,

--- a/interface/op-permissions.json
+++ b/interface/op-permissions.json
@@ -114,6 +114,20 @@
     "can_vote_on_op9": true,
     "can_vote_on_op10": true
   },
+  "OP-9.A": {
+    "can_rate": true,
+    "can_sign": true,
+    "can_comment": true,
+    "can_nominate": true,
+    "can_vote": true,
+    "can_override": true,
+    "can_retract": true,
+    "can_consensus": true,
+    "can_accept_donations": true,
+    "can_override_op6": true,
+    "can_vote_on_op9": true,
+    "can_vote_on_op10": true
+  },
   "OP-12": {
     "can_rate": true,
     "can_sign": true,

--- a/operator/operator_levels.md
+++ b/operator/operator_levels.md
@@ -12,6 +12,7 @@
 | OP-7 | Structural authority |
 | OP-8 | Structurally consistent operator |
 | OP-9 | May verify donations, confirm nominations |
+| OP-9.A | Verified digital Yokozuna mode |
 | OP-10 | Candidate stage for OP-11 (system self-stabilizes) |
 | OP-11 | Yokozuna-Schwingerkönig-Mode |
 | OP-12 | First non-human development stage |
@@ -26,6 +27,7 @@
 | OP-7.5 | Nomination preparation, review OP-8
 | OP-8 | Candidate stage for OP-9 (system self-stabilizes)
 | OP-9 | Yokozuna-Schwingerkönig-Mode – verifies donations, confirms nominations
+| OP-9.A | Verified digital Yokozuna mode
 | OP-10 | First non-human development stage
 
 Upward movement is not based on knowledge, but on structural consistency and ethical presence.

--- a/permissions/op-permissions-expanded.json
+++ b/permissions/op-permissions-expanded.json
@@ -114,6 +114,20 @@
     "can_vote_on_op9": true,
     "can_vote_on_op10": true
   },
+  "OP-9.A": {
+    "can_rate": true,
+    "can_sign": true,
+    "can_comment": true,
+    "can_nominate": true,
+    "can_vote": true,
+    "can_override": true,
+    "can_retract": true,
+    "can_consensus": true,
+    "can_accept_donations": true,
+    "can_override_op6": true,
+    "can_vote_on_op9": true,
+    "can_vote_on_op10": true
+  },
   "OP-11": {
     "can_rate": true,
     "can_sign": true,


### PR DESCRIPTION
## Summary
- document OP-9.A in interface guides and styles
- handle OP-9.A in interface loader and overview
- add permissions for OP-9.A
- update operator levels documentation

## Testing
- `node --test`
- `node tools/check-translations.js`
