### PR TITLE
Fix settings header layout

### DIFF
--- a/interface/settings.html
+++ b/interface/settings.html
@@ -15,10 +15,14 @@
   <script src="module-logo.js"></script>
 </head>
 <body>
+  <a class="skip-link" href="#main_content">Skip to main content</a>
   <div id="op_background"></div>
   <header>
     <h1>Settings</h1>
   </header>
+  <section class="hero">
+    <p class="tagline">Ethik-Kompass für technologische Projekte</p>
+  </section>
   <nav>
     <a href="../home.html">Home</a>
     <a href="../bewertung.html">Bewertung</a>


### PR DESCRIPTION
## Summary
- add missing skip link and hero tagline to settings page

## Testing
- `node --test`
- `node tools/check-translations.js` *(fails: likely untranslated entries)*