### PR TITLE
Apply 20% opacity reduction

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -13,7 +13,7 @@
   --nav-bg: rgba(51, 51, 51, 0.9);
   --card-alpha-bg: rgba(43, 43, 43, 0.92);
   --accent-color: #ccaa22;
-  --foreground-opacity: 0.5;
+  --foreground-opacity: 0.4;
 }
 
 /* Theme classes override the CSS variables */

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -3,14 +3,14 @@
 (function() {
   function setForegroundOpacity(percent) {
     let p = parseInt(percent, 10);
-    if (isNaN(p)) p = 50;
+    if (isNaN(p)) p = 40;
     if (p < 0) p = 0;
     if (p > 100) p = 100;
     document.documentElement.style.setProperty('--foreground-opacity', (p / 100).toString());
   }
   window.setForegroundOpacity = setForegroundOpacity;
   document.addEventListener('DOMContentLoaded', () => {
-    const stored = parseInt(localStorage.getItem('ethicom_fg_opacity') || '50', 10);
+    const stored = parseInt(localStorage.getItem('ethicom_fg_opacity') || '40', 10);
     setForegroundOpacity(stored);
   });
 })();

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -55,8 +55,8 @@
       <input type="range" id="bg_symbol_count" min="10" max="400" step="10" value="40" />
     </div>
     <div id="foreground_opacity" class="card">
-      <label for="fg_opacity">Foreground transparency: <span id="fg_opacity_val">50</span>%</label>
-      <input type="range" id="fg_opacity" min="0" max="100" step="1" value="50" />
+      <label for="fg_opacity">Foreground transparency: <span id="fg_opacity_val">40</span>%</label>
+      <input type="range" id="fg_opacity" min="0" max="100" step="1" value="40" />
     </div>
     <div id="touch_features" class="card">
       <h3>Touch Features</h3>
@@ -126,7 +126,7 @@
       const fgSlider = document.getElementById('fg_opacity');
       const fgVal = document.getElementById('fg_opacity_val');
       if (fgSlider && fgVal) {
-        const storedFg = parseInt(localStorage.getItem('ethicom_fg_opacity') || '50', 10);
+        const storedFg = parseInt(localStorage.getItem('ethicom_fg_opacity') || '40', 10);
         fgSlider.value = storedFg;
         fgVal.textContent = storedFg;
         fgSlider.addEventListener('input', e => {


### PR DESCRIPTION
## Summary
- lower default foreground-opacity to 0.4
- update settings UI to show 40% foreground transparency
- set new default in JavaScript utilities

## Testing
- `node --test`
- `node tools/check-translations.js`
