### PR TITLE
Add gatekeeper cross platform note

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ Local control can be toggled via `tools/gatekeeper.js`. The script reads
 to `true` for the controller `gstekeeper.local`. This keeps remote commands gated and
 limited to the local environment.
 `gstekeeper.local` holds back every personal ID/information and has permission to share anonymous and signed data as a sign of trust.
+The gatekeeper runs on any platform that can execute Node.js. Copy the repository or the
+`tools` and `app` folders to a USB drive and run `node tools/gatekeeper.js` on Windows,
+macOS, Linux or mobile shells such as Termux. Even older hardware is sufficient—if Node.js
+works, the gatekeeper does too. Use it responsibly as noted in `DISCLAIMERS.md`.
 **4789**
 
 ### API Access Control [⇧](#contents)


### PR DESCRIPTION
## Summary
- add cross-platform usage notes for the gatekeeper in `README.md`

## Testing
- `node --test`
- `node tools/check-translations.js`
