### PR TITLE
Fix background OP8 logo rendering

### DIFF
--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -19,7 +19,8 @@ function initLogoBackground() {
   const FADE_MS = 1000;
   const images = levels.map(lvl => {
     const img = new Image();
-    img.src = `../op-logo/tanna_op${lvl}.png`;
+    const src = lvl >= 8 ? 7 : lvl;
+    img.src = `../op-logo/tanna_op${src}.png`;
     return img;
   });
 
@@ -29,10 +30,13 @@ function initLogoBackground() {
   const total = Number.isFinite(stored) ? stored : 40;
   for (let i = 0; i < total; i++) {
     const lvl = levels[i % levels.length];
-    const img = images[lvl];
+    const img = images[lvl >= 8 ? 7 : lvl];
     const mass = lvl + 1;
+    const count = lvl >= 8 ? lvl - 6 : 1;
+    const hue = lvl >= 8 ? (lvl - 7) * 30 : 0;
     const size = 30 + lvl * 10 + Math.random() * 10;
     const radius = size / 2;
+    const subSize = size / count;
     const x = Math.random() * (canvas.width - size) + radius;
     const y = Math.random() * (canvas.height - size) + radius;
     const angle = Math.random() * Math.PI * 2;
@@ -42,6 +46,9 @@ function initLogoBackground() {
     symbols.push({
       img,
       lvl,
+      count,
+      hue,
+      subSize,
       mass,
       x,
       y,
@@ -172,13 +179,20 @@ function initLogoBackground() {
         ctx.translate(s.x, s.y);
         if (s.rotation) ctx.rotate(s.rotation);
         ctx.globalAlpha = s.alpha;
-        ctx.drawImage(
-          s.img,
-          -s.radius * s.scale,
-          -s.radius * s.scale,
-          s.size * s.scale,
-          s.size * s.scale
-        );
+        ctx.filter = s.hue ? `hue-rotate(${s.hue}deg)` : 'none';
+
+        const start = -s.radius * s.scale;
+        for (let n = 0; n < s.count; n++) {
+          const xOff = start + n * s.subSize * s.scale;
+          ctx.drawImage(
+            s.img,
+            xOff,
+            -s.subSize * s.scale / 2,
+            s.subSize * s.scale,
+            s.subSize * s.scale
+          );
+        }
+        ctx.filter = 'none';
         ctx.restore();
       }
 

--- a/tools/op8-logo-assembler.js
+++ b/tools/op8-logo-assembler.js
@@ -11,25 +11,18 @@ async function assembleOp8(outputPath) {
   }
 
   const img = await loadImage(op7Path);
-  const side = Math.max(img.width, img.height);
-  const canvas = createCanvas(side, side);
+
+  const width = img.width * 2;
+  const height = img.height;
+  const canvas = createCanvas(width, height);
   const ctx = canvas.getContext('2d');
 
-  ctx.translate(side / 2, side / 2);
-
-  ctx.save();
-  ctx.rotate(-Math.PI / 2);
-  ctx.drawImage(img, -img.width / 2, -img.height / 2);
-  ctx.restore();
-
-  ctx.save();
-  ctx.rotate(Math.PI / 2);
-  ctx.drawImage(img, -img.width / 2, -img.height / 2);
-  ctx.restore();
+  ctx.drawImage(img, 0, 0);
+  ctx.drawImage(img, img.width, 0);
 
   ctx.globalCompositeOperation = 'source-in';
   ctx.fillStyle = '#39FF14';
-  ctx.fillRect(-side / 2, -side / 2, side, side);
+  ctx.fillRect(0, 0, width, height);
 
   const buffer = canvas.toBuffer('image/png');
   fs.writeFileSync(outputPath, buffer);


### PR DESCRIPTION
## Summary
- redraw OP-8 logo generator script to place two OP-7 logos side by side
- update `logo-background.js` so OP-8+ backgrounds reuse the OP-7 image with color shift

## Testing
- `node --test`
- `node tools/check-translations.js`