### PR TITLE
Allow full foreground transparency

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -369,7 +369,7 @@ button:hover {
 #op_background {
   position: fixed;
   inset: 0;
-  z-index: 90;
+  z-index: -1;
   overflow: hidden;
   opacity: 0.08;
   pointer-events: none;
@@ -388,7 +388,7 @@ body::before {
   inset: 0;
   pointer-events: none;
   background: rgba(0, 0, 0, var(--foreground-opacity));
-  z-index: 80;
+  z-index: 0;
 }
 
 /* Modified logo used in citation view */

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -4,8 +4,8 @@
   function setForegroundOpacity(percent) {
     let p = parseInt(percent, 10);
     if (isNaN(p)) p = 50;
-    if (p < 20) p = 20;
-    if (p > 80) p = 80;
+    if (p < 0) p = 0;
+    if (p > 100) p = 100;
     document.documentElement.style.setProperty('--foreground-opacity', (p / 100).toString());
   }
   window.setForegroundOpacity = setForegroundOpacity;

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -56,7 +56,7 @@
     </div>
     <div id="foreground_opacity" class="card">
       <label for="fg_opacity">Foreground transparency: <span id="fg_opacity_val">50</span>%</label>
-      <input type="range" id="fg_opacity" min="20" max="80" step="1" value="50" />
+      <input type="range" id="fg_opacity" min="0" max="100" step="1" value="50" />
     </div>
     <div id="touch_features" class="card">
       <h3>Touch Features</h3>


### PR DESCRIPTION
## Summary
- move foreground overlay behind text so letters stay clear
- allow 0–100% foreground opacity in settings

## Testing
- `node --test`
- `node tools/check-translations.js`