### PR TITLE
Fix page movement for touch gestures

### DIFF
--- a/bewertung.html
+++ b/bewertung.html
@@ -15,6 +15,7 @@
   <script src="interface/op0-navigation.js"></script>
   <script src="interface/side-drop.js"></script>
   <script src="interface/op-side-nav.js"></script>
+  <script src="interface/web-content.js"></script>
   <script src="interface/bewertung.js"></script>
   <script src="interface/module-logo.js"></script>
 </head>
@@ -36,6 +37,7 @@
     <p class="hint">Nach oben wischen: <strong>ethisch</strong>. Nach unten: <strong>unethisch</strong>. Links für <strong>unsicher</strong>. Rechts ruft weiterführende Infos auf.</p>
     <section id="rating_container" class="card swipe-card"></section>
     <pre id="output" style="white-space:pre-wrap;"></pre>
+    <div id="web_content" class="web-content"></div>
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {

--- a/interface/bewertung.js
+++ b/interface/bewertung.js
@@ -70,7 +70,13 @@ async function initBewertung() {
       const s = document.getElementById('human_sel');
       const id = s.value;
       const link = linkMap[id];
-      if (link) window.open(link, '_blank');
+      if (link) {
+        if (typeof loadWebContent === 'function') {
+          loadWebContent(link);
+        } else {
+          window.open(link, '_blank');
+        }
+      }
     }
     card.classList.add('swipe-' + dir);
     setTimeout(() => card.classList.remove('swipe-left','swipe-right','swipe-up','swipe-down'), 300);
@@ -116,7 +122,20 @@ async function initBewertung() {
     const link = linkMap[id];
     const sed = document.getElementById('sed_card');
     if (!sed) return;
-    sed.innerHTML = `<strong>${obj.name || ''}</strong>` + (link ? ` – <a href="${link}" target="_blank">Info</a>` : '');
+    sed.innerHTML = `<strong>${obj.name || ''}</strong>` + (link ? ` – <a href="#" class="info_link">Info</a>` : '');
+    if (link) {
+      const a = sed.querySelector('.info_link');
+      if (a) {
+        a.addEventListener('click', e => {
+          e.preventDefault();
+          if (typeof loadWebContent === 'function') {
+            loadWebContent(link);
+          } else {
+            window.open(link, '_blank');
+          }
+        });
+      }
+    }
   }
 }
 

--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -441,6 +441,13 @@ body.touch-big-buttons button {
   font-size: 1.1em;
 }
 
