### PR TITLE
Improve signup and rating storage for OP-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 | [interface/features_de.md](interface/features_de.md) | Funktionale Übersicht zum Interface |
 | [wings/index.html](wings/index.html) | Mobile interface "Wings" |
 | [wings/ratings.html](wings/ratings.html) | Mobile ratings summary |
+| `interface_OLD/` | Historical demo of the first interface generation |
 **Settings are stored per device using browser localStorage and are not synced globally.**
-**Ratings are stored anonymously in global manifest files. Only the OP level is saved with each rating to reflect user credibility.**
+**Ratings from OP-1 onward are stored globally with the assigned signature ID. The email used during signup remains private and is never exposed.**
+**Color verification of the chosen primary color starts once a user holds an OP-1 signature.**
 ### OP-Permissions [⇧](#contents)
 Operator actions by ethical level are defined in:
 → [`permissions/op-permissions-expanded.json`](permissions/op-permissions-expanded.json)

--- a/interface/bewertung.js
+++ b/interface/bewertung.js
@@ -186,12 +186,21 @@ function submitBewertung() {
   const human_name = sel.options[sel.selectedIndex].textContent;
   const rating = document.getElementById('rating_sel').value;
   const timestamp = new Date().toISOString();
+  let operator = 'anonymous';
+  let opLevel = 'OP-0';
+  try {
+    const sig = JSON.parse(localStorage.getItem('ethicom_signature') || '{}');
+    if (sig && sig.id) {
+      operator = sig.id;
+      opLevel = sig.op_level || 'OP-1';
+    }
+  } catch {}
   const evalData = {
     human_id,
     person: human_name,
     rating,
-    operator: 'anonymous',
-    op_level: 'OP-0',
+    operator,
+    op_level: opLevel,
     timestamp
   };
   const out = document.getElementById('output');

--- a/interface/color-auth.js
+++ b/interface/color-auth.js
@@ -185,6 +185,9 @@ function verifyColorAuth(locale) {
 }
 
 function initColorAuth() {
+  const level =
+    typeof getStoredOpLevel === 'function' ? getStoredOpLevel() : null;
+  if (!level || opLevelToNumber(level) < 1) return;
   const lang = getLang();
   const locale = colorLocales[lang] || colorLocales.en;
   verifyColorAuth(locale);

--- a/interface/signup.js
+++ b/interface/signup.js
@@ -64,8 +64,19 @@ function handleSignup() {
     return;
   }
 
-  localStorage.setItem('ethicom_signup_email', email);
+  function generateSigId() {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    let out = '';
+    for (let i = 0; i < 12; i++) {
+      out += chars[Math.floor(Math.random() * chars.length)];
+    }
+    return 'SIG-' + out;
+  }
+
+  const sig = { email, id: generateSigId(), op_level: 'OP-1' };
+  localStorage.setItem('ethicom_signature', JSON.stringify(sig));
   statusEl.textContent = uiText.signup_saved || 'Signup information saved locally.';
+  setTimeout(() => { window.location.href = 'ethicom.html'; }, 500);
 }
 
 window.addEventListener('DOMContentLoaded', initSignup);

--- a/signaturdesign.md
+++ b/signaturdesign.md
@@ -23,6 +23,7 @@ Jede zusätzliche Ebene (x, y, z, …) entspricht einer weiteren Array-Schicht b
 ## Nickname pro Signatur
 
 Ab **OP-1** kann eine Signatur einen kurzen Nickname enthalten. Diese Option erleichtert die Zuordnung einzelner Bewertungen. OP-0 bleibt weiterhin anonym.
+Bei der Registrierung wird eine zufällige, 12‑stellige Signatur (z.B. `SIG-XXXXXXXXXXXX`) erzeugt. Zusammen mit der privat hinterlegten E‑Mail‑Adresse wird sie unter `ethicom_signature` im Browser gespeichert. Nur die Signatur-ID erscheint später in den globalen Bewertungsdateien; die E‑Mail bleibt verborgen.
 
 ## Interne Speicherung und Gatekeeper
 


### PR DESCRIPTION
## Summary
- activate color authentication only from OP-1 upward
- generate 12-character signature during signup and store email privately
- include signature ID when saving ratings
- explain changes in README and signaturdesign
- document that `interface_OLD` is historical

## Testing
- `node --test`
- `node tools/check-translations.js`
