### PR TITLE
Clarify developer level and founder transparency

### DIFF
--- a/operator/founder_visibility.md
+++ b/operator/founder_visibility.md
@@ -1,0 +1,7 @@
+# Founder Transparency
+
+The founder of Ethics Structure 4789 is **Raphael Lauper, Bern, Switzerland**.
+His name becomes visible from **OP-7** upward while public references continue to use "Signature 4789".
+
+**OP-9.A** is a responsible developer mode introduced by the founder.
+The first OP-9.A decides who may join this level from OP-6 and can define further sublevels such as 9.1 or 9.B.

--- a/operator/operator_levels.md
+++ b/operator/operator_levels.md
@@ -12,24 +12,14 @@
 | OP-7 | Structural authority |
 | OP-8 | Structurally consistent operator |
 | OP-9 | May verify donations, confirm nominations |
-| OP-9.A | Verified digital Yokozuna mode |
+| OP-9.A | Verified digital Yokozuna / developer mode |
 | OP-10 | Candidate stage for OP-11 (system self-stabilizes) |
 | OP-11 | Yokozuna-Schwingerkönig-Mode |
 | OP-12 | First non-human development stage |
-| OP-0 | Neutral use (no system influence)  
-| OP-1 | Recognizes ethical context  
-| OP-2 | Provides feedback, reacts responsibly  
-| OP-3 | Forms structured language with consequence  
-| OP-4 | Influences others with structure  
-| OP-5 | Leads without directing  
-| OP-6 | Creates origin-level modules  
-| OP-7 | Structural authority
-| OP-8 | Candidate stage for OP-9 (system self-stabilizes)
-| OP-9 | Yokozuna-Schwingerkönig-Mode – verifies donations, confirms nominations
-| OP-9.A | Verified digital Yokozuna mode
-| OP-10 | First non-human development stage
 
 Upward movement is not based on knowledge, but on structural consistency and ethical presence.
+
+See [founder_visibility.md](founder_visibility.md) for transparency rules from OP-7 upward.
 
 # 4789 is OP-9
 


### PR DESCRIPTION
## Summary
- define founder visibility for OP-7+
- note OP-9.A as developer mode
- link new info from operator levels

## Testing
- `node --test`
- `node tools/check-translations.js`