### PR TITLE
Add header logos and background scripts

### DIFF
--- a/README.html
+++ b/README.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="interface/ethicom-style.css" />
   <script src="interface/theme-manager.js"></script>
   <script src="interface/logo-background.js"></script>
+  <script src="interface/module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -171,6 +171,12 @@ header.with-logo {
   background-position: 0.5em center;
 }
 
+header .title-logo {
+  height: 1em;
+  vertical-align: middle;
+  margin-left: 0.4em;
+}
+
 .hero {
   text-align: center;
   margin: 1.5em auto;

--- a/interface/module-logo.js
+++ b/interface/module-logo.js
@@ -27,9 +27,22 @@ function insertModuleLogo() {
   header.style.backgroundPosition = '0.5em center';
   header.style.backgroundSize = `auto ${size}`;
   header.style.paddingLeft = `calc(${size} + 1em)`;
-  const img = new Image();
-  img.onerror = () => { header.style.backgroundImage = `url('${fallback}')`; };
-  img.src = src;
+
+  if (h1 && !header.querySelector('.title-logo')) {
+    const imgEl = document.createElement('img');
+    imgEl.className = 'title-logo';
+    imgEl.src = src;
+    imgEl.alt = level;
+    imgEl.setAttribute('aria-label', level);
+    imgEl.style.height = size;
+    imgEl.style.marginLeft = '0.4em';
+    imgEl.onerror = () => { imgEl.src = fallback; };
+    h1.insertAdjacentElement('afterend', imgEl);
+  } else {
+    const img = new Image();
+    img.onerror = () => { header.style.backgroundImage = `url('${fallback}')`; };
+    img.src = src;
+  }
 }
 
 if (typeof window !== 'undefined') {

--- a/interface/shneiderman.html
+++ b/interface/shneiderman.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>
+  <script src="module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/README.html
+++ b/interface_OLD/README.html
@@ -7,11 +7,14 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="side-drop.js"></script>
   <script src="op-side-nav.js"></script>
+  <script src="../interface/logo-background.js"></script>
+  <script src="../interface/module-logo.js"></script>
   <style>body{white-space:pre-wrap;font-family:monospace;color:#fff;background:#000;padding:1em;}</style>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>
   <a href="#" id="side_menu" class="icon-only">☰</a>
+  <div id="op_background"></div>
 <main id="main_content">
 # Ethicom – Ethical Evaluation Interface (by 4789)
 

--- a/interface_OLD/about.html
+++ b/interface_OLD/about.html
@@ -17,6 +17,7 @@
   <script src="module-arranger.js"></script>
   <script src="side-drop.js"></script>
   <script src="op-side-nav.js"></script>
+  <script src="../interface/module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/chat.html
+++ b/interface_OLD/chat.html
@@ -15,6 +15,7 @@
   <script src="module-arranger.js"></script>
   <script src="side-drop.js"></script>
   <script src="op-side-nav.js"></script>
+  <script src="../interface/module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/erstkontakt.html
+++ b/interface_OLD/erstkontakt.html
@@ -20,6 +20,7 @@
   <script src="module-arranger.js"></script>
   <script src="side-drop.js"></script>
   <script src="op-side-nav.js"></script>
+  <script src="../interface/module-logo.js"></script>
   <style>
     #op_interface { margin-top: 1em; }
   </style>

--- a/interface_OLD/ethicom.html
+++ b/interface_OLD/ethicom.html
@@ -25,6 +25,7 @@
   <script src="module-arranger.js"></script>
   <script src="side-drop.js"></script>
   <script src="op-side-nav.js"></script>
+  <script src="../interface/module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/page-flow-demo.html
+++ b/interface_OLD/page-flow-demo.html
@@ -11,6 +11,7 @@
   <script src="module-arranger.js"></script>
   <script src="side-drop.js"></script>
   <script src="op-side-nav.js"></script>
+  <script src="../interface/module-logo.js"></script>
   <style>
     #flow {
       display: flex;

--- a/interface_OLD/ratings.html
+++ b/interface_OLD/ratings.html
@@ -15,6 +15,7 @@
   <script src="module-arranger.js"></script>
   <script src="side-drop.js"></script>
   <script src="op-side-nav.js"></script>
+  <script src="../interface/module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/settings.html
+++ b/interface_OLD/settings.html
@@ -18,6 +18,7 @@
   <script src="module-arranger.js"></script>
   <script src="side-drop.js"></script>
   <script src="op-side-nav.js"></script>
+  <script src="../interface/module-logo.js"></script>
 </head>
 <body class="left-layout">
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/signup.html
+++ b/interface_OLD/signup.html
@@ -15,6 +15,7 @@
   <script src="module-arranger.js"></script>
   <script src="side-drop.js"></script>
   <script src="op-side-nav.js"></script>
+  <script src="../interface/module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/tanna-tabs.html
+++ b/interface_OLD/tanna-tabs.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="theme-manager.js"></script>
   <script src="../interface/logo-background.js"></script>
+  <script src="../interface/module-logo.js"></script>
   <style>
     body {
       margin: 0;

--- a/interface_OLD/tanna-template-dark.html
+++ b/interface_OLD/tanna-template-dark.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="theme-manager.js"></script>
   <script src="../interface/logo-background.js"></script>
+  <script src="../interface/module-logo.js"></script>
   <script src="module-arranger.js"></script>
   <script src="side-drop.js"></script>
   <script src="op-side-nav.js"></script>

--- a/interface_OLD/tanna-template-light.html
+++ b/interface_OLD/tanna-template-light.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="theme-manager.js"></script>
   <script src="../interface/logo-background.js"></script>
+  <script src="../interface/module-logo.js"></script>
   <script src="module-arranger.js"></script>
   <script src="side-drop.js"></script>
   <script src="op-side-nav.js"></script>

--- a/interface_OLD/tanna-template.html
+++ b/interface_OLD/tanna-template.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="theme-manager.js"></script>
   <script src="../interface/logo-background.js"></script>
+  <script src="../interface/module-logo.js"></script>
   <script src="module-arranger.js"></script>
   <script src="side-drop.js"></script>
   <script src="op-side-nav.js"></script>

--- a/interface_OLD/tools.html
+++ b/interface_OLD/tools.html
@@ -16,6 +16,7 @@
   <script src="module-arranger.js"></script>
   <script src="side-drop.js"></script>
   <script src="op-side-nav.js"></script>
+  <script src="../interface/module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>


### PR DESCRIPTION
## Summary
- enhance `module-logo.js` to insert logo image beside header titles
- style header logo in `ethicom-style.css`
- include `module-logo.js` on all HTML pages
- enable Tanna background on `interface_OLD/README.html`

## Testing
- `node --test`
- `node tools/check-translations.js`