### PR TITLE
Remove outdated erstkontakt links

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 | [index.html](index.html) | Start page linking to Ethicom and ratings |
 | [interface/about.html](interface/about.html) | Explains the 4789 module |
 | [interface/chat.html](interface/chat.html) | Chat interface |
-| [interface/erstkontakt.html](interface/erstkontakt.html) | Guided first contact |
 | [interface/ethicom.html](interface/ethicom.html) | Main evaluation module |
 | [interface/page-flow-demo.html](interface/page-flow-demo.html) | Demo of horizontal flow |
 | [bewertung.html](bewertung.html) | Swipe-based person rating |

--- a/index.html
+++ b/index.html
@@ -28,7 +28,6 @@
   </section>
   <nav>
     <a href="index.html" aria-current="page">Home</a>
-    <a href="interface/erstkontakt.html">Erstkontakt</a>
     <a href="interface/ethicom.html">Ethicom</a>
     <a href="bewertung.html">Bewertung</a>
     <a href="interface/signup.html">Signup</a>

--- a/start.html
+++ b/start.html
@@ -26,7 +26,6 @@
         <li><a href="interface_OLD/README.html">README</a></li>
         <li><a href="interface_OLD/about.html">Über das Modul</a></li>
         <li><a href="interface_OLD/chat.html">Chat</a></li>
-        <li><a href="interface_OLD/erstkontakt.html">Willkommen</a></li>
         <li><a href="interface_OLD/ethicom.html">Ethik-Kompass</a></li>
         <li><a href="interface_OLD/page-flow-demo.html">Page Flow Demo</a></li>
         <li><a href="interface_OLD/ratings.html">Bewertungen</a></li>

--- a/wings/index.html
+++ b/wings/index.html
@@ -32,7 +32,6 @@
   </section>
   <nav role="navigation" aria-label="Main">
     <a href="../index.html">Home</a>
-    <a href="../interface/erstkontakt.html">Erstkontakt</a>
     <a href="../interface/ethicom.html" data-ui="nav_start">Ethicom</a>
     <a href="../bewertung.html" data-ui="nav_ratings">Bewertung</a>
     <a href="../interface/signup.html" data-ui="nav_signup">Signup</a>


### PR DESCRIPTION
## Summary
- drop link to missing `erstkontakt.html` from navigation
- clean up README and old interface list

## Testing
- `node --test`
- `node tools/check-translations.js`