### PR TITLE
Remove OP-7.5 from permission tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Humor ist willkommen, wenn er Verantwortung und Klarheit unterstützt.
 ### OP-Permissions [⇧](#contents)
 Operator actions by ethical level are defined in:
 → [`permissions/op-permissions-expanded.json`](permissions/op-permissions-expanded.json)
+Additional flags now cover structural capabilities:
+`can_observe_only`, `can_override_op6`, `can_vote_on_op9`,
+`can_vote_on_op10`, `can_act_as_structure`,
+`can_execute_evaluations`, and `can_finalize_system`.
+OP‑10 has been added as a dedicated observation level.
 
 ### SRC vs. OO Levels [⇧](#contents)
 Comparison table: [`references/src_vs_oo.md`](references/src_vs_oo.md)

--- a/i18n/README.de.md
+++ b/i18n/README.de.md
@@ -35,7 +35,6 @@ Beim Klick auf das OP-1-Modul erscheint im Interface die englische Statusmeldung
 | <a id="op-5"></a> OP-5 | darf frühere Bewertungen zurückziehen |
 | <a id="op-6"></a> OP-6 | kann Konsens verifizieren |
 | <a id="op-7"></a> OP-7 | strukturelle Autorität |
-| <a id="op-7-5"></a> OP-7.5 | Nominierung vorbereiten, OP‑8 prüfen |
 | <a id="op-8"></a> OP-8 | Kandidatenstufe für OP‑9 (System stabilisiert sich) |
 | <a id="op-9"></a> OP-9 | darf Spenden verifizieren, Nominierungen bestätigen |
 | <a id="op-10"></a> OP-10 | Kandidat für Yokozuna (OP‑11) |

--- a/interface/README.html
+++ b/interface/README.html
@@ -64,7 +64,6 @@ For OP-6 and above, the generator can optionally store a hashed passport or ID l
 | <a id="op-5"></a> OP-5 | may withdraw previous evaluations |
 | <a id="op-6"></a> OP-6 | can verify consensus |
 | <a id="op-7"></a> OP-7 | structural authority |
-| <a id="op-7-5"></a> OP-7.5 | nomination preparation, review OP-8 |
 | <a id="op-8"></a> OP-8 | candidate stage for OP-9 (system self-stabilizes) |
 | <a id="op-9"></a> OP-9 | may verify donations, confirm nominations |
 | <a id="op-9-a"></a> OP-9.A | verified digital Yokozuna mode |

--- a/interface/README.md
+++ b/interface/README.md
@@ -31,6 +31,10 @@ For OP-6 and above, the generator can optionally store a hashed passport or ID l
 - `manifest-viewer.js` → display any stored evaluation manifest
 - `revision-overview.js` → list withdrawn or revised manifests
 - `permissions-viewer.js` → visualize OP permissions
+- The permissions list now defines OP-10 and flags like
+  `can_observe_only`, `can_override_op6`, `can_vote_on_op9`,
+  `can_vote_on_op10`, `can_act_as_structure`,
+  `can_execute_evaluations`, and `can_finalize_system`.
 - `language-manager.js` → generate snippets for new translations
 - `semantic-manager.js` → manage emotion word lists for sentiment (OP-5+) 
 - `chat-interface.js` → local chat for operators with greeting dummy
@@ -57,7 +61,6 @@ For OP-6 and above, the generator can optionally store a hashed passport or ID l
 | <a id="op-5"></a> OP-5 | may withdraw previous evaluations |
 | <a id="op-6"></a> OP-6 | can verify consensus |
 | <a id="op-7"></a> OP-7 | structural authority |
-| <a id="op-7-5"></a> OP-7.5 | nomination preparation, review OP-8 |
 | <a id="op-8"></a> OP-8 | candidate stage for OP-9 (system self-stabilizes) |
 | <a id="op-9"></a> OP-9 | may verify donations, confirm nominations |
 | <a id="op-9-a"></a> OP-9.A | verified digital Yokozuna mode |
