### PR TITLE
Set foreground opacity default to zero

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -13,7 +13,7 @@
   --nav-bg: rgba(51, 51, 51, 0.9);
   --card-alpha-bg: rgba(43, 43, 43, 0.92);
   --accent-color: #ccaa22;
-  --foreground-opacity: 0.4;
+  --foreground-opacity: 0;
 }
 
 /* Theme classes override the CSS variables */
@@ -28,7 +28,7 @@
   --nav-bg: rgba(51, 51, 51, 0.9);
   --card-alpha-bg: rgba(43, 43, 43, 0.92);
   --accent-color: #ccaa22;
-  --foreground-opacity: 0.3;
+  --foreground-opacity: 0;
 }
 
 .theme-tanna {
@@ -56,7 +56,7 @@
   --nav-bg: rgba(0, 0, 0, 0.85);
   --card-alpha-bg: rgba(34, 34, 34, 0.9);
   --accent-color: #33cc33;
-  --foreground-opacity: 0.3;
+  --foreground-opacity: 0;
 }
 
 /* Dark base with Tanna accents */
@@ -71,7 +71,7 @@
   --nav-bg: rgba(0, 0, 0, 0.85);
   --card-alpha-bg: rgba(34, 34, 34, 0.9);
   --accent-color: #33cc33;
-  --foreground-opacity: 0.3;
+  --foreground-opacity: 0;
 }
 
 .theme-tanna-light {

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -3,14 +3,14 @@
 (function() {
   function setForegroundOpacity(percent) {
     let p = parseInt(percent, 10);
-    if (isNaN(p)) p = 40;
+    if (isNaN(p)) p = 0;
     if (p < 0) p = 0;
     if (p > 100) p = 100;
     document.documentElement.style.setProperty('--foreground-opacity', (p / 100).toString());
   }
   window.setForegroundOpacity = setForegroundOpacity;
   document.addEventListener('DOMContentLoaded', () => {
-    const stored = parseInt(localStorage.getItem('ethicom_fg_opacity') || '40', 10);
+    const stored = parseInt(localStorage.getItem('ethicom_fg_opacity') || '0', 10);
     setForegroundOpacity(stored);
   });
 })();

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -65,8 +65,8 @@
       <input type="range" id="bg_same_level_count" min="1" max="10" step="1" value="1" />
     </div>
     <div id="foreground_opacity" class="card">
-      <label for="fg_opacity">Foreground transparency: <span id="fg_opacity_val">40</span>%</label>
-      <input type="range" id="fg_opacity" min="0" max="100" step="1" value="40" />
+      <label for="fg_opacity">Foreground transparency: <span id="fg_opacity_val">0</span>%</label>
+      <input type="range" id="fg_opacity" min="0" max="100" step="1" value="0" />
     </div>
     <div id="touch_features" class="card">
       <h3>Touch Features</h3>
@@ -169,7 +169,7 @@
       const fgSlider = document.getElementById('fg_opacity');
       const fgVal = document.getElementById('fg_opacity_val');
       if (fgSlider && fgVal) {
-        const storedFg = parseInt(localStorage.getItem('ethicom_fg_opacity') || '40', 10);
+        const storedFg = parseInt(localStorage.getItem('ethicom_fg_opacity') || '0', 10);
         fgSlider.value = storedFg;
         fgVal.textContent = storedFg;
         fgSlider.addEventListener('input', e => {


### PR DESCRIPTION
## Summary
- keep text fully opaque by default
- update style and util script for 0% foreground transparency
- reflect new default in settings UI

## Testing
- `node --test`
- `node tools/check-translations.js`
