### PR TITLE
Implement nickname option for signatures

### DIFF
--- a/app/user_state.yaml
+++ b/app/user_state.yaml
@@ -1,6 +1,7 @@
 user:
   op_level: 0
   language: auto
+  nickname: null
   progress:
     ethics_test_passed: false
     last_feedback: null

--- a/interface/signature-generator.js
+++ b/interface/signature-generator.js
@@ -17,6 +17,9 @@ function setupSignatureCreator(containerId = "op_interface", defaultOP = "OP-1")
       <label for="sig_id">Signature ID (e.g. SIG-ABCD-1234-XY9Z):</label>
       <input type="text" id="sig_id" placeholder="sig-XXXX-XXXX-XXXX" />
 
+      <label for="sig_nick">Nickname (optional):</label>
+      <input type="text" id="sig_nick" placeholder="your nickname" />
+
       <label for="sig_pass">Password (kept local):</label>
       <input type="password" id="sig_pass" placeholder="Your password" />${passField}
 
@@ -28,6 +31,7 @@ function setupSignatureCreator(containerId = "op_interface", defaultOP = "OP-1")
 
 function generateEthicomSignature(op_level) {
   const sig = document.getElementById("sig_id").value.trim().toUpperCase();
+  const nick = document.getElementById("sig_nick").value.trim();
   const pw = document.getElementById("sig_pass").value;
   const passEl = document.getElementById("sig_passport");
   const passRaw = passEl ? passEl.value.trim() : "";
@@ -78,6 +82,9 @@ function generateEthicomSignature(op_level) {
     };
     if (passHash) {
       sigObject.pass_hash = passHash;
+    }
+    if (nick) {
+      sigObject.nickname = nick;
     }
 
     localStorage.setItem("ethicom_signature", JSON.stringify(sigObject));

--- a/signaturdesign.md
+++ b/signaturdesign.md
@@ -20,3 +20,7 @@ Beispiel: Für OP-9 (Signatur 4789) sind zehn verschachtelte Arrays erforderlich
 
 Jede zusätzliche Ebene (x, y, z, …) entspricht einer weiteren Array-Schicht bis die Ziel-OP-Stufe erreicht ist. Danach folgt eine abschließende Ebene zur Sicherung der Bewertung.
 
+## Nickname pro Signatur
+
+Ab **OP-1** kann eine Signatur einen kurzen Nickname enthalten. Diese Option erleichtert die Zuordnung einzelner Bewertungen. OP-0 bleibt weiterhin anonym.
+

--- a/tools/dev-sandbox.js
+++ b/tools/dev-sandbox.js
@@ -6,7 +6,7 @@ function sha256(str) {
   return crypto.createHash('sha256').update(str).digest('hex');
 }
 
-function generateEthicomSignature(id, pw, opLevel = 'OP-1') {
+function generateEthicomSignature(id, pw, opLevel = 'OP-1', nickname = '') {
   const policy = {
     'OP-1': 4,
     'OP-2': 6,
@@ -34,6 +34,7 @@ function generateEthicomSignature(id, pw, opLevel = 'OP-1') {
   const created = new Date().toISOString();
   const hash = sha256(`${id}|${created}|${pw}`);
   const obj = { id, created, hash, protected: true, required_length: required, op_level: opLevel, local_only: true };
+  if (nickname) obj.nickname = nickname;
   localStorage['ethicom_signature'] = JSON.stringify(obj);
   return obj;
 }
@@ -95,7 +96,7 @@ function generateSignedManifest(src_lvl, comment, op_level = 'OP-1') {
 
 function main() {
   console.log('=== Generating Signature ===');
-  const sig = generateEthicomSignature('SIG-TEST-1234-ABCD', 'pwtest', 'OP-1');
+  const sig = generateEthicomSignature('SIG-TEST-1234-ABCD', 'pwtest', 'OP-1', 'dev');
   console.log(sig);
 
   console.log('\n=== Verifying Signature ===');


### PR DESCRIPTION
## Summary
- add `nickname` field to `user_state.yaml`
- document nickname usage for OP-1+ in `signaturdesign.md`
- allow optional nickname when creating signatures
- support nickname in `dev-sandbox.js`

## Testing
- `node --test`
- `node tools/check-translations.js`
