### PR TITLE
Clarify OP-0 entry conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ OP‑10 has been added as a dedicated observation level.
 
 | Level | Description |
 |-------|-------------|
-| <a id="op-0"></a> OP-0 | anonymous observer |
+| <a id="op-0"></a> OP-0 | anonymous observer – default for visitors without a signature |
 | <a id="op-1"></a> OP-1 | first signed rating |
 | <a id="op-2"></a> OP-2 | provides feedback responsibly |
 | <a id="op-3"></a> OP-3 | rating requires justification |

--- a/i18n/README.de.md
+++ b/i18n/README.de.md
@@ -16,6 +16,7 @@ Sprachen: siehe `i18n/ui-text.json`
 
 OP-0 erlaubt dir, Ethicom anonym auszuprobieren.
 Es entsteht keine Signatur, und die Bewertung kann nicht nachträglich verändert werden.
+Jeder Besuch ohne Signatur landet automatisch in dieser Stufe.
 Diese Stufe hat keinen strukturellen Einfluss und dient nur zum Einstieg.
 
 ## OP-1 – Erste signierte Bewertung <a id="op-1"></a>

--- a/interface/dynamic-info.js
+++ b/interface/dynamic-info.js
@@ -2,7 +2,7 @@ const infoTexts = {
   'ethicom': 'Your interface will load here once verified.',
   'language-manager': 'Generate JSON snippets for new UI translations.',
   'semantic-manager': 'Generate JSON snippets for positive and negative words.',
-  'op-0': 'You are submitting an anonymous evaluation. It will have no lasting influence and cannot be revised.',
+  'op-0': 'Anonymous evaluation for visitors without a signature. No lasting influence and cannot be revised.',
   'op-0-human': 'Anonymous yes/no rating for historical figures. Stored only with OP level.',
   'op-1': 'You are submitting your first signed evaluation. It will be stored with your signature.',
   'op-1-human': 'Signed yes/no rating for historical figures. A justification is required.',

--- a/interface_OLD/dynamic-info.js
+++ b/interface_OLD/dynamic-info.js
@@ -2,7 +2,7 @@ const infoTexts = {
   'ethicom': 'Your interface will load here once verified.',
   'language-manager': 'Generate JSON snippets for new UI translations.',
   'semantic-manager': 'Generate JSON snippets for positive and negative words.',
-  'op-0': 'You are submitting an anonymous evaluation. It will have no lasting influence and cannot be revised.',
+  'op-0': 'Anonymous evaluation for visitors without a signature. No lasting influence and cannot be revised.',
   'op-0-human': 'Anonymous yes/no rating for historical figures. Stored only with OP level.',
   'op-1': 'You are submitting your first signed evaluation. It will be stored with your signature.',
   'op-1-human': 'Signed yes/no rating for historical figures. A justification is required.',


### PR DESCRIPTION
## Summary
- mention that OP-0 is the default level for visitors without a signature
- note the automatic placement in German README
- clarify OP-0 info text in the interface files

## Testing
- `node --test`
- `node tools/check-translations.js`
