### PR TITLE
Add OP-10 permissions and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Humor ist willkommen, wenn er Verantwortung und Klarheit unterstützt.
 ### OP-Permissions [⇧](#contents)
 Operator actions by ethical level are defined in:
 → [`permissions/op-permissions-expanded.json`](permissions/op-permissions-expanded.json)
+Additional flags now cover structural capabilities:
+`can_observe_only`, `can_override_op6`, `can_vote_on_op9`,
+`can_vote_on_op10`, `can_act_as_structure`,
+`can_execute_evaluations`, and `can_finalize_system`.
+OP‑10 has been added as a dedicated observation level.
 
 ### SRC vs. OO Levels [⇧](#contents)
 Comparison table: [`references/src_vs_oo.md`](references/src_vs_oo.md)

--- a/interface/README.md
+++ b/interface/README.md
@@ -31,6 +31,10 @@ For OP-6 and above, the generator can optionally store a hashed passport or ID l
 - `manifest-viewer.js` → display any stored evaluation manifest
 - `revision-overview.js` → list withdrawn or revised manifests
 - `permissions-viewer.js` → visualize OP permissions
+- The permissions list now defines OP-10 and flags like
+  `can_observe_only`, `can_override_op6`, `can_vote_on_op9`,
+  `can_vote_on_op10`, `can_act_as_structure`,
+  `can_execute_evaluations`, and `can_finalize_system`.
 - `language-manager.js` → generate snippets for new translations
 - `semantic-manager.js` → manage emotion word lists for sentiment (OP-5+) 
 - `chat-interface.js` → local chat for operators with greeting dummy
