### PR TITLE
Set German as default interface language

### DIFF
--- a/interface/README.html
+++ b/interface/README.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/interface/README.md
+++ b/interface/README.md
@@ -156,7 +156,7 @@ auf Tanna. Zwei Varianten mit höherem Kontrast stehen ebenfalls zur Verfügung:
 
 ```html
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
   <meta charset="utf-8" />
   <title>Neue Seite</title>

--- a/interface/chat.html
+++ b/interface/chat.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -16,7 +16,7 @@ function renderBadge(currentRank, maxRank) {
   mainSpan.className = `badge op-${currentRank.replace("OP-", "").replace(".", "")}`;
   mainSpan.textContent = currentRank;
 
-  const lang = localStorage.getItem('ethicom_lang') || document.documentElement.lang || 'en';
+  const lang = localStorage.getItem('ethicom_lang') || document.documentElement.lang || 'de';
   const mainLink = document.createElement("a");
   mainLink.href = `${getReadmePath(lang)}#${currentRank.toLowerCase().replace(/\./g, '-')}`;
   mainLink.appendChild(mainSpan);
@@ -53,7 +53,7 @@ function renderAllBadges() {
     "OP-12"
   ];
 
-  const lang = localStorage.getItem('ethicom_lang') || document.documentElement.lang || 'en';
+  const lang = localStorage.getItem('ethicom_lang') || document.documentElement.lang || 'de';
   gallery.innerHTML = "";
   levels.forEach(lvl => {
     const span = document.createElement("span");

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/interface/language-selector.js
+++ b/interface/language-selector.js
@@ -16,8 +16,11 @@ function askLanguageChoice() {
 
 function getLanguage() {
   const stored = localStorage.getItem("ethicom_lang");
-  const lang = stored || askLanguageChoice();
-  if (lang) document.documentElement.lang = lang;
+  const lang = stored || "de";
+  if (lang) {
+    document.documentElement.lang = lang;
+    localStorage.setItem("ethicom_lang", lang);
+  }
   if (typeof updateReadmeLinks === 'function') updateReadmeLinks(lang);
   return lang;
 }

--- a/interface/page-flow-demo.html
+++ b/interface/page-flow-demo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/interface/signup.js
+++ b/interface/signup.js
@@ -8,7 +8,7 @@ const secureHosts = [
 let uiText = {};
 
 function applySignupTexts() {
-  document.documentElement.lang = localStorage.getItem('ethicom_lang') || 'en';
+  document.documentElement.lang = localStorage.getItem('ethicom_lang') || 'de';
   const t = uiText;
   const h2 = document.querySelector('[data-ui="signup_title"]');
   if (h2) h2.textContent = t.signup_title || h2.textContent;

--- a/interface/tanna-template-dark.html
+++ b/interface/tanna-template-dark.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/interface/tanna-template-light.html
+++ b/interface/tanna-template-light.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/interface/tanna-template.html
+++ b/interface/tanna-template.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/interface/tools.html
+++ b/interface/tools.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
## Summary
- default UI language to German in language-selector.js
- update signup script and utility helpers for German default
- mark all interface templates with `lang="de"`
- adjust interface README snippet

## Testing
- `node --test`
- `node tools/check-translations.js`
