### PR TITLE
Implement OP level side navigation

### DIFF
--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -24,6 +24,7 @@
   <script src="color-auth.js"></script>
   <script src="module-arranger.js"></script>
   <script src="side-drop.js"></script>
+  <script src="op-side-nav.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>
@@ -135,7 +136,7 @@
         initTranslationManager();
         renderAllBadges();
         initOpButtons();
-        initSideDrop('about.html');
+        initSideDrop('op-navigation.html');
         const badgeBtn = document.getElementById('badge_display');
         if (badgeBtn) badgeBtn.addEventListener('click', toggleSideDrop);
       });

--- a/interface/op-navigation.html
+++ b/interface/op-navigation.html
@@ -1,0 +1,3 @@
+<div class="card">
+  <ul id="op_side_nav" class="op-side-nav"></ul>
+</div>

--- a/interface/op-side-nav.js
+++ b/interface/op-side-nav.js
@@ -1,0 +1,13 @@
+function setupOpSideNav(container){
+  const list = container.querySelector('#op_side_nav');
+  if(!list) return;
+  const levels=['OP-0','OP-1','OP-2','OP-3','OP-4','OP-5','OP-6','OP-7','OP-8','OP-9','OP-10','OP-11','OP-12'];
+  list.innerHTML = levels.map(l => `<li><button class="accent-button" data-level="${l}">${l}</button></li>`).join('');
+  list.querySelectorAll('button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      if(typeof handleOpButton==='function') handleOpButton(btn.dataset.level);
+      if(typeof toggleSideDrop==='function') toggleSideDrop();
+    });
+  });
+}
+if(typeof window!=='undefined') window.setupOpSideNav=setupOpSideNav;

--- a/interface/side-drop.js
+++ b/interface/side-drop.js
@@ -52,6 +52,9 @@ async function toggleSideDrop() {
         if (typeof applyInfoTexts === 'function') {
           applyInfoTexts(content);
         }
+        if (typeof setupOpSideNav === 'function') {
+          setupOpSideNav(content);
+        }
       }
       sideDropLoaded = true;
     } catch {}


### PR DESCRIPTION
## Summary
- add `op-side-nav.js` script to set up a side menu for OP levels
- load side menu via `op-navigation.html` and initialize from `ethicom.html`
- call new setup function in `side-drop.js`

## Testing
- `node --test`
- `node tools/check-translations.js`