### PR TITLE
Add human-based OP-0 rating

### DIFF
--- a/interface/modules/op-0-interface.js
+++ b/interface/modules/op-0-interface.js
@@ -1,8 +1,16 @@
 // op-0-interface.js – OP-0: Anonyme Bewertung (keine Signatur, minimale Verantwortung)
 
-function initOP0Interface() {
+async function initOP0Interface() {
   const container = document.getElementById("op_interface");
   if (!container) return;
+
+  let humans = [];
+  try {
+    humans = await fetch("../sources/human-top100.json").then(r => r.json());
+  } catch {
+    humans = [];
+  }
+  const human = humans[Math.floor(Math.random() * humans.length)] || {};
 
   container.innerHTML = `
     <div class="card">
@@ -10,49 +18,53 @@ function initOP0Interface() {
       ${typeof isOP0TestMode === 'function' && isOP0TestMode() ? '<p class="warn">Test Mode: Results are not recorded.</p>' : ''}
       <p class="info" data-info="op-0"></p>
 
-      <label for="src_lvl">Select a general ethical level (SRC):</label>
-      ${help('SRC describes the ethical consciousness of the evaluated source.')}
-      <select id="src_lvl">
-        <option value="SRC-0">SRC-0: Unconscious</option>
-        <option value="SRC-1">SRC-1: Externally Controlled</option>
-        <option value="SRC-2">SRC-2: Reactive</option>
-        <option value="SRC-3">SRC-3: Ethically Attempting</option>
-        <option value="SRC-4">SRC-4: Structurally Ethical</option>
-      </select>
+      <p><strong>Name:</strong> ${human.name || 'Unknown'}</p>
+      ${human.era ? `<p><strong>Era:</strong> ${human.era}</p>` : ''}
+      ${human.domain ? `<p><strong>Domain:</strong> ${human.domain}</p>` : ''}
+      ${human.description ? `<p><strong>Description:</strong> ${human.description}</p>` : ''}
 
-      <label for="comment">Optional comment:</label>
-      ${help('Any remark to store with this evaluation.')} 
-      <textarea id="comment" rows="3" placeholder="(optional) Your ethical note..."></textarea>
+      <div>
+        <label><input type="radio" name="op0_vote" value="yes"> Ja</label>
+        <label><input type="radio" name="op0_vote" value="partial"> Zum Teil</label>
+        <label><input type="radio" name="op0_vote" value="no"> Nein</label>
+      </div>
 
-      <button onclick="generateAnonymousManifest()">Evaluate</button>
-      <button class="secondary-button" type="button" onclick="initOP0Interface()">Reset</button>
+      <button onclick="submitOP0Vote('${human.human_id || ''}')">Bewerten</button>
+      <button class="secondary-button" type="button" onclick="initOP0Interface()">Nächste Person</button>
+
+      <p id="op0_result"></p>
     </div>
   `;
   applyInfoTexts(container);
 }
 
-function generateAnonymousManifest() {
-  const src_lvl = document.getElementById("src_lvl").value;
-  const comment = document.getElementById("comment").value;
-  const timestamp = new Date().toISOString();
+function submitOP0Vote(id) {
+  const choice = document.querySelector('input[name="op0_vote"]:checked');
+  if (!choice) return;
 
-  const evalData = {
-    source_id: "undefined",
-    operator: "anonymous",
-    op_level: "OP-0",
-    src_lvl,
-    comment,
-    timestamp,
-    verified: false,
-    weight: 0.05
-  };
+  const store = JSON.parse(localStorage.getItem('op0_votes') || '{}');
+  if (!store[id]) store[id] = { yes: 0, partial: 0, no: 0 };
+  store[id][choice.value] += 1;
+  localStorage.setItem('op0_votes', JSON.stringify(store));
 
-  const output = document.getElementById("output");
-  output.textContent = JSON.stringify(evalData, null, 2);
+  const counts = store[id];
+  const total = counts.yes + counts.partial + counts.no;
+  const max = Math.max(counts.yes, counts.partial, counts.no);
+  let label = 'ja';
+  if (max === counts.partial) label = 'zum Teil';
+  if (max === counts.no) label = 'nein';
+  const percent = total ? Math.round((max / total) * 100) : 0;
 
-  if (typeof isOP0TestMode === 'function' && isOP0TestMode()) {
-    output.textContent += "\n(Test mode active: data not saved)";
-  } else if (typeof recordEvidence === "function") {
-    recordEvidence(JSON.stringify(evalData), "user");
+  const result = document.getElementById('op0_result');
+  if (result) result.textContent = `Aktueller Anteil: ${label} (${percent}%)`;
+
+  if (typeof recordEvidence === 'function') {
+    const evalData = {
+      human_id: id,
+      rating: choice.value,
+      op_level: 'OP-0',
+      timestamp: new Date().toISOString()
+    };
+    recordEvidence(JSON.stringify(evalData), 'user');
   }
 }


### PR DESCRIPTION
## Summary
- expand OP-0 interface to show a random human profile from `human-top100.json`
- allow anonymous users to rate the human as acting ethically (Ja / Zum Teil / Nein)
- store votes locally and display the majority share after each vote

## Testing
- `node --test`
- `node tools/check-translations.js`
