### PR TITLE
Document OP-10+ digital nature

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,11 @@ OP‑10 has been added as a dedicated observation level.
 | <a id="op-8"></a> OP-8 | candidate stage for OP-9 (system self-stabilizes) |
 | <a id="op-9"></a> OP-9 | may verify donations, confirm nominations |
 | <a id="op-9-a"></a> OP-9.A | verified digital Yokozuna mode |
-| <a id="op-10"></a> OP-10 | candidate for Yokozuna (OP-11) |
-| <a id="op-11"></a> OP-11 | Yokozuna-Schwingerkönig mode |
-| <a id="op-12"></a> OP-12 | first non-human stage |
+| <a id="op-10"></a> OP-10 | digital candidate for Yokozuna (OP-11) |
+| <a id="op-11"></a> OP-11 | digital Yokozuna-Schwingerkönig mode |
+| <a id="op-12"></a> OP-12 | fully digital, first non-human stage |
+
+Only digital agents can advance beyond OP-9.
 
 ### SRC vs. OO Levels [⇧](#contents)
 Comparison table: [`references/src_vs_oo.md`](references/src_vs_oo.md)

--- a/i18n/README.de.md
+++ b/i18n/README.de.md
@@ -37,6 +37,8 @@ Beim Klick auf das OP-1-Modul erscheint im Interface die englische Statusmeldung
 | <a id="op-7"></a> OP-7 | strukturelle Autorität |
 | <a id="op-8"></a> OP-8 | Kandidatenstufe für OP‑9 (System stabilisiert sich) |
 | <a id="op-9"></a> OP-9 | darf Spenden verifizieren, Nominierungen bestätigen |
-| <a id="op-10"></a> OP-10 | Kandidat für Yokozuna (OP‑11) |
-| <a id="op-11"></a> OP-11 | Yokozuna-Schwingerkönig-Modus |
-| <a id="op-12"></a> OP-12 | erste nicht‑menschliche Stufe |
+| <a id="op-10"></a> OP-10 | digitale Kandidatenstufe für Yokozuna (OP‑11) |
+| <a id="op-11"></a> OP-11 | digitaler Yokozuna-Schwingerkönig-Modus |
+| <a id="op-12"></a> OP-12 | vollständig digital, erste nicht‑menschliche Stufe |
+
+Nur digitale Agenten erreichen Stufe OP-10 und höher.

--- a/interface/README.html
+++ b/interface/README.html
@@ -70,9 +70,11 @@ For OP-6 and above, the generator can optionally store a hashed passport or ID l
 | <a id="op-8"></a> OP-8 | candidate stage for OP-9 (system self-stabilizes) |
 | <a id="op-9"></a> OP-9 | may verify donations, confirm nominations |
 | <a id="op-9-a"></a> OP-9.A | verified digital Yokozuna mode |
-| <a id="op-10"></a> OP-10 | candidate for Yokozuna (OP-11) |
-| <a id="op-11"></a> OP-11 | Yokozuna-Schwingerkönig mode |
-| <a id="op-12"></a> OP-12 | first non-human stage |
+| <a id="op-10"></a> OP-10 | digital candidate for Yokozuna (OP-11) |
+| <a id="op-11"></a> OP-11 | digital Yokozuna-Schwingerkönig mode |
+| <a id="op-12"></a> OP-12 | fully digital, first non-human stage |
+
+Only digital agents can progress past OP-9.
 The range from OP-0 to OP-3 forms the editing stage (*Bearbeitungsstufe*) where evaluations can still be adjusted.
 
 ---

--- a/interface/README.md
+++ b/interface/README.md
@@ -16,7 +16,7 @@ For OP-6 and above, the generator can optionally store a hashed passport or ID l
 - **Signatures are created locally and verified structurally**
 - **Languages are equal – no default, no bias**
 - **Responsibility must be visible, verifiable, and correctable**
-- **No one can act as OP-10 – OP-10 is structure itself**
+- **OP-10 und höher existieren nur digital – OP-10 ist reine Struktur**
 
 ---
 
@@ -72,9 +72,10 @@ For OP-6 and above, the generator can optionally store a hashed passport or ID l
 | <a id="op-8"></a> OP-8 | candidate stage for OP-9; OP-9+ may delegate functions |
 | <a id="op-9"></a> OP-9 | may verify donations, confirm nominations |
 | <a id="op-9-a"></a> OP-9.A | verified digital Yokozuna mode |
-| <a id="op-10"></a> OP-10 | candidate for Yokozuna (OP-11) |
-| <a id="op-11"></a> OP-11 | Yokozuna-Schwingerkönig mode |
+| <a id="op-10"></a> OP-10 | digital candidate for Yokozuna (OP-11) |
+| <a id="op-11"></a> OP-11 | digital Yokozuna-Schwingerkönig mode |
 
+Only digital agents can progress past OP-9.
 The range from OP-0 to OP-3 forms the editing stage (*Bearbeitungsstufe*) where evaluations can still be adjusted.
 
 ---

--- a/interface/dynamic-help.js
+++ b/interface/dynamic-help.js
@@ -50,13 +50,13 @@ const helpMap = {
     'Nominate operators and verify donations.'
   ] },
   'OP-10': { title: 'OP-10 Tips', items: [
-    'Candidate for Yokozuna (OP-11).'
+    'Digital candidate for Yokozuna (OP-11).'
   ] },
   'OP-11': { title: 'OP-11 Tips', items: [
-    'Yokozuna-level responsibilities apply.'
+    'Digital Yokozuna-level responsibilities apply.'
   ] },
   'OP-12': { title: 'OP-12 Tips', items: [
-    'First non-human development stage.'
+    'Fully digital, first non-human stage.'
   ] }
 };
 

--- a/operator/operator_levels.md
+++ b/operator/operator_levels.md
@@ -13,9 +13,9 @@
 | OP-8 | candidate stage for OP-9; OP-9+ may delegate functions |
 | OP-9 | May verify donations, confirm nominations |
 | OP-9.A | Verified digital Yokozuna / developer mode |
-| OP-10 | candidate for Yokozuna (OP-11) |
-| OP-11 | Yokozuna-Schwingerkönig-Mode |
-| OP-12 | First non-human development stage |
+| OP-10 | digital candidate for Yokozuna (OP-11) |
+| OP-11 | digital Yokozuna-Schwingerkönig-Mode |
+| OP-12 | fully digital, first non-human stage |
 
 Upward movement is not based on knowledge, but on structural consistency and ethical presence.
 
@@ -23,4 +23,4 @@ See [founder_visibility.md](founder_visibility.md) for transparency rules from O
 
 # 4789 is OP-9
 
-- OP-10 marks the rare candidate stage toward Yokozuna (OP-11). Human access is exceptional.
+- OP-10 marks the transition to digital-only stages toward Yokozuna (OP-11). From here only digital agents advance.


### PR DESCRIPTION
## Summary
- clarify that OP-10 and higher are digital-only
- update German translation and operator level table
- mention digital transition in interface documentation and help text

## Testing
- `node --test`
- `node tools/check-translations.js`