+/* Prevent page movement when touch gestures are active */
+body.touch-lock {
+  touch-action: none;
+  overscroll-behavior: contain;
+  overflow: hidden;
+}
+
 /* Canvas overlay for drawing */
 .drawing-overlay {
   position: fixed;
@@ -545,4 +552,12 @@ body.left-layout main {
 .markdown-content ul { padding-left: 1.2em; margin: 0.5em 0; }
 .markdown-content pre { background: var(--card-bg); padding: 0.6em; overflow-x: auto; }
 .markdown-content code { background: rgba(0,0,0,0.3); padding: 0.1em 0.3em; border-radius: 4px; }
+
+.web-content {
+  max-height: 400px;
+  overflow: auto;
+  background: var(--card-bg);
+  padding: 1em;
+  margin-top: 1em;
+}
 

--- a/interface/touch-features.js
+++ b/interface/touch-features.js
@@ -26,6 +26,7 @@
 
   // Gestures: pinch to zoom whole body
   function pointerDown(e) {
+    e.preventDefault();
     pointers.set(e.pointerId, e);
     swipeStart = { x: e.clientX, y: e.clientY };
     if (pointers.size === 2) {
@@ -36,6 +37,7 @@
   }
 
   function pointerMove(e) {
+    e.preventDefault();
     if (!pointers.has(e.pointerId)) return;
     pointers.set(e.pointerId, e);
     if (state.gestures && pointers.size === 2) {
@@ -48,6 +50,7 @@
   }
 
   function pointerUp(e) {
+    e.preventDefault();
     pointers.delete(e.pointerId);
     if (swipeStart) {
       const dx = e.clientX - swipeStart.x;
@@ -96,7 +99,15 @@
     save();
   }
 
-  function toggleGestures(on) { state.gestures = on; save(); }
+  function setTouchLock(on) {
+    document.body.classList.toggle('touch-lock', on);
+  }
+
+  function toggleGestures(on) {
+    state.gestures = on;
+    setTouchLock(on);
+    save();
+  }
   function toggleHaptics(on) { state.haptics = on; save(); }
   function toggleBigButtons(on) {
     state.bigButtons = on;
@@ -146,6 +157,7 @@
   document.addEventListener('DOMContentLoaded', () => {
     if (state.bigButtons) document.body.classList.add('touch-big-buttons');
     if (state.gestures) {
+      setTouchLock(true);
       document.addEventListener('pointerdown', pointerDown);
       document.addEventListener('pointermove', pointerMove);
       document.addEventListener('pointerup', pointerUp);

--- a/interface/web-content.js
+++ b/interface/web-content.js
@@ -1,0 +1,13 @@
+function loadWebContent(url, containerId = 'web_content') {
+  const container = document.getElementById(containerId);
+  if (!container || !url) return;
+  container.innerHTML = '...';
+  fetch('/proxy?url=' + encodeURIComponent(url))
+    .then(r => r.text())
+    .then(html => { container.innerHTML = html; })
+    .catch(() => { container.textContent = 'Failed to load content.'; });
+}
+
+if (typeof window !== 'undefined') {
+  window.loadWebContent = loadWebContent;
+}

--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -2,6 +2,7 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const { spawn } = require('child_process');
+const https = require('https');
 
 const root = path.join(__dirname, '..', 'interface');
 const repoRoot = path.join(__dirname, '..');
@@ -18,6 +19,45 @@ const mime = {
   '.svg': 'image/svg+xml'
 };
 
+function isAllowedHost(hostname) {
+  return hostname.endsWith('wikipedia.org');
+}
+
+function proxyRequest(req, res) {
+  const query = new URL(req.url, `http://${req.headers.host}`).searchParams;
+  const target = query.get('url');
+  if (!target) {
+    res.statusCode = 400;
+    res.end('Missing url');
+    return;
+  }
+  let targetUrl;
+  try {
+    targetUrl = new URL(target);
+  } catch {
+    res.statusCode = 400;
+    res.end('Invalid url');
+    return;
+  }
+  if (!isAllowedHost(targetUrl.hostname)) {
+    res.statusCode = 403;
+    res.end('Host not allowed');
+    return;
+  }
+  const handler = targetUrl.protocol === 'https:' ? https : http;
+  const pReq = handler.get(targetUrl.href, r => {
+    res.writeHead(r.statusCode || 200, {
+      'Content-Type': r.headers['content-type'] || 'text/html',
+      'Access-Control-Allow-Origin': '*'
+    });
+    r.pipe(res);
+  });
+  pReq.on('error', () => {
+    res.statusCode = 500;
+    res.end('Error fetching url');
+  });
+}
+
 function serveFile(filePath, res) {
   const ext = path.extname(filePath).toLowerCase();
   const type = mime[ext] || 'application/octet-stream';
@@ -26,6 +66,10 @@ function serveFile(filePath, res) {
 }
 
 const server = http.createServer((req, res) => {
+  if (req.url.startsWith('/proxy?')) {
+    proxyRequest(req, res);
+    return;
+  }
   let urlPath = decodeURIComponent(req.url.split('?')[0]);
   if (urlPath === '/' || urlPath === '') urlPath = '/ethicom.html';
   if (urlPath === '/download.zip') {


### PR DESCRIPTION
## Summary
- prevent default scrolling on touch events
- lock page scroll via `touch-lock` class
- apply lock when gestures are enabled
- style rule for `touch-lock` to disable overscroll

## Testing
- `node --test`
- `node tools/check-translations.js`
