### PR TITLE
Add dark-tanna theme

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -59,6 +59,21 @@
   --foreground-opacity: 0.3;
 }
 
+/* Dark base with Tanna accents */
+.theme-dark-tanna {
+  --bg-color: #1e1e1e;
+  --text-color: #e0e0e0;
+  --header-text-color: #e0e0e0;
+  --nav-text-color: #e0e0e0;
+  --primary-color: #228B22;
+  --card-bg: #2b2b2b;
+  --header-bg: rgba(0, 0, 0, 0.85);
+  --nav-bg: rgba(0, 0, 0, 0.85);
+  --card-alpha-bg: rgba(34, 34, 34, 0.9);
+  --accent-color: #33cc33;
+  --foreground-opacity: 0.3;
+}
+
 .theme-tanna-light {
   --bg-color: #ffffff;
   --text-color: #002200;

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -40,6 +40,8 @@
       <select id="theme_select">
         <option value="dark">Dark</option>
         <option value="tanna">Tanna</option>
+        <option value="tanna-dark">Tanna Dark</option>
+        <option value="dark-tanna">Dark Tanna</option>
         <option value="ocean">Ocean</option>
         <option value="desert">Desert</option>
         <option value="transparent">Transparent</option>

--- a/interface/theme-manager.js
+++ b/interface/theme-manager.js
@@ -1,6 +1,6 @@
 function applyTheme(theme) {
   const body = document.body;
-  body.classList.remove('theme-dark', 'theme-tanna', 'theme-ocean', 'theme-desert', 'theme-transparent', 'theme-custom');
+  body.classList.remove('theme-dark', 'theme-tanna', 'theme-ocean', 'theme-desert', 'theme-transparent', 'theme-custom', 'theme-tanna-dark', 'theme-dark-tanna');
   document.documentElement.style.removeProperty('--primary-color');
   document.documentElement.style.removeProperty('--accent-color');
   if (theme === 'custom') {
@@ -8,7 +8,7 @@ function applyTheme(theme) {
     Object.keys(custom).forEach(k => document.documentElement.style.setProperty(k, custom[k]));
     body.classList.add('theme-custom');
   } else {
-    if (theme === 'tanna') {
+    if (theme.includes('tanna')) {
       const saved = localStorage.getItem('ethicom_tanna_color');
       if (saved) {
         const { r, g, b } = JSON.parse(saved);
@@ -31,14 +31,14 @@ function initThemeSelection() {
   const tannaCard = document.getElementById('tanna_color');
   let theme = localStorage.getItem('ethicom_theme') || 'dark';
   applyTheme(theme);
-  if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
+  if (tannaCard) tannaCard.style.display = theme.includes('tanna') ? 'block' : 'none';
   if (select) {
     select.value = theme;
     select.addEventListener('change', e => {
       theme = e.target.value;
       localStorage.setItem('ethicom_theme', theme);
       applyTheme(theme);
-      if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
+      if (tannaCard) tannaCard.style.display = theme.includes('tanna') ? 'block' : 'none';
     });
   }
   if (customBtn) {


### PR DESCRIPTION
## Summary
- style: add `dark-tanna` CSS theme
- feature: extend theme manager to support `tanna-dark` and new `dark-tanna`
- settings: offer new theme choices

## Testing
- `node --test`
- `node tools/check-translations.js`
