### PR TITLE
Simplify OP‑0 interface navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,12 +30,6 @@
     <a href="index.html" aria-current="page">Home</a>
     <a href="interface/ethicom.html">Ethicom</a>
     <a href="bewertung.html">Bewertung</a>
-    <a href="interface/signup.html">Signup</a>
-    <a href="interface/tools.html">Tools</a>
-    <a href="interface/chat.html">Chat</a>
-    <a href="interface/settings.html" class="icon-only">⚙</a>
-    <a href="wings/index.html">Wings</a>
-    <a href="README.md" target="_blank" class="readme-link">README</a>
     <a href="#" id="side_menu" class="icon-only">☰</a>
   </nav>
   <main id="main_content">

--- a/interface/op0-navigation.js
+++ b/interface/op0-navigation.js
@@ -13,13 +13,13 @@
     return lvl;
   }
   function insertNav(){
+    if(document.querySelector('nav')) return;
     const base = location.pathname.includes('/wings/') ? '../' : '';
     const navHtml =
       '<nav class="op0-nav">'+
       `<a href="${base}start.html">Start</a>`+
       `<a href="${base}bewertung.html">Bewertung</a>`+
       `<a href="${base}interface/ethicom.html">Ethicom</a>`+
-      `<a href="${base}interface/signup.html">Signup</a>`+
       '</nav>';
     document.body.insertAdjacentHTML('afterbegin', navHtml);
   }


### PR DESCRIPTION
## Summary
- trim the navigation bar on the start page
- remove the Signup link from the OP‑0 injected navigation
- avoid duplicating nav bars if one already exists

## Testing
- `node --test`
- `node tools/check-translations.js`
