### PR TITLE
Limit OP‑0 navigation links

### DIFF
--- a/README.html
+++ b/README.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>README</title>
+  <link rel="stylesheet" href="interface/ethicom-style.css" />
+</head>
+<body>
+  <a class="skip-link" href="#main_content">Skip to main content</a>
+  <main id="main_content">
+    <h1>README</h1>
+    <p>See <a href="README.md">README.md</a> for project details.</p>
+  </main>
+</body>
+</html>

--- a/bewertung.html
+++ b/bewertung.html
@@ -22,10 +22,11 @@
     <h1>Bewertung</h1>
     <p class="tagline">OP-0 Personenbewertung</p>
     <nav>
-      <a href="index.html">Home</a>
+      <a href="home.html">Home</a>
       <a href="bewertung.html" aria-current="page">Bewertung</a>
-      <a href="interface/ethicom.html">Ethicom</a>
-      <a href="#" id="side_menu" class="icon-only">☰</a>
+      <a href="interface/settings.html" class="icon-only">⚙</a>
+      <a href="interface/signup.html">Signup</a>
+      <a href="README.html" class="readme-link">README</a>
     </nav>
   </header>
   <main id="main_content">

--- a/home.html
+++ b/home.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>4789 Index</title>
+  <title>Home</title>
   <link rel="stylesheet" href="interface/ethicom-style.css" />
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/color-auth.js"></script>
@@ -21,7 +21,7 @@
   <a class="skip-link" href="#main_content">Skip to main content</a>
   <div id="op_background"></div>
   <header>
-    <h1>Index</h1>
+    <h1>Home</h1>
   </header>
   <section class="hero">
     <p class="tagline">Ethik-Kompass für technologische Projekte</p>

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -4,7 +4,7 @@
 function getReadmePath(lang) {
   const prefix = window.location.pathname.includes('/interface/') ? '..' : '.';
   return lang === 'en'
-    ? `${prefix}/README.md`
+    ? `${prefix}/README.html`
     : `${prefix}/i18n/README.${lang}.md`;
 }
 

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -25,11 +25,11 @@
     <p class="tagline">Ethik-Kompass für technologische Projekte</p>
   </section>
   <nav>
-    <a href="../index.html">Home</a>
-    <a href="ethicom.html" aria-current="page">Ethicom</a>
+    <a href="../home.html">Home</a>
+    <a href="../bewertung.html">Bewertung</a>
     <a href="settings.html" class="icon-only">⚙</a>
-    <a href="../README.md" target="_blank" class="readme-link">README</a>
-    <a href="#" id="side_menu" class="icon-only">☰</a>
+    <a href="signup.html">Signup</a>
+    <a href="../README.html" class="readme-link">README</a>
   </nav>
   <main id="main_content">
     <section id="op_interface" class="card">

