### PR TITLE
Modify signup to allow insecure email for low OP

### DIFF
--- a/i18n/ui-text.json
+++ b/i18n/ui-text.json
@@ -22,6 +22,7 @@
     "signup_placeholder_pw": "At least 8 characters",
     "signup_invalid_email": "Invalid email format.",
     "signup_unsupported": "Email provider not supported. Use a secure host.",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
     "help_title": "Help – Operator Conduct",
@@ -97,6 +98,7 @@
     "signup_placeholder_pw": "Mindestens 8 Zeichen",
     "signup_invalid_email": "Ungültiges E-Mail-Format.",
     "signup_unsupported": "E-Mail-Anbieter nicht unterstützt. Nutze einen sicheren Host.",
+    "signup_insecure_warn": "Unsicherer E-Mail-Anbieter. Bis OP-5 zulässig.",
     "signup_pw_short": "Passwort muss mindestens 8 Zeichen haben.",
     "signup_saved": "Registrierungsdaten lokal gespeichert.",
     "help_title": "Hilfe – Operator-Verhalten",
@@ -172,6 +174,7 @@
     "signup_placeholder_pw": "Au moins 8 caractères",
     "signup_invalid_email": "Format d'adresse invalide.",
     "signup_unsupported": "Fournisseur non pris en charge. Utilisez un hôte sûr.",
+    "signup_insecure_warn": "Hôte de courriel non sécurisé. Toléré jusqu'à OP-5.",
     "signup_pw_short": "Le mot de passe doit comporter au moins 8 caractères.",
     "signup_saved": "Informations d'inscription enregistrées localement.",
     "access_title": "Paramètres d'accessibilité",
@@ -254,6 +257,7 @@
     "signup_placeholder_pw": "Al menos 8 caracteres",
     "signup_invalid_email": "Formato de correo electrónico no válido.",
     "signup_unsupported": "Proveedor de correo no soportado. Usa un host seguro.",
+    "signup_insecure_warn": "Proveedor de correo inseguro. Permitido solo hasta OP-5.",
     "signup_pw_short": "La contraseña debe tener al menos 8 caracteres.",
     "signup_saved": "Información de registro guardada localmente.",
     "help_title": "Ayuda – Conducta del Operador",
@@ -332,6 +336,7 @@
     "signup_placeholder_pw": "No mínimo 8 caracteres",
     "signup_invalid_email": "Formato de email inválido.",
     "signup_unsupported": "Provedor de email não suportado. Use um host seguro.",
+    "signup_insecure_warn": "Host de email inseguro. Permitido apenas até OP-5.",
     "signup_pw_short": "A senha deve ter no mínimo 8 caracteres.",
     "signup_saved": "Informações de cadastro salvas localmente.",
     "help_title": "Ajuda – Conduta do Operador",
@@ -447,7 +452,8 @@
     "status_loading_op0": "Loading OP-0...",
     "simple_toggle_label": "Toggle Simple Mode",
     "simple_mode_on": "Simple mode is active.",
