### PR TITLE
Fix duplicate OP logos

### DIFF
--- a/home.html
+++ b/home.html
@@ -36,11 +36,11 @@
   </nav>
   <main id="main_content">
     <section class="card">
-      <h2><img src="op-logo/tanna_op0.png" class="citation-logo start-op-logo" alt="OP-0" aria-label="OP-0" /> Willkommen</h2>
+      <h2>Willkommen</h2>
       <p>Diese Seite führt zur Ethicom-Oberfläche. Sie folgt dem Corporate Design von Signature 4789.</p>
     </section>
     <section class="card">
-      <h2><img src="op-logo/tanna_op0.png" class="citation-logo start-op-logo" alt="OP-0" aria-label="OP-0" /> Disclaimers</h2>
+      <h2>Disclaimers</h2>
       <ul>
         <li>Diese Struktur wird ohne Gewährleistung bereitgestellt.</li>
         <li>Die Nutzung erfolgt auf eigene Verantwortung.</li>
@@ -49,7 +49,7 @@
       </ul>
     </section>
     <section class="card">
-      <h2><img src="op-logo/tanna_op0.png" class="citation-logo start-op-logo" alt="OP-0" aria-label="OP-0" /> Direkt loslegen</h2>
+      <h2>Direkt loslegen</h2>
       <p>Starte die Bewertung über <a href="interface/ethicom.html">Ethicom</a>. Eine Vorschau für OP‑0 ist ohne Anmeldung möglich.</p>
     </section>
     <section id="op_overview" class="card"></section>

--- a/index.html
+++ b/index.html
@@ -37,11 +37,11 @@
   </nav>
   <main id="main_content">
     <section class="card">
-      <h2><img src="op-logo/tanna_op0.png" class="citation-logo start-op-logo" alt="OP-0" aria-label="OP-0" /> Willkommen</h2>
+      <h2>Willkommen</h2>
       <p>Diese Seite führt zur Ethicom-Oberfläche. Sie folgt dem Corporate Design von Signature 4789.</p>
     </section>
     <section class="card">
-      <h2><img src="op-logo/tanna_op0.png" class="citation-logo start-op-logo" alt="OP-0" aria-label="OP-0" /> Disclaimers</h2>
+      <h2>Disclaimers</h2>
       <ul>
         <li>Diese Struktur wird ohne Gewährleistung bereitgestellt.</li>
         <li>Die Nutzung erfolgt auf eigene Verantwortung.</li>
@@ -50,7 +50,7 @@
       </ul>
     </section>
     <section class="card">
-      <h2><img src="op-logo/tanna_op0.png" class="citation-logo start-op-logo" alt="OP-0" aria-label="OP-0" /> Direkt loslegen</h2>
+      <h2>Direkt loslegen</h2>
       <p>Starte die Bewertung über <a href="interface/ethicom.html">Ethicom</a>. Eine Vorschau für OP‑0 ist ohne Anmeldung möglich.</p>
     </section>
     <section id="op_overview" class="card"></section>


### PR DESCRIPTION
## Summary
- show OP logo only in the header title
- clean up duplicate images in index and home pages

## Testing
- `node --test`
- `node tools/check-translations.js`
