### PR TITLE
Add navigation bar and highlight active link

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     <p class="tagline">Ethik-Kompass für technologische Projekte</p>
   </section>
   <nav>
-    <a href="index.html">Home</a>
+    <a href="index.html" aria-current="page">Home</a>
     <a href="interface/erstkontakt.html">Erstkontakt</a>
     <a href="interface/ethicom.html">Ethicom</a>
     <a href="interface/ratings.html">Bewertungen</a>

--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -153,6 +153,11 @@ nav a:focus {
   text-decoration: underline;
 }
 
+nav a[aria-current="page"] {
+  color: var(--accent-color);
+  text-decoration: underline;
+}
+
 header h1 {
   margin: 0;
   color: var(--header-text-color);

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -11,7 +11,6 @@
   <script src="theme-manager.js"></script>
   <script src="color-auth.js"></script>
   <script src="logo-background.js"></script>
-  <script src="op0-navigation.js"></script>
   <script src="touch-features.js"></script>
   <script src="side-drop.js"></script>
   <script src="op-side-nav.js"></script>

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -11,7 +11,6 @@
   <script src="touch-features.js"></script>
   <script src="attention-seeker.js"></script>
   <script src="logo-background.js"></script>
-  <script src="op0-navigation.js"></script>
 </head>
 <body>
   <div id="op_background"></div>

--- a/interface/start.html
+++ b/interface/start.html
@@ -12,13 +12,19 @@
   </style>
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>
-  <script src="op0-navigation.js"></script>
 </head>
 <body>
   <div id="op_background"></div>
   <header>
     <h1>Ethicom</h1>
     <p class="tagline">Responsibility with System</p>
+    <nav>
+      <a href="../index.html">Home</a>
+      <a href="start.html" aria-current="page">Start</a>
+      <a href="ethicom.html">Ethicom</a>
+      <a href="settings.html" class="icon-only">⚙</a>
+      <a href="../README.md" target="_blank" class="readme-link">README</a>
+    </nav>
   </header>
   <main id="main_content">
     <section class="card">

--- a/start.html
+++ b/start.html
@@ -11,7 +11,6 @@
   </style>
   <script src="interface/theme-manager.js"></script>
   <script src="interface/logo-background.js"></script>
-  <script src="interface/op0-navigation.js"></script>
 </head>
 <body>
   <div id="op_background"></div>


### PR DESCRIPTION
## Summary
- add standard navigation to `interface/start.html` so OP-0 visitors can leave the page
- highlight the current link via CSS using `aria-current="page"`
- mark "Home" link as current in `index.html`
- remove unused `op0-navigation.js` references

## Testing
- `node --test`
- `node tools/check-translations.js`