### PR TITLE
Adapt background logos to theme hue

### DIFF
--- a/interface/theme-manager.js
+++ b/interface/theme-manager.js
@@ -23,6 +23,7 @@ function applyTheme(theme) {
     }
     body.classList.add('theme-' + theme);
   }
+  document.dispatchEvent(new CustomEvent('themeChanged', { detail: theme }));
 }
 
 function initThemeSelection() {


### PR DESCRIPTION
## Summary
- let theme changes alter the logo hue by dispatching a `themeChanged` event
- apply the hue difference when drawing the Tanna symbols

## Testing
- `node --test`
- `node tools/check-translations.js`