-    "simple_mode_off": "Simple mode is off."
+    "simple_mode_off": "Simple mode is off.",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "hi": {
     "title": "Ethicom: मानवीय मूल्यांकन",
@@ -522,7 +528,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "ar": {
     "title": "إيثيكوم: التقييم البشري",
@@ -597,7 +604,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "ja": {
     "title": "Ethicom：人間による評価",
@@ -672,7 +680,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "sw": {
     "title": "Ethicom: Tathmini ya Kibinadamu",
@@ -747,7 +756,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "ru": {
     "title": "Ethicom: Оценка человеком",
@@ -822,7 +832,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "it": {
     "title": "Ethicom: Valutazione Umana",
@@ -857,6 +868,7 @@
     "signup_placeholder_pw": "Almeno 8 caratteri",
     "signup_invalid_email": "Formato email non valido.",
     "signup_unsupported": "Provider email non supportato. Usa un host sicuro.",
+    "signup_insecure_warn": "Provider email non sicuro. Consentito solo fino a OP-5.",
     "signup_pw_short": "La password deve essere di almeno 8 caratteri.",
     "signup_saved": "Informazioni di registrazione salvate localmente.",
     "help_title": "Aiuto – Comportamento dell'Operatore",
@@ -972,7 +984,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "fa": {
     "title": "ایتیکام: ارزیابی انسانی",
@@ -1047,7 +1060,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "pl": {
     "title": "Ethicom: Ocena Ludzka",
@@ -1122,7 +1136,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "am": {
     "title": "Ethicom: Human Evaluation",
@@ -1197,7 +1212,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "af": {
     "title": "Ethicom: Human Evaluation",
@@ -1272,7 +1288,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "bn": {
     "title": "Ethicom: Human Evaluation",
@@ -1347,7 +1364,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "ha": {
     "title": "Ethicom: Human Evaluation",
@@ -1422,7 +1440,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "id": {
     "title": "Ethicom: Human Evaluation",
@@ -1497,7 +1516,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "ig": {
     "title": "Ethicom: Human Evaluation",
@@ -1572,7 +1592,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "om": {
     "title": "Ethicom: Human Evaluation",
@@ -1647,7 +1668,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "rm": {
     "title": "Ethicom: Human Evaluation",
@@ -1722,7 +1744,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "ta": {
     "title": "Ethicom: Human Evaluation",
@@ -1797,7 +1820,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "te": {
     "title": "Ethicom: Human Evaluation",
@@ -1872,7 +1896,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "th": {
     "title": "Ethicom: Human Evaluation",
@@ -1947,7 +1972,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "tr": {
     "title": "Ethicom: Human Evaluation",
@@ -2022,7 +2048,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "ur": {
     "title": "Ethicom: Human Evaluation",
@@ -2097,7 +2124,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "vi": {
     "title": "Ethicom: Human Evaluation",
@@ -2172,7 +2200,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "xh": {
     "title": "Ethicom: Human Evaluation",
@@ -2247,7 +2276,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "yo": {
     "title": "Ethicom: Human Evaluation",
@@ -2322,7 +2352,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "zu": {
     "title": "Ethicom: Human Evaluation",
@@ -2397,7 +2428,8 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   },
   "nl": {
     "title": "Ethicom: Menselijke Evaluatie",
@@ -2472,6 +2504,7 @@
       "If a contradiction arises, apply self-reflection (structure_9874).",
       "Humor is allowed if responsibility and clarity remain."
     ],
-    "btn_disclaimer_accept": "I understand"
+    "btn_disclaimer_accept": "I understand",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5."
   }
 }

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -5,6 +5,7 @@
   <title>Ethicom Signup</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>
+  <script src="ethicom-utils.js"></script>
   <script src="signup.js"></script>
   <script src="color-auth.js"></script>
   <script src="theme-manager.js"></script>

--- a/interface/signup.js
+++ b/interface/signup.js
@@ -48,9 +48,15 @@ function handleSignup() {
   }
 
   const domain = email.split('@')[1].toLowerCase();
+  const level = getStoredOpLevel() || 'OP-1';
+  const levelNum = opLevelToNumber(level);
   if (!secureHosts.includes(domain)) {
-    statusEl.textContent = uiText.signup_unsupported || 'Email provider not supported. Use a secure host.';
-    return;
+    if (levelNum >= 6) {
+      statusEl.textContent = uiText.signup_unsupported || 'Email provider not supported. Use a secure host.';
+      return;
+    } else {
+      statusEl.textContent = uiText.signup_insecure_warn || 'Insecure email host. Allowed only until OP-5.';
+    }
   }
 
   if (password.length < 8) {


### PR DESCRIPTION
## Summary
- allow insecure email hosts for levels below OP-6
- include `ethicom-utils.js` so signup can read current OP level
- document warning text in all translations

## Testing
- `node --test`
- `node tools/check-translations.js`
