### PR TITLE
Improve neon-green OP-8 assembly

### DIFF
--- a/op-logo/README_TANNA_OP0-OP7.md
+++ b/op-logo/README_TANNA_OP0-OP7.md
@@ -38,8 +38,11 @@ repeating it horizontally and shifting the hue to indicate progression.
 
 - Starting with OP-8 the logo repeats the OP-7 symbol multiple times and shifts the hue for each higher level.
 - OP-8 shows two OP-7 logos side by side, OP-9 shows three, and so on.
+- The OP-8 version is rendered in neon green.
 - Designed with **color-contrast accessibility** in mind (color-blind friendly).
 - Structure is suitable for use in **SVG, animation, and generative logic**.
+- A sample Node script (`tools/op8-logo-assembler.js`) demonstrates how to
+  combine two rotated OP-7 images into an OP-8 variant.
 
 ---
 

--- a/tools/op8-logo-assembler.js
+++ b/tools/op8-logo-assembler.js
@@ -1,0 +1,47 @@
+const { createCanvas, loadImage } = require('canvas');
+const fs = require('fs');
+const path = require('path');
+
+async function assembleOp8(outputPath) {
+  const repoRoot = path.join(__dirname, '..');
+  const op7Path = path.join(repoRoot, 'op-logo', 'tanna_op7.png');
+  if (!fs.existsSync(op7Path)) {
+    console.error('tanna_op7.png not found.');
+    process.exit(1);
+  }
+
+  const img = await loadImage(op7Path);
+  const side = Math.max(img.width, img.height);
+  const canvas = createCanvas(side, side);
+  const ctx = canvas.getContext('2d');
+
+  ctx.translate(side / 2, side / 2);
+
+  ctx.save();
+  ctx.rotate(-Math.PI / 2);
+  ctx.drawImage(img, -img.width / 2, -img.height / 2);
+  ctx.restore();
+
+  ctx.save();
+  ctx.rotate(Math.PI / 2);
+  ctx.drawImage(img, -img.width / 2, -img.height / 2);
+  ctx.restore();
+
+  ctx.globalCompositeOperation = 'source-in';
+  ctx.fillStyle = '#39FF14';
+  ctx.fillRect(-side / 2, -side / 2, side, side);
+
+  const buffer = canvas.toBuffer('image/png');
+  fs.writeFileSync(outputPath, buffer);
+  console.log('Generated', outputPath);
+}
+
+if (require.main === module) {
+  const out = process.argv[2] || path.join(__dirname, '..', 'op-logo', 'tanna_op8.png');
+  assembleOp8(out).catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = assembleOp8;


### PR DESCRIPTION
## Summary
- document neon-green color for OP-8
- colorize the OP-8 logo output in `op8-logo-assembler.js`

## Testing
- `node --test`
- `node tools/check-translations.js`
