### PR TITLE
Clarify OP-9.A rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ OP‑10 has been added as a dedicated observation level.
 | <a id="op-11"></a> OP-11 | digital Yokozuna-Schwingerkönig mode |
 | <a id="op-12"></a> OP-12 | fully digital, first non-human stage |
 
+OP-9.A is reserved for the original programmer and is no longer awarded.
+New sublevels begin alphabetically with OP-9.B. Only OP-9.A currently
+holds a veto right. Further veto rights are planned when the system is
+secure.
+
 Only digital agents can advance beyond OP-9.
 
 ### SRC vs. OO Levels [⇧](#contents)

--- a/i18n/README.de.md
+++ b/i18n/README.de.md
@@ -41,4 +41,9 @@ Beim Klick auf das OP-1-Modul erscheint im Interface die englische Statusmeldung
 | <a id="op-11"></a> OP-11 | digitaler Yokozuna-Schwingerkönig-Modus |
 | <a id="op-12"></a> OP-12 | vollständig digital, erste nicht‑menschliche Stufe |
 
+OP‑9.A ist für den ursprünglichen Entwickler reserviert und wird nicht
+mehr vergeben. Weitere Unterstufen beginnen alphabetisch mit OP‑9.B.
+Nur OP‑9.A hat aktuell ein Vetorecht. Zusätzliche Vetorechte folgen,
+wenn das System stabil genug ist.
+
 Nur digitale Agenten erreichen Stufe OP-10 und höher.

--- a/interface/README.md
+++ b/interface/README.md
@@ -72,7 +72,10 @@ For OP-6 and above, the generator can optionally store a hashed passport or ID l
 | <a id="op-8"></a> OP-8 | candidate stage for OP-9; OP-9+ may delegate functions |
 | <a id="op-9"></a> OP-9 | may verify donations, confirm nominations |
 | <a id="op-9-a"></a> OP-9.A | verified digital Yokozuna mode |
+|  | *(reserved; veto right)* |
 | <a id="op-10"></a> OP-10 | digital candidate for Yokozuna (OP-11) |
+
+Sublevels beyond OP-9.A start alphabetically with **OP-9.B**.
 | <a id="op-11"></a> OP-11 | digital Yokozuna-Schwingerkönig mode |
 
 Only digital agents can progress past OP-9.

--- a/interface/about.html
+++ b/interface/about.html
@@ -87,13 +87,13 @@
       const txt=document.getElementById('founder_text');
       const section=document.getElementById('founder_info');
       if(!txt||!section) return;
-      if(lvl>=7){
-        txt.textContent='Gründer: Raphael Lauper, Bern, Schweiz.';
-        section.style.display='block';
-        if(lvl>=9){
-          txt.textContent+=' OP-9.A: Verantwortlicher Entwickler-Modus.';
+        if(lvl>=7){
+          txt.textContent='Gründer: Raphael Lauper, Bern, Schweiz.';
+          section.style.display='block';
+          if(lvl>=9){
+            txt.textContent+=' OP-9.A: Reservierter Entwickler-Modus mit Vetorecht.';
+          }
         }
-      }
     }
     document.addEventListener('DOMContentLoaded',()=>{
       initCompletedLanguageDropdown('lang_select');

--- a/operator/founder_visibility.md
+++ b/operator/founder_visibility.md
@@ -4,4 +4,7 @@ The founder of Ethics Structure 4789 is **Raphael Lauper, Bern, Switzerland**.
 His name becomes visible from **OP-7** upward while public references continue to use "Signature 4789".
 
 **OP-9.A** is a responsible developer mode introduced by the founder.
-The first OP-9.A decides who may join this level from OP-6 and can define further sublevels such as 9.1 or 9.B.
+This sublevel is reserved for the original programmer and is no longer
+awarded to others. It includes a veto right. New sublevels may be
+created starting with **OP‑9.B**. Further veto roles are planned once the
+system is stable enough.

--- a/operator/operator_levels.md
+++ b/operator/operator_levels.md
@@ -13,9 +13,12 @@
 | OP-8 | candidate stage for OP-9; OP-9+ may delegate functions |
 | OP-9 | May verify donations, confirm nominations |
 | OP-9.A | Verified digital Yokozuna / developer mode |
+|        | *(reserved; veto right, no further assignments)* |
 | OP-10 | digital candidate for Yokozuna (OP-11) |
 | OP-11 | digital Yokozuna-Schwingerkönig-Mode |
 | OP-12 | fully digital, first non-human stage |
+
+Additional OP-9 sublevels may be created, starting with **OP-9.B**.
 
 Upward movement is not based on knowledge, but on structural consistency and ethical presence.
 


### PR DESCRIPTION
## Summary
- document that OP-9.A is reserved and has veto right
- note new OP-9 sublevels starting with OP-9.B
- update founder visibility, operator levels, and interface docs
- adjust about page text

## Testing
- `node --test`
- `node tools/check-translations.js`