### PR TITLE
Implement module order controls

### DIFF
--- a/interface/about.html
+++ b/interface/about.html
@@ -13,6 +13,7 @@
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>
   <script src="touch-features.js"></script>
+  <script src="module-arranger.js"></script>
 </head>
 <body>
   <div id="op_background"></div>
@@ -94,6 +95,7 @@
     }
     document.addEventListener('DOMContentLoaded',()=>{
       initCompletedLanguageDropdown('lang_select');
+      applyStoredModuleOrder();
       loadUiTexts().then(texts=>{
         const lang=getLanguage();
         applyTexts(texts[lang]||texts.en||{});

--- a/interface/chat.html
+++ b/interface/chat.html
@@ -11,6 +11,7 @@
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>
   <script src="touch-features.js"></script>
+  <script src="module-arranger.js"></script>
 </head>
 <body>
   <div id="op_background"></div>
@@ -41,6 +42,7 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       initLanguageDropdown('lang_select');
+      applyStoredModuleOrder();
       loadInterfaceForOP('chat');
     });
   </script>

--- a/interface/erstkontakt.html
+++ b/interface/erstkontakt.html
@@ -14,6 +14,7 @@
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>
   <script src="touch-features.js"></script>
+  <script src="module-arranger.js"></script>
   <style>
     #op_interface { margin-top: 1em; }
   </style>
@@ -57,6 +58,7 @@
         return;
       }
       initLanguageDropdown('lang_select');
+      applyStoredModuleOrder();
       initRatings();
       loadUiTexts().then(texts => {
         const uiText = texts[getLanguage()] || texts.en || {};

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -21,6 +21,7 @@
   <script src="attention-seeker.js"></script>
   <script src="touch-features.js"></script>
   <script src="color-auth.js"></script>
+  <script src="module-arranger.js"></script>
 </head>
 <body>
   <div id="op_background"></div>
@@ -118,6 +119,7 @@
     let uiText = {};
     document.addEventListener("DOMContentLoaded", () => {
       initLanguageDropdown("lang_select");
+      applyStoredModuleOrder();
       loadUiTexts().then(texts => {
         uiText = texts[getLanguage()] || texts.en || {};
         applyTexts(uiText);

--- a/interface/module-arranger.js
+++ b/interface/module-arranger.js
@@ -1,0 +1,25 @@
+function getModuleOrder(){
+  try {
+    return JSON.parse(localStorage.getItem('module_order') || '[]');
+  } catch {
+    return [];
+  }
+}
+
+function setModuleOrder(order){
+  localStorage.setItem('module_order', JSON.stringify(order));
+}
+
+function applyStoredModuleOrder(){
+  const main = document.querySelector('main');
+  if(!main) return;
+  const order = getModuleOrder();
+  order.forEach(id => {
+    const el = document.getElementById(id);
+    if(el) main.appendChild(el);
+  });
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { getModuleOrder, setModuleOrder, applyStoredModuleOrder };
+}

--- a/interface/page-flow-demo.html
+++ b/interface/page-flow-demo.html
@@ -7,6 +7,7 @@
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>
   <script src="touch-features.js"></script>
+  <script src="module-arranger.js"></script>
   <style>
     #flow {
       display: flex;
@@ -30,14 +31,35 @@
 </head>
 <body>
   <div id="op_background"></div>
-  <nav><a href="ethicom.html">Back</a></nav>
-  <div id="flow">
-    <div class="page">Page One</div>
-    <div class="page">Page Two</div>
-    <div class="page">Page Three</div>
-  </div>
+  <header>
+    <h1>Page Flow Demo</h1>
+  </header>
+  <section class="hero">
+    <p class="tagline">Ethik-Kompass für technologische Projekte</p>
+  </section>
+  <nav>
+    <a href="../index.html">Home</a>
+    <a href="erstkontakt.html">Erstkontakt</a>
+    <a href="ethicom.html" data-ui="nav_start">Ethicom</a>
+    <a href="ratings.html" data-ui="nav_ratings">Bewertungen</a>
+    <a href="signup.html" data-ui="nav_signup">Signup</a>
+    <a href="tools.html" data-ui="nav_tools">Tools</a>
+    <a href="settings.html" data-ui="nav_settings" class="icon-only">⚙</a>
+    <a href="../wings/index.html">Wings</a>
+    <a href="../README.md" target="_blank" data-ui="nav_readme" class="readme-link">README</a>
+  </nav>
+  <main>
+    <div id="flow">
+      <div class="page">Page One</div>
+      <div class="page">Page Two</div>
+      <div class="page">Page Three</div>
+    </div>
+  </main>
   <script>
-    initPageFlow('flow');
+    document.addEventListener('DOMContentLoaded', () => {
+      applyStoredModuleOrder();
+      initPageFlow('flow');
+    });
   </script>
 </body>
 </html>

--- a/interface/ratings.html
+++ b/interface/ratings.html
@@ -11,6 +11,7 @@
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>
   <script src="touch-features.js"></script>
+  <script src="module-arranger.js"></script>
 </head>
 <body>
   <div id="op_background"></div>
@@ -70,6 +71,7 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       initLanguageDropdown('lang_select');
+      applyStoredModuleOrder();
       initRatings();
     });
   </script>

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -14,6 +14,7 @@
   <script src="attention-seeker.js"></script>
   <script src="touch-features.js"></script>
   <script src="logo-background.js"></script>
+  <script src="module-arranger.js"></script>
 </head>
 <body class="left-layout">
   <div id="op_background"></div>
@@ -75,10 +76,17 @@
       <button onclick="toggleOP0TestMode()" class="accent-button">Toggle OP-0 Test Mode</button>
     </div>
     <div id="access_setup" class="card"></div>
+    <div id="module_manager" class="card">
+      <h3>Module Order</h3>
+      <ul id="module_manager_list" style="list-style:none; padding:0;"></ul>
+      <input id="module_add_input" placeholder="module id" type="text"/>
+      <button onclick="addModuleId()" class="accent-button">Add</button>
+    </div>
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       initLanguageDropdown('lang_select');
+      applyStoredModuleOrder();
       const lang = localStorage.getItem('ethicom_lang');
       fetch('../i18n/ui-text.json').then(r => r.json()).then(t => {
         const texts = t[lang] || t.en || {};
@@ -121,7 +129,50 @@
           alert('Reload the page to apply.');
         });
       }
+      initModuleManager();
     });
+
+    function initModuleManager(){
+      const main = document.querySelector('main');
+      if(!main) return;
+      let order = getModuleOrder();
+      const modules = Array.from(main.children).filter(e=>e.id).map(e=>e.id);
+      order = order.filter(id => modules.includes(id));
+      modules.forEach(id => { if(!order.includes(id)) order.push(id); });
+      setModuleOrder(order);
+      renderModuleList();
+    }
+
+    function renderModuleList(){
+      const list = document.getElementById('module_manager_list');
+      if(!list) return;
+      list.innerHTML='';
+      const order = getModuleOrder();
+      order.forEach((id, idx) => {
+        const li = document.createElement('li');
+        li.textContent=id+' ';
+        const up=document.createElement('button'); up.textContent='\u2191';
+        up.onclick=()=>{ if(idx>0){ const o=getModuleOrder(); [o[idx-1],o[idx]]=[o[idx],o[idx-1]]; setModuleOrder(o); renderModuleList(); applyStoredModuleOrder(); } };
+        const down=document.createElement('button'); down.textContent='\u2193';
+        down.onclick=()=>{ const o=getModuleOrder(); if(idx<o.length-1){ [o[idx],o[idx+1]]=[o[idx+1],o[idx]]; setModuleOrder(o); renderModuleList(); applyStoredModuleOrder(); } };
+        const rem=document.createElement('button'); rem.textContent='x';
+        rem.onclick=()=>{ const o=getModuleOrder().filter((_,i)=>i!==idx); setModuleOrder(o); renderModuleList(); applyStoredModuleOrder(); };
+        li.appendChild(up); li.appendChild(down); li.appendChild(rem);
+        list.appendChild(li);
+      });
+    }
+
+    function addModuleId(){
+      const inp=document.getElementById('module_add_input');
+      if(!inp) return;
+      const id=inp.value.trim();
+      if(!id) return;
+      const order=getModuleOrder();
+      if(!order.includes(id)){ order.push(id); setModuleOrder(order); }
+      inp.value='';
+      renderModuleList();
+      applyStoredModuleOrder();
+    }
   </script>
 </body>
 </html>

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -11,6 +11,7 @@
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>
   <script src="touch-features.js"></script>
+  <script src="module-arranger.js"></script>
 </head>
 <body>
   <div id="op_background"></div>
@@ -49,6 +50,7 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       initLanguageDropdown('lang_select');
+      applyStoredModuleOrder();
       initSignup();
     });
   </script>

