### PR TITLE
Enable configurable foreground transparency

### DIFF
--- a/bewertung.html
+++ b/bewertung.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Bewertung</title>
   <link rel="stylesheet" href="interface/ethicom-style.css" />
+  <script src="interface/ethicom-utils.js"></script>
   <script src="interface/language-selector.js"></script>
   <script src="interface/theme-manager.js"></script>
   <script src="interface/color-auth.js"></script>

--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -13,6 +13,7 @@
   --nav-bg: rgba(51, 51, 51, 0.9);
   --card-alpha-bg: rgba(43, 43, 43, 0.92);
   --accent-color: #ccaa22;
+  --foreground-opacity: 0.5;
 }
 
 /* Theme classes override the CSS variables */
@@ -356,7 +357,7 @@ button:hover {
 #op_background {
   position: fixed;
   inset: 0;
-  z-index: 0;
+  z-index: 90;
   overflow: hidden;
   opacity: 0.08;
   pointer-events: none;
@@ -366,6 +367,16 @@ button:hover {
   width: 100%;
   height: 100%;
   display: block;
+}
+
+/* Foreground overlay */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: rgba(0, 0, 0, var(--foreground-opacity));
+  z-index: 80;
 }
 
 /* Modified logo used in citation view */

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -1,5 +1,19 @@
 
 // ethicom-utils.js – Hilfsfunktionen für Interface-Anzeige
+(function() {
+  function setForegroundOpacity(percent) {
+    let p = parseInt(percent, 10);
+    if (isNaN(p)) p = 50;
+    if (p < 20) p = 20;
+    if (p > 80) p = 80;
+    document.documentElement.style.setProperty('--foreground-opacity', (p / 100).toString());
+  }
+  window.setForegroundOpacity = setForegroundOpacity;
+  document.addEventListener('DOMContentLoaded', () => {
+    const stored = parseInt(localStorage.getItem('ethicom_fg_opacity') || '50', 10);
+    setForegroundOpacity(stored);
+  });
+})();
 
 function getReadmePath(lang) {
   const prefix = window.location.pathname.includes('/interface/') ? '..' : '.';

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Settings</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="ethicom-utils.js"></script>
   <script src="language-selector.js"></script>
   <script src="theme-manager.js"></script>
   <script src="accessibility.js"></script>
@@ -44,6 +45,10 @@
     <div id="background_count" class="card">
       <label for="bg_symbol_count">Tanna symbols in background: <span id="bg_symbol_count_val">40</span></label>
       <input type="range" id="bg_symbol_count" min="10" max="400" step="10" value="40" />
+    </div>
+    <div id="foreground_opacity" class="card">
+      <label for="fg_opacity">Foreground transparency: <span id="fg_opacity_val">50</span>%</label>
+      <input type="range" id="fg_opacity" min="20" max="80" step="1" value="50" />
     </div>
     <div id="touch_features" class="card">
       <h3>Touch Features</h3>
@@ -95,6 +100,21 @@
         slider.addEventListener('change', e => {
           localStorage.setItem('ethicom_bg_count', e.target.value);
           alert('Reload the page to apply.');
+        });
+      }
+
+      const fgSlider = document.getElementById('fg_opacity');
+      const fgVal = document.getElementById('fg_opacity_val');
+      if (fgSlider && fgVal) {
+        const storedFg = parseInt(localStorage.getItem('ethicom_fg_opacity') || '50', 10);
+        fgSlider.value = storedFg;
+        fgVal.textContent = storedFg;
+        fgSlider.addEventListener('input', e => {
+          fgVal.textContent = e.target.value;
+          setForegroundOpacity(e.target.value);
+        });
+        fgSlider.addEventListener('change', e => {
+          localStorage.setItem('ethicom_fg_opacity', e.target.value);
         });
       }
     });

--- a/interface/start.html
+++ b/interface/start.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Ethicom Start</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="ethicom-utils.js"></script>
   <style>
     .op-list { list-style: none; padding: 0; }
     .op-list li { margin-bottom: 0.6em; display: flex; align-items: center; gap: 0.4em; }

--- a/start.html
+++ b/start.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Start</title>
   <link rel="stylesheet" href="interface/ethicom-style.css" />
+  <script src="interface/ethicom-utils.js"></script>
   <style>
     .op-list { list-style: none; padding: 0; }
     .op-list li { margin-bottom: 0.6em; }

--- a/wings/ratings.html
+++ b/wings/ratings.html
@@ -6,6 +6,7 @@
   <title>Bewertungen</title>
   <link rel="stylesheet" href="../interface/ethicom-style.css" />
   <link rel="stylesheet" href="wings-style.css" />
+  <script src="../interface/ethicom-utils.js"></script>
   <script src="../interface/language-selector.js"></script>
   <script src="../interface/translation-manager.js"></script>
   <script src="../interface/signature-strength.js"></script>


### PR DESCRIPTION
## Summary
- add `--foreground-opacity` variable and overlay in `ethicom-style.css`
- expose `setForegroundOpacity` utility to configure overlay
- allow adjusting foreground transparency in settings
- include utility script on pages missing it

## Testing
- `node --test`
- `node tools/check-translations.js` *(reports missing translations)*