### PR TITLE
Improve README formatting

### DIFF
--- a/README.html
+++ b/README.html
@@ -9,6 +9,7 @@
   <script src="interface/accessibility.js"></script>
   <script src="interface/logo-background.js"></script>
   <script src="interface/module-logo.js"></script>
+  <script src="interface/render-markdown.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>
@@ -47,9 +48,9 @@
     </section>
     <section class="card">
       <p>For complete details see <a href="README.md">README.md</a>.</p>
-      <pre id="readme_content" style="white-space: pre-wrap;">
+      <article id="readme_content" class="markdown-content">
         Loading README...
-      </pre>
+      </article>
     </section>
   </main>
   <script>
@@ -59,12 +60,12 @@
       fetch('README.md')
         .then(r => r.text())
         .then(t => {
-          const pre = document.getElementById('readme_content');
-          if (pre) pre.textContent = t;
+          const container = document.getElementById('readme_content');
+          if (container) container.innerHTML = renderMarkdown(t);
         })
         .catch(() => {
-          const pre = document.getElementById('readme_content');
-          if (pre) pre.textContent = 'Failed to load README.';
+          const container = document.getElementById('readme_content');
+          if (container) container.textContent = 'Failed to load README.';
         });
     });
   </script>

--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -533,3 +533,12 @@ body.left-layout main {
 .cover-item { flex:0 0 auto; background:var(--card-alpha-bg); padding:0.5em; border-radius:4px; text-align:center; min-width:120px; }
 .cover-item span { display:block; color:var(--accent-color); font-size:0.9em; }
 
+/* Basic markdown rendering */
+.markdown-content { line-height: 1.5; }
+.markdown-content h1 { font-size: 1.6em; margin: 1em 0 0.5em; }
+.markdown-content h2 { font-size: 1.4em; margin: 1em 0 0.5em; }
+.markdown-content h3 { font-size: 1.2em; margin: 1em 0 0.5em; }
+.markdown-content ul { padding-left: 1.2em; margin: 0.5em 0; }
+.markdown-content pre { background: var(--card-bg); padding: 0.6em; overflow-x: auto; }
+.markdown-content code { background: rgba(0,0,0,0.3); padding: 0.1em 0.3em; border-radius: 4px; }
+

--- a/interface/render-markdown.js
+++ b/interface/render-markdown.js
@@ -1,0 +1,54 @@
+function convertInline(text) {
+  return text
+    .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\[(.*?)\]\((.*?)\)/g, '<a href="$2">$1</a>');
+}
+
+function renderMarkdown(md) {
+  const lines = md.split(/\n/);
+  let html = '';
+  let inList = false;
+  let inCode = false;
+  for (let line of lines) {
+    if (line.trim().startsWith('```')) {
+      if (inCode) {
+        html += '</code></pre>';
+        inCode = false;
+      } else {
+        inCode = true;
+        html += '<pre><code>';
+      }
+      continue;
+    }
+    if (inCode) {
+      html += line.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;') + '\n';
+      continue;
+    }
+    if (line.startsWith('- ')) {
+      if (!inList) {
+        html += '<ul>';
+        inList = true;
+      }
+      html += '<li>' + convertInline(line.substring(2).trim()) + '</li>';
+      continue;
+    }
+    if (inList) {
+      html += '</ul>';
+      inList = false;
+    }
+    let m = line.match(/^(#{1,6})\s+(.*)$/);
+    if (m) {
+      const level = m[1].length;
+      html += `<h${level}>` + convertInline(m[2].trim()) + `</h${level}>`;
+      continue;
+    }
+    if (line.trim() === '') {
+      continue;
+    }
+    html += '<p>' + convertInline(line.trim()) + '</p>';
+  }
+  if (inList) html += '</ul>';
+  if (inCode) html += '</code></pre>';
+  return html;
+}


### PR DESCRIPTION
## Summary
- load a small Markdown renderer in README.html
- render README.md in the interface with basic styles
- add minimal CSS rules for Markdown content

## Testing
- `node --test`
- `node tools/check-translations.js`