@@ -98,7 +102,7 @@ interface/
 ```
 
 The interface directory groups the UI logic by operational level. Each file is
-loaded dynamically so the system can scale from OP-0 through OP-10.
+loaded dynamically so the system can scale from OP-0 through OP-12.
 
 ## Dev Mode (disabled)
 

--- a/interface/op-permissions-expanded.json
+++ b/interface/op-permissions-expanded.json
@@ -8,7 +8,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-1": {
     "can_rate": true,
@@ -19,7 +26,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-2": {
     "can_rate": true,
@@ -30,7 +44,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-3": {
     "can_rate": true,
@@ -41,7 +62,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-4": {
     "can_rate": true,
@@ -52,7 +80,14 @@
     "can_override": false,
     "can_retract": true,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-5": {
     "can_rate": true,
@@ -63,7 +98,14 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-6": {
     "can_rate": true,
@@ -74,7 +116,14 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": true,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-7": {
     "can_rate": true,
@@ -86,7 +135,13 @@
     "can_retract": true,
     "can_consensus": true,
     "can_accept_donations": false,
-    "can_override_op6": true
+    "can_override_op6": true,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-7.5": {
     "can_rate": true,
@@ -98,7 +153,31 @@
     "can_retract": true,
     "can_consensus": true,
     "can_accept_donations": false,
-    "can_override_op6": false
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
+  },
+  "OP-8": {
+    "can_rate": true,
+    "can_sign": true,
+    "can_comment": true,
+    "can_nominate": true,
+    "can_vote": true,
+    "can_override": false,
+    "can_retract": true,
+    "can_consensus": true,
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-9": {
     "can_rate": true,
@@ -112,7 +191,11 @@
     "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
-    "can_vote_on_op10": true
+    "can_vote_on_op10": true,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-9.A": {
     "can_rate": true,
@@ -126,7 +209,29 @@
     "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
-    "can_vote_on_op10": true
+    "can_vote_on_op10": true,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
+  },
+  "OP-10": {
+    "can_rate": false,
+    "can_sign": false,
+    "can_comment": false,
+    "can_nominate": false,
+    "can_vote": false,
+    "can_override": false,
+    "can_retract": false,
+    "can_consensus": false,
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": true,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-11": {
     "can_rate": true,
@@ -141,6 +246,7 @@
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
+    "can_observe_only": false,
     "can_act_as_structure": true,
     "can_execute_evaluations": true,
     "can_finalize_system": true
@@ -158,9 +264,9 @@
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
+    "can_observe_only": true,
     "can_act_as_structure": true,
     "can_execute_evaluations": true,
-    "can_finalize_system": true,
-    "can_observe_only": true
+    "can_finalize_system": true
   }
 }

--- a/interface/op-permissions.json
+++ b/interface/op-permissions.json
@@ -8,7 +8,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-1": {
     "can_rate": true,
@@ -19,7 +26,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-2": {
     "can_rate": true,
@@ -30,7 +44,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-3": {
     "can_rate": true,
@@ -41,7 +62,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-4": {
     "can_rate": true,
@@ -52,7 +80,14 @@
     "can_override": false,
     "can_retract": true,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-5": {
     "can_rate": true,
@@ -63,7 +98,14 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-6": {
     "can_rate": true,
@@ -74,7 +116,14 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": true,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-7": {
     "can_rate": true,
@@ -86,7 +135,13 @@
     "can_retract": true,
     "can_consensus": true,
     "can_accept_donations": false,
-    "can_override_op6": true
+    "can_override_op6": true,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-7.5": {
     "can_rate": true,
@@ -98,7 +153,31 @@
     "can_retract": true,
     "can_consensus": true,
     "can_accept_donations": false,
-    "can_override_op6": false
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
+  },
+  "OP-8": {
+    "can_rate": true,
+    "can_sign": true,
+    "can_comment": true,
+    "can_nominate": true,
+    "can_vote": true,
+    "can_override": false,
+    "can_retract": true,
+    "can_consensus": true,
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-9": {
     "can_rate": true,
@@ -112,7 +191,11 @@
     "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
-    "can_vote_on_op10": true
+    "can_vote_on_op10": true,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-9.A": {
     "can_rate": true,
@@ -126,23 +209,29 @@
     "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
-    "can_vote_on_op10": true
-  },
-  "OP-12": {
-    "can_rate": true,
-    "can_sign": true,
-    "can_comment": true,
-    "can_nominate": true,
-    "can_vote": true,
-    "can_override": true,
-    "can_retract": true,
-    "can_consensus": true,
-    "can_accept_donations": false,
-    "can_override_op6": true,
-    "can_vote_on_op9": true,
     "can_vote_on_op10": true,
-    "can_act_as_structure": true,
-    "can_execute_evaluations": true
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
+  },
+  "OP-10": {
+    "can_rate": false,
+    "can_sign": false,
+    "can_comment": false,
+    "can_nominate": false,
+    "can_vote": false,
+    "can_override": false,
+    "can_retract": false,
+    "can_consensus": false,
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": true,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-11": {
     "can_rate": true,
@@ -157,6 +246,7 @@
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
+    "can_observe_only": false,
     "can_act_as_structure": true,
     "can_execute_evaluations": true,
     "can_finalize_system": true

--- a/permissions/op-permissions-expanded.json
+++ b/permissions/op-permissions-expanded.json
@@ -8,7 +8,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-1": {
     "can_rate": true,
@@ -19,7 +26,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-2": {
     "can_rate": true,
@@ -30,7 +44,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-3": {
     "can_rate": true,
@@ -41,7 +62,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-4": {
     "can_rate": true,
@@ -52,7 +80,14 @@
     "can_override": false,
     "can_retract": true,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-5": {
     "can_rate": true,
@@ -63,7 +98,14 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-6": {
     "can_rate": true,
@@ -74,7 +116,14 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": true,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-7": {
     "can_rate": true,
@@ -86,7 +135,13 @@
     "can_retract": true,
     "can_consensus": true,
     "can_accept_donations": false,
-    "can_override_op6": true
+    "can_override_op6": true,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-7.5": {
     "can_rate": true,
@@ -98,7 +153,31 @@
     "can_retract": true,
     "can_consensus": true,
     "can_accept_donations": false,
-    "can_override_op6": false
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
+  },
+  "OP-8": {
+    "can_rate": true,
+    "can_sign": true,
+    "can_comment": true,
+    "can_nominate": true,
+    "can_vote": true,
+    "can_override": false,
+    "can_retract": true,
+    "can_consensus": true,
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-9": {
     "can_rate": true,
@@ -112,7 +191,11 @@
     "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
-    "can_vote_on_op10": true
+    "can_vote_on_op10": true,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-9.A": {
     "can_rate": true,
@@ -126,7 +209,29 @@
     "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
-    "can_vote_on_op10": true
+    "can_vote_on_op10": true,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
+  },
+  "OP-10": {
+    "can_rate": false,
+    "can_sign": false,
+    "can_comment": false,
+    "can_nominate": false,
+    "can_vote": false,
+    "can_override": false,
+    "can_retract": false,
+    "can_consensus": false,
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": true,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-11": {
     "can_rate": true,
@@ -141,6 +246,7 @@
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
+    "can_observe_only": false,
     "can_act_as_structure": true,
     "can_execute_evaluations": true,
     "can_finalize_system": true
@@ -158,9 +264,9 @@
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
+    "can_observe_only": true,
     "can_act_as_structure": true,
     "can_execute_evaluations": true,
-    "can_finalize_system": true,
-    "can_observe_only": true
+    "can_finalize_system": true
   }
 }


### PR DESCRIPTION
## Summary
- add permission keys for all OP levels
- introduce OP-8 and OP-10 in permission table
- regenerate expanded permissions
- update docs with new flags and OP-10 mention

## Testing
- `node --test`
- `node tools/check-translations.js`