--- a/interface/tanna-template-dark.html
+++ b/interface/tanna-template-dark.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>
+  <script src="module-arranger.js"></script>
 </head>
 <body>
   <div id="op_background"></div>
@@ -17,6 +18,7 @@
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
+      applyStoredModuleOrder();
       applyTheme('tanna-dark');
     });
   </script>

--- a/interface/tanna-template-light.html
+++ b/interface/tanna-template-light.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>
+  <script src="module-arranger.js"></script>
 </head>
 <body>
   <div id="op_background"></div>
@@ -17,6 +18,7 @@
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
+      applyStoredModuleOrder();
       applyTheme('tanna-light');
     });
   </script>

--- a/interface/tanna-template.html
+++ b/interface/tanna-template.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>
+  <script src="module-arranger.js"></script>
 </head>
 <body>
   <div id="op_background"></div>
@@ -17,6 +18,7 @@
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
+      applyStoredModuleOrder();
       applyTheme('tanna');
     });
   </script>

--- a/interface/tools.html
+++ b/interface/tools.html
@@ -12,6 +12,7 @@
   <script src="disclaimer.js"></script>
   <script src="logo-background.js"></script>
   <script src="touch-features.js"></script>
+  <script src="module-arranger.js"></script>
 </head>
 <body>
   <div id="op_background"></div>
@@ -55,6 +56,7 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       initLanguageDropdown('lang_select');
+      applyStoredModuleOrder();
       const lang = localStorage.getItem('ethicom_lang');
       fetch('../i18n/ui-text.json').then(r => r.json()).then(t => {
         const texts = t[lang] || t.en || {};


### PR DESCRIPTION
## Summary
- add module-arranger.js to store module layout
- allow arranging modules in settings page
- apply shared layout script across interface pages
- unify page-flow-demo with the same design

## Testing
- `node --test`
- `node tools/check-translations.js`