### PR TITLE
Add percentage to ethik scores

### DIFF
--- a/test/ethik-score.test.js
+++ b/test/ethik-score.test.js
@@ -8,6 +8,16 @@ test('computeScores averages correctly', () => {
     'src-002': [2]
   };
   const result = computeScores(perSource);
-  assert.deepStrictEqual(result['src-001'], { score: 4.33, level: 'SRC-4', evaluations: 3 });
-  assert.deepStrictEqual(result['src-002'], { score: 2, level: 'SRC-2', evaluations: 1 });
+  assert.deepStrictEqual(result['src-001'], {
+    score: 4.33,
+    level: 'SRC-4',
+    evaluations: 3,
+    percent: 54
+  });
+  assert.deepStrictEqual(result['src-002'], {
+    score: 2,
+    level: 'SRC-2',
+    evaluations: 1,
+    percent: 25
+  });
 });

--- a/tools/ethik-score.js
+++ b/tools/ethik-score.js
@@ -29,7 +29,8 @@ function computeScores(perSource) {
     result[src] = {
       score: +avg.toFixed(2),
       level: reverseMap[Math.round(avg)] || `SRC-${Math.round(avg)}`,
-      evaluations: nums.length
+      evaluations: nums.length,
+      percent: Math.round((avg / 8) * 100)
     };
   }
   return result;


### PR DESCRIPTION
## Summary
- include `percent` field in ethik score output
- test new percentage calculation

## Testing
- `node --test`
- `node tools/check-translations.js`