--- a/interface/language-selector.js
+++ b/interface/language-selector.js
@@ -34,7 +34,7 @@ function getUiTextPath() {
 function updateReadmeLinks(lang) {
   const prefix = window.location.pathname.includes('/interface/') ? '..' : '.';
   const base = lang === 'en'
-    ? `${prefix}/README.md`
+    ? `${prefix}/README.html`
     : `${prefix}/i18n/README.${lang}.md`;
   document.querySelectorAll('a.readme-link').forEach(a => {
     const anchor = a.getAttribute('href').split('#')[1];

--- a/interface/op0-navigation.js
+++ b/interface/op0-navigation.js
@@ -14,12 +14,14 @@
   }
   function insertNav(){
     if(document.querySelector('nav')) return;
-    const base = location.pathname.includes('/wings/') ? '../' : '';
+    const base = (location.pathname.includes('/interface/') || location.pathname.includes('/wings/')) ? '../' : '';
     const navHtml =
       '<nav class="op0-nav">'+
-      `<a href="${base}start.html">Start</a>`+
+      `<a href="${base}home.html">Home</a>`+
       `<a href="${base}bewertung.html">Bewertung</a>`+
-      `<a href="${base}interface/ethicom.html">Ethicom</a>`+
+      `<a href="${base}interface/settings.html">Settings</a>`+
+      `<a href="${base}interface/signup.html">Signup</a>`+
+      `<a href="${base}README.html">README</a>`+
       '</nav>';
     document.body.insertAdjacentHTML('afterbegin', navHtml);
   }

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -18,10 +18,11 @@
     <h1>Settings</h1>
   </header>
   <nav>
-    <a href="../index.html">Home</a>
-    <a href="start.html">Start</a>
+    <a href="../home.html">Home</a>
+    <a href="../bewertung.html">Bewertung</a>
     <a href="settings.html" aria-current="page" class="icon-only">⚙</a>
-    <a href="../README.md" target="_blank" class="readme-link">README</a>
+    <a href="signup.html">Signup</a>
+    <a href="../README.html" class="readme-link">README</a>
   </nav>
   <main id="main_content">
     <div id="lang_selection" class="card">

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Registrierung</title>
+  <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="language-selector.js"></script>
+  <script src="ethicom-utils.js"></script>
+  <script src="signup.js"></script>
+  <script src="color-auth.js"></script>
+  <script src="theme-manager.js"></script>
+  <script src="logo-background.js"></script>
+  <script src="touch-features.js"></script>
+  <script src="module-arranger.js"></script>
+  <script src="side-drop.js"></script>
+  <script src="op-side-nav.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main_content">Skip to main content</a>
+  <div id="op_background"></div>
+  <header>
+    <h1>Registrierung</h1>
+  </header>
+  <section class="hero">
+    <p class="tagline">Ethik-Kompass für technologische Projekte</p>
+  </section>
+  <nav>
+    <a href="../home.html">Home</a>
+    <a href="../bewertung.html">Bewertung</a>
+    <a href="settings.html" class="icon-only">⚙</a>
+    <a href="signup.html" aria-current="page">Signup</a>
+    <a href="../README.html" class="readme-link">README</a>
+  </nav>
+  <main id="main_content">
+    <div id="lang_selection" class="card" style="margin-bottom:1em;">
+      <label for="lang_select" data-ui="choose_language_label">Language:</label>
+      <select id="lang_select"></select>
+    </div>
+    <h2 data-ui="signup_title">Sign up</h2>
+    <label for="email_input" data-ui="signup_email">Email:</label>
+    <input type="email" id="email_input" placeholder="name@provider.com" />
+
+    <label for="pw_input" data-ui="signup_password">Password:</label>
+    <input type="password" id="pw_input" placeholder="At least 8 characters" />
+
+    <button id="signup_btn" onclick="handleSignup()">Create Account</button>
+    <pre id="signup_status" style="white-space:pre-wrap;margin-top:1em;"></pre>
+  </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      initLanguageDropdown('lang_select');
+      applyStoredModuleOrder();
+      initSignup();
+      initSideDrop('op-navigation.html');
+      const menu=document.getElementById('side_menu');
+      if(menu) menu.addEventListener('click',e=>{e.preventDefault();toggleSideDrop();});
+    });
+  </script>
+  <div id="side_drop"></div>
+</body>
+</html>

--- a/interface/signup.js
+++ b/interface/signup.js
@@ -1,0 +1,71 @@
+const secureHosts = [
+  'protonmail.com',
+  'tutanota.com',
+  'mailbox.org',
+  'posteo.de'
+];
+
+let uiText = {};
+
+function applySignupTexts() {
+  document.documentElement.lang = localStorage.getItem('ethicom_lang') || 'de';
+  const t = uiText;
+  const h2 = document.querySelector('[data-ui="signup_title"]');
+  if (h2) h2.textContent = t.signup_title || h2.textContent;
+  const emailLabel = document.querySelector('label[for="email_input"]');
+  if (emailLabel) emailLabel.textContent = t.signup_email || emailLabel.textContent;
+  const pwLabel = document.querySelector('label[for="pw_input"]');
+  if (pwLabel) pwLabel.textContent = t.signup_password || pwLabel.textContent;
+  const signupBtn = document.getElementById('signup_btn');
+  if (signupBtn) signupBtn.textContent = t.signup_btn || signupBtn.textContent;
+  const emailInput = document.getElementById('email_input');
+  if (emailInput && t.signup_placeholder_email) emailInput.placeholder = t.signup_placeholder_email;
+  const pwInput = document.getElementById('pw_input');
+  if (pwInput && t.signup_placeholder_pw) pwInput.placeholder = t.signup_placeholder_pw;
+}
+
+function initSignup() {
+  const lang = getLanguage();
+  fetch('../i18n/ui-text.json')
+    .then(r => r.json())
+    .then(data => {
+      uiText = data[lang] || data.en || {};
+      applySignupTexts();
+    });
+}
+
+function handleSignup() {
+  const emailInput = document.getElementById('email_input');
+  const pwInput = document.getElementById('pw_input');
+  const statusEl = document.getElementById('signup_status');
+  const email = emailInput.value.trim();
+  const password = pwInput.value;
+  statusEl.textContent = '';
+
+  if (!/^[^@]+@[^@]+\.[^@]+$/.test(email)) {
+    statusEl.textContent = uiText.signup_invalid_email || 'Invalid email format.';
+    return;
+  }
+
+  const domain = email.split('@')[1].toLowerCase();
+  const level = getStoredOpLevel() || 'OP-1';
+  const levelNum = opLevelToNumber(level);
+  if (!secureHosts.includes(domain)) {
+    if (levelNum >= 6) {
+      statusEl.textContent = uiText.signup_unsupported || 'Email provider not supported. Use a secure host.';
+      return;
+    } else {
+      statusEl.textContent = uiText.signup_insecure_warn || 'Insecure email host. Allowed only until OP-5.';
+    }
+  }
+
+  if (password.length < 8) {
+    statusEl.textContent = uiText.signup_pw_short || 'Password must be at least 8 characters.';
+    return;
+  }
+
+  localStorage.setItem('ethicom_signup_email', email);
+  statusEl.textContent = uiText.signup_saved || 'Signup information saved locally.';
+}
+
+window.addEventListener('DOMContentLoaded', initSignup);

--- a/interface/start.html
+++ b/interface/start.html
@@ -19,11 +19,11 @@
     <h1>Ethicom</h1>
     <p class="tagline">Responsibility with System</p>
     <nav>
-      <a href="../index.html">Home</a>
-      <a href="start.html" aria-current="page">Start</a>
-      <a href="ethicom.html">Ethicom</a>
+      <a href="../home.html">Home</a>
+      <a href="../bewertung.html">Bewertung</a>
       <a href="settings.html" class="icon-only">⚙</a>
-      <a href="../README.md" target="_blank" class="readme-link">README</a>
+      <a href="signup.html">Signup</a>
+      <a href="../README.html" class="readme-link">README</a>
     </nav>
   </header>
   <main id="main_content">


### PR DESCRIPTION
## Summary
- add `home.html` and a short `README.html`
- restrict navigation to Home, Bewertung, Settings, Signup and README on OP‑0 pages
- update helper scripts to point to `README.html`
- copy signup page into modern interface

## Testing
- `node --test`
- `node tools/check-translations.js`
