### PR TITLE
Limit side drop to OP‑6 users

### DIFF
--- a/interface/features_de.md
+++ b/interface/features_de.md
@@ -62,6 +62,8 @@ if (user.op_level >= 5) {
 }
 ```
 
+- Das Side-Drop-Menü steht erst ab OP-6 zur Verfügung.
+
 ## 5. Fortschrittsanzeige
 
 Ein schmaler Balken zeigt den aktuellen Fortschritt an, z.B. beim Ethiktest oder beim Erreichen eines OP-Levels.

--- a/interface/side-drop.js
+++ b/interface/side-drop.js
@@ -3,6 +3,13 @@ let sideDropUrl = null;
 let sideDropLoaded = false;
 
 function initSideDrop(url) {
+  const level =
+    typeof getStoredOpLevel === 'function' &&
+    typeof opLevelToNumber === 'function'
+      ? opLevelToNumber(getStoredOpLevel())
+      : 0;
+  if (level < 6) return; // side drop only from OP‑6 interface
+
   sideDropUrl = url;
   const container = document.getElementById('side_drop');
   if (!container) return;


### PR DESCRIPTION
## Summary
- restrict `initSideDrop` so the menu only appears from OP‑6
- document the OP‑6 requirement in German feature list

## Testing
- `node --test`
- `node tools/check-translations.js`