### PR TITLE
Add person rating aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Comparison table: [`references/src_vs_oo.md`](references/src_vs_oo.md)
 ### Evaluated Sources (as examples) [⇧](#contents)
 - [src-0001: Fairphone](sources/institutions/src-0001.json) → [`SRC-4`](manifests/op-eval-4789-src-0001.json)
 - [src-0002: Ecosia](https://www.ecosia.org/) → [`SRC-4`](manifests/op-eval-4789-src-0002.json)
+- [human-wiki dataset](references/human-wiki-links.json) → [`SRC-1`](manifests/op-eval-anon-humanwiki.json)
 
 ### File Integrity [⇧](#contents)
 

--- a/evidence/person-ratings.json
+++ b/evidence/person-ratings.json
@@ -1,0 +1,50 @@
+[
+  {
+    "human_id": "hum-0103",
+    "person": "Adolf Hitler",
+    "rating": "no",
+    "operator": "anonymous",
+    "op_level": "OP-0",
+    "timestamp": "2025-05-25T21:28:29.448Z"
+  },
+  {
+    "human_id": "hum-0103",
+    "person": "Adolf Hitler",
+    "rating": "no",
+    "operator": "sig-1234",
+    "op_level": "OP-1",
+    "timestamp": "2025-05-26T11:00:00.000Z"
+  },
+  {
+    "human_id": "hum-0103",
+    "person": "Adolf Hitler",
+    "rating": "no",
+    "operator": "sig-9876",
+    "op_level": "OP-9",
+    "timestamp": "2025-05-27T09:15:00.000Z"
+  },
+  {
+    "human_id": "hum-0101",
+    "person": "Ada Lovelace",
+    "rating": "yes",
+    "operator": "anonymous",
+    "op_level": "OP-0",
+    "timestamp": "2025-05-25T21:30:00.000Z"
+  },
+  {
+    "human_id": "hum-0101",
+    "person": "Ada Lovelace",
+    "rating": "yes",
+    "operator": "sig-5555",
+    "op_level": "OP-2",
+    "timestamp": "2025-05-26T08:00:00.000Z"
+  },
+  {
+    "human_id": "hum-0101",
+    "person": "Ada Lovelace",
+    "rating": "yes",
+    "operator": "sig-9999",
+    "op_level": "OP-5",
+    "timestamp": "2025-05-27T12:45:00.000Z"
+  }
+]

--- a/manifests/index.json
+++ b/manifests/index.json
@@ -1,4 +1,5 @@
 [
   "op-eval-4789-src-0001.json",
-  "op-eval-4789-src-0002.json"
+  "op-eval-4789-src-0002.json",
+  "op-eval-anon-humanwiki.json"
 ]

--- a/manifests/op-eval-anon-humanwiki.json
+++ b/manifests/op-eval-anon-humanwiki.json
@@ -1,0 +1,12 @@
+{
+  "source_id": "human-wiki",
+  "src_lvl": "SRC-1",
+  "op_level": "OP-0",
+  "operator": "anonymous",
+  "comment": "Initial data set for historical figures derived from Wikipedia links.",
+  "timestamp": "2025-05-25T21:28:29.448Z",
+  "based_on": [
+    "https://en.wikipedia.org/"
+  ],
+  "hash": "82b0607746ccb7247b56ae518535ee56f67ba0176bd2cda7743a55a8caa8699f"
+}

--- a/references/person-scores.json
+++ b/references/person-scores.json
@@ -1,0 +1,15 @@
+{
+  "hum-0103": {
+    "average_rating": 0,
+    "average_op_level": 3.33,
+    "evaluations": 3,
+    "score": 0
+  },
+  "hum-0101": {
+    "average_rating": 1,
+    "average_op_level": 2.33,
+    "evaluations": 3,
+    "score": 10
+  }
+}
+

--- a/test/person-score.test.js
+++ b/test/person-score.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { computePersonScores } = require('../tools/person-score');
+
+test('computePersonScores aggregates ratings', () => {
+  const ratings = [
+    { human_id: 'h1', rating: 'yes', op_level: 'OP-0' },
+    { human_id: 'h1', rating: 'no', op_level: 'OP-2' },
+    { human_id: 'h2', rating: 'unclear', op_level: 'OP-1' }
+  ];
+  const result = computePersonScores(ratings);
+  assert.deepStrictEqual(result['h1'], {
+    average_rating: 0.5,
+    average_op_level: 1,
+    evaluations: 2,
+    score: 5
+  });
+  assert.deepStrictEqual(result['h2'], {
+    average_rating: 0.5,
+    average_op_level: 1,
+    evaluations: 1,
+    score: 5
+  });
+});

--- a/tools/person-score.js
+++ b/tools/person-score.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadRatings(filePath) {
+  const p = filePath || path.join(__dirname, '..', 'evidence', 'person-ratings.json');
+  if (!fs.existsSync(p)) return [];
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function ratingToValue(r) {
+  if (r === 'yes') return 1;
+  if (r === 'unclear') return 0.5;
+  return 0;
+}
+
+function opLevelToNumber(level) {
+  const n = parseFloat(String(level).replace('OP-', ''));
+  return isNaN(n) ? 0 : n;
+}
+
+function computePersonScores(list) {
+  const result = {};
+  list.forEach(r => {
+    const id = r.human_id;
+    if (!result[id]) result[id] = { total: 0, ops: 0, count: 0 };
+    result[id].total += ratingToValue(r.rating);
+    result[id].ops += opLevelToNumber(r.op_level);
+    result[id].count += 1;
+  });
+  const scores = {};
+  for (const [id, info] of Object.entries(result)) {
+    const avg = info.total / info.count;
+    const opAvg = info.ops / info.count;
+    scores[id] = {
+      average_rating: +avg.toFixed(2),
+      average_op_level: +opAvg.toFixed(2),
+      evaluations: info.count,
+      score: +(avg * 10).toFixed(2)
+    };
+  }
+  return scores;
+}
+
+function main() {
+  const data = loadRatings();
+  const scores = computePersonScores(data);
+  const outDir = path.join(__dirname, '..', 'references');
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, 'person-scores.json');
+  fs.writeFileSync(outPath, JSON.stringify(scores, null, 2));
+  console.log('Person scores written to', outPath);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { loadRatings, computePersonScores };


### PR DESCRIPTION
## Summary
- add example person rating log
- compute consensus scores from person ratings
- track human wiki source in a new manifest
- list the human-wiki dataset in README
- generate `person-scores.json`
- test new person score module

## Testing
- `node --test`
- `node tools/check-translations.js`