### PR TITLE
Enable custom Tanna count

### DIFF
--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -18,8 +18,14 @@ function initLogoBackground() {
       ? opLevelToNumber(getStoredOpLevel())
       : 0;
   const maxStored = Number.isFinite(storedLevel) ? storedLevel : 0;
+  const sameLevelCount = storedLevel >= 1
+    ? Math.max(1, parseInt(localStorage.getItem('ethicom_same_level_count') || '1', 10))
+    : 1;
   const levels = [];
-  for (let i = 0; i <= maxStored && i <= 9; i++) levels.push(i);
+  for (let i = 0; i <= maxStored && i <= 9; i++) {
+    const reps = i === storedLevel && storedLevel >= 1 ? sameLevelCount : 1;
+    for (let n = 0; n < reps; n++) levels.push(i);
+  }
   if (levels.length === 0) levels.push(0);
   const maxLvl = Math.max(...levels);
   const minScale = 0.3;

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -54,6 +54,10 @@
       <label for="bg_symbol_count">Tanna symbols in background: <span id="bg_symbol_count_val">40</span></label>
       <input type="range" id="bg_symbol_count" min="10" max="400" step="10" value="40" />
     </div>
+    <div id="same_level_count" class="card" style="display:none;">
+      <label for="bg_same_level_count">Your level Tannas: <span id="bg_same_level_val">1</span></label>
+      <input type="range" id="bg_same_level_count" min="1" max="10" step="1" value="1" />
+    </div>
     <div id="foreground_opacity" class="card">
       <label for="fg_opacity">Foreground transparency: <span id="fg_opacity_val">50</span>%</label>
       <input type="range" id="fg_opacity" min="20" max="80" step="1" value="50" />
@@ -119,6 +123,23 @@
         slider.addEventListener('input', e => val.textContent = e.target.value);
         slider.addEventListener('change', e => {
           localStorage.setItem('ethicom_bg_count', e.target.value);
+          alert('Reload the page to apply.');
+        });
+      }
+
+      const sameWrap = document.getElementById('same_level_count');
+      const sameSlider = document.getElementById('bg_same_level_count');
+      const sameVal = document.getElementById('bg_same_level_val');
+      const lvlNum = typeof getStoredOpLevel === 'function' ? opLevelToNumber(getStoredOpLevel()) : 0;
+      if (sameWrap) sameWrap.style.display = lvlNum >= 1 ? 'block' : 'none';
+      if (lvlNum >= 1 && sameSlider && sameVal) {
+        const storedSame = parseInt(localStorage.getItem('ethicom_same_level_count') || '1', 10);
+        const cur = Math.max(1, storedSame);
+        sameSlider.value = cur;
+        sameVal.textContent = cur;
+        sameSlider.addEventListener('input', e => sameVal.textContent = e.target.value);
+        sameSlider.addEventListener('change', e => {
+          localStorage.setItem('ethicom_same_level_count', e.target.value);
           alert('Reload the page to apply.');
         });
       }


### PR DESCRIPTION
## Summary
- allow choosing number of same-level Tanna symbols
- show slider only once OP level is at least 1
- read the preference in the logo background animation

## Testing
- `node --test`
- `node tools/check-translations.js`