@@ -98,7 +101,7 @@ interface/
 ```
 
 The interface directory groups the UI logic by operational level. Each file is
-loaded dynamically so the system can scale from OP-0 through OP-10.
+loaded dynamically so the system can scale from OP-0 through OP-12.
 
 ## Dev Mode (disabled)
 

--- a/interface/modules/permissions-viewer.js
+++ b/interface/modules/permissions-viewer.js
@@ -19,7 +19,7 @@ async function loadPermissionTable() {
     const data = await fetch("../permissions/op-permissions-expanded.json").then(r => r.json());
     const order = [
       'OP-0','OP-1','OP-2','OP-3','OP-4','OP-5','OP-6',
-      'OP-7','OP-7.5','OP-8','OP-9','OP-10','OP-11','OP-12'
+      'OP-7','OP-8','OP-9','OP-10','OP-11','OP-12'
     ];
     order.forEach(level => {
       if (!data[level]) return;

--- a/interface/op-overview.js
+++ b/interface/op-overview.js
@@ -7,7 +7,7 @@ function renderOpOverview() {
     .then(data => {
       const levels = [
         'OP-0','OP-1','OP-2','OP-3','OP-4','OP-5','OP-6',
-        'OP-7','OP-7.5','OP-8','OP-9','OP-9.A','OP-10','OP-11','OP-12'
+        'OP-7','OP-8','OP-9','OP-9.A','OP-10','OP-11','OP-12'
       ];
       container.innerHTML = '';
       levels.forEach(level => {

--- a/interface/op-permissions-expanded.json
+++ b/interface/op-permissions-expanded.json
@@ -8,7 +8,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-1": {
     "can_rate": true,
@@ -19,7 +26,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-2": {
     "can_rate": true,
@@ -30,7 +44,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-3": {
     "can_rate": true,
@@ -41,7 +62,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-4": {
     "can_rate": true,
@@ -52,7 +80,14 @@
     "can_override": false,
     "can_retract": true,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-5": {
     "can_rate": true,
@@ -63,7 +98,14 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-6": {
     "can_rate": true,
@@ -74,7 +116,14 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": true,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-7": {
     "can_rate": true,
@@ -86,9 +135,15 @@
     "can_retract": true,
     "can_consensus": true,
     "can_accept_donations": false,
-    "can_override_op6": true
+    "can_override_op6": true,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
-  "OP-7.5": {
+  "OP-8": {
     "can_rate": true,
     "can_sign": true,
     "can_comment": true,
@@ -98,7 +153,13 @@
     "can_retract": true,
     "can_consensus": true,
     "can_accept_donations": false,
-    "can_override_op6": false
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-9": {
     "can_rate": true,
@@ -112,7 +173,11 @@
     "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
-    "can_vote_on_op10": true
+    "can_vote_on_op10": true,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-9.A": {
     "can_rate": true,
@@ -126,7 +191,29 @@
     "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
-    "can_vote_on_op10": true
+    "can_vote_on_op10": true,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
+  },
+  "OP-10": {
+    "can_rate": false,
+    "can_sign": false,
+    "can_comment": false,
+    "can_nominate": false,
+    "can_vote": false,
+    "can_override": false,
+    "can_retract": false,
+    "can_consensus": false,
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": true,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-11": {
     "can_rate": true,
@@ -141,6 +228,7 @@
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
+    "can_observe_only": false,
     "can_act_as_structure": true,
     "can_execute_evaluations": true,
     "can_finalize_system": true
@@ -158,9 +246,9 @@
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
+    "can_observe_only": true,
     "can_act_as_structure": true,
     "can_execute_evaluations": true,
-    "can_finalize_system": true,
-    "can_observe_only": true
+    "can_finalize_system": true
   }
 }

--- a/interface/op-permissions.json
+++ b/interface/op-permissions.json
@@ -8,7 +8,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-1": {
     "can_rate": true,
@@ -19,7 +26,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-2": {
     "can_rate": true,
@@ -30,7 +44,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-3": {
     "can_rate": true,
@@ -41,7 +62,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-4": {
     "can_rate": true,
@@ -52,7 +80,14 @@
     "can_override": false,
     "can_retract": true,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-5": {
     "can_rate": true,
@@ -63,7 +98,14 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-6": {
     "can_rate": true,
@@ -74,7 +116,14 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": true,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-7": {
     "can_rate": true,
@@ -86,9 +135,15 @@
     "can_retract": true,
     "can_consensus": true,
     "can_accept_donations": false,
-    "can_override_op6": true
+    "can_override_op6": true,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
-  "OP-7.5": {
+  "OP-8": {
     "can_rate": true,
     "can_sign": true,
     "can_comment": true,
@@ -98,7 +153,13 @@
     "can_retract": true,
     "can_consensus": true,
     "can_accept_donations": false,
-    "can_override_op6": false
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-9": {
     "can_rate": true,
@@ -112,7 +173,11 @@
     "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
-    "can_vote_on_op10": true
+    "can_vote_on_op10": true,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-9.A": {
     "can_rate": true,
@@ -126,23 +191,29 @@
     "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
-    "can_vote_on_op10": true
-  },
-  "OP-12": {
-    "can_rate": true,
-    "can_sign": true,
-    "can_comment": true,
-    "can_nominate": true,
-    "can_vote": true,
-    "can_override": true,
-    "can_retract": true,
-    "can_consensus": true,
-    "can_accept_donations": false,
-    "can_override_op6": true,
-    "can_vote_on_op9": true,
     "can_vote_on_op10": true,
-    "can_act_as_structure": true,
-    "can_execute_evaluations": true
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
+  },
+  "OP-10": {
+    "can_rate": false,
+    "can_sign": false,
+    "can_comment": false,
+    "can_nominate": false,
+    "can_vote": false,
+    "can_override": false,
+    "can_retract": false,
+    "can_consensus": false,
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": true,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-11": {
     "can_rate": true,
@@ -157,6 +228,7 @@
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
+    "can_observe_only": false,
     "can_act_as_structure": true,
     "can_execute_evaluations": true,
     "can_finalize_system": true

--- a/operator/operator_levels.md
+++ b/operator/operator_levels.md
@@ -24,7 +24,6 @@
 | OP-5 | Leads without directing  
 | OP-6 | Creates origin-level modules  
 | OP-7 | Structural authority
-| OP-7.5 | Nomination preparation, review OP-8
 | OP-8 | Candidate stage for OP-9 (system self-stabilizes)
 | OP-9 | Yokozuna-Schwingerkönig-Mode – verifies donations, confirms nominations
 | OP-9.A | Verified digital Yokozuna mode

--- a/permissions/op-permissions-expanded.json
+++ b/permissions/op-permissions-expanded.json
@@ -8,7 +8,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-1": {
     "can_rate": true,
@@ -19,7 +26,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-2": {
     "can_rate": true,
@@ -30,7 +44,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-3": {
     "can_rate": true,
@@ -41,7 +62,14 @@
     "can_override": false,
     "can_retract": false,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-4": {
     "can_rate": true,
@@ -52,7 +80,14 @@
     "can_override": false,
     "can_retract": true,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-5": {
     "can_rate": true,
@@ -63,7 +98,14 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": false,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-6": {
     "can_rate": true,
@@ -74,7 +116,14 @@
     "can_override": true,
     "can_retract": true,
     "can_consensus": true,
-    "can_accept_donations": false
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-7": {
     "can_rate": true,
@@ -86,9 +135,15 @@
     "can_retract": true,
     "can_consensus": true,
     "can_accept_donations": false,
-    "can_override_op6": true
+    "can_override_op6": true,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
-  "OP-7.5": {
+  "OP-8": {
     "can_rate": true,
     "can_sign": true,
     "can_comment": true,
@@ -98,7 +153,13 @@
     "can_retract": true,
     "can_consensus": true,
     "can_accept_donations": false,
-    "can_override_op6": false
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-9": {
     "can_rate": true,
@@ -112,7 +173,11 @@
     "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
-    "can_vote_on_op10": true
+    "can_vote_on_op10": true,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-9.A": {
     "can_rate": true,
@@ -126,7 +191,29 @@
     "can_accept_donations": true,
     "can_override_op6": true,
     "can_vote_on_op9": true,
-    "can_vote_on_op10": true
+    "can_vote_on_op10": true,
+    "can_observe_only": false,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
+  },
+  "OP-10": {
+    "can_rate": false,
+    "can_sign": false,
+    "can_comment": false,
+    "can_nominate": false,
+    "can_vote": false,
+    "can_override": false,
+    "can_retract": false,
+    "can_consensus": false,
+    "can_accept_donations": false,
+    "can_override_op6": false,
+    "can_vote_on_op9": false,
+    "can_vote_on_op10": false,
+    "can_observe_only": true,
+    "can_act_as_structure": false,
+    "can_execute_evaluations": false,
+    "can_finalize_system": false
   },
   "OP-11": {
     "can_rate": true,
@@ -141,6 +228,7 @@
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
+    "can_observe_only": false,
     "can_act_as_structure": true,
     "can_execute_evaluations": true,
     "can_finalize_system": true
@@ -158,9 +246,9 @@
     "can_override_op6": true,
     "can_vote_on_op9": true,
     "can_vote_on_op10": true,
+    "can_observe_only": true,
     "can_act_as_structure": true,
     "can_execute_evaluations": true,
-    "can_finalize_system": true,
-    "can_observe_only": true
+    "can_finalize_system": true
   }
 }


### PR DESCRIPTION
## Summary
- strip OP-7.5 level from permission tables and docs
- update viewers to skip OP-7.5
- regenerate expanded permissions

## Testing
- `node --test`
- `node tools/check-translations.js`
