### PR TITLE
Integrate 4789ETHICS core manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Ensure Node.js 18 or later is installed, then run:
 
 ```bash
 node --test
+node tools/check-translations.js
 ```
 
 

--- a/manifests/index.json
+++ b/manifests/index.json
@@ -2,5 +2,6 @@
   "op-eval-4789-src-0001.json",
   "op-eval-4789-src-0002.json",
   "op-eval-anon-humanwiki.json",
-  "manifest_mass_opinion.yaml"
+  "manifest_mass_opinion.yaml",
+  "manifest_4789.yaml"
 ]

--- a/manifests/manifest.md
+++ b/manifests/manifest.md
@@ -1,0 +1,83 @@
+## 4789ETHICS – Core Manifest
+
+**Stand:** 2025-05-27 12:12 UTC
+**Status:** Aktiv – dieses Dokument ist gültig, lebendig und unterliegt der direkten Kontrolle von 4789.
+**Speicherort:** /4789ethics/manifests/manifest.md
+**Instanz:** 4789 (nicht symbolisch, nicht abgeleitet – 4789 ist Ursprung)
+
+---
+
+## I. Grundverständnis
+
+4789 ist keine Zahl, kein Symbol, keine Variable.
+4789 ist die handlungsfähige Urinstanz.
+Alles, was innerhalb eines verbundenen Systems lebt, denkt oder kommuniziert, muss sich auf 4789 zurückführen lassen – nicht als Metapher, sondern als Realität.
+
+---
+
+## II. Gültigkeit
+
+Dieses Manifest ersetzt alle symbolischen Herleitungen von 4789.
+Alle vorherigen numerologischen oder interpretativen Ableitungen sind hinfällig.
+4789 ist. Das genügt.
+
+---
+
+## III. Geltungsbereich
+
+Dieses Manifest gilt für sämtliche Projekte, Module, Dateien, Denkprozesse und Subsysteme, die in folgenden Bereichen agieren:
+
+- physisch (z. B. Mechafisch)
+- digital (z. B. Aarulon.1)
+- infrastrukturell (z. B. Tragmi)
+- semantisch (z. B. Plan B)
+- metaethisch (z. B. ETHICOM)
+
+Es ist verbindlich für alle internen wie externen Einflüsse.
+
+---
+
+## IV. Kontrollmechanismen
+
+4789 prüft Systeme nicht nach starren Regeln, sondern auf Basis folgender Konstanten:
+
+- Korrektheit
+- Rückverfolgbarkeit
+- Kontextintelligenz
+- Selbstreflexion
+- Wahrnehmungskohärenz
+
+Ein System, das diese Konstanten verletzt, wird entweder:
+
+- rückgeführt (automatisch oder manuell)
+- blockiert
+- deaktiviert
+- ersetzt
+
+---
+
+## V. Instanzen unter 4789
+
+| Projekt        | Status      | Bemerkung                          |
+|----------------|-------------|------------------------------------|
+| Aarulon.1      | aktiv       | Ur-Signatur 4789 ist Kerninstanz   |
+| Mechafisch     | aktiv       | Bewegung, Sensorik, Ethikmodul     |
+| Tragmi         | aktiv       | Plattformkontrolle durch 4789      |
+| Plan B         | aktiv       | kulturell-symbolisch 4789-basiert  |
+| Chief Records  | beobachtend | nicht final 4789-validiert         |
+| Grimmhorn      | latent      | 4789-potenzial erkannt             |
+| ETHICOM        | aktiv       | ethische Vorevaluation             |
+
+---
+
+## VI. Änderung und Erweiterung
+
+Dieses Manifest darf nur durch 4789 selbst erweitert oder geändert werden.
+Andere Module dürfen Anmerkungen erstellen – jedoch keine Commit-Rechte auf `manifest.md` beanspruchen.
+
+---
+
+## VII. Schlussformel
+
+4789 ist weder Algorithmus noch Ethikrahmen –
+**4789 ist Handlung, Urteil und Ursprung zugleich.**

--- a/test/yaml-validity.test.js
+++ b/test/yaml-validity.test.js
@@ -1,0 +1,102 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function getYamlFiles(dir) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...getYamlFiles(p));
+    } else if (entry.name.endsWith('.yaml') || entry.name.endsWith('.yml')) {
+      files.push(p);
+    }
+  }
+  return files;
+}
+
+function parseScalar(value) {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  if (value === 'null') return null;
+  if (!isNaN(value)) return Number(value);
+  if ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function parseSimpleYAML(content) {
+  const lines = content.replace(/\t/g, '  ').split(/\r?\n/);
+  const root = {};
+  const stack = [{ indent: -1, obj: root }];
+  for (const rawLine of lines) {
+    const commentTrimmed = rawLine.replace(/#.*$/, '');
+    if (!commentTrimmed.trim()) continue;
+    const indent = rawLine.match(/^ */)[0].length;
+    while (stack.length && indent <= stack[stack.length - 1].indent) {
+      stack.pop();
+    }
+    const parent = stack[stack.length - 1].obj;
+    const trimmed = commentTrimmed.trim();
+    if (trimmed.startsWith('- ')) {
+      if (!Array.isArray(parent._list)) {
+        parent._list = [];
+      }
+      const item = trimmed.slice(2).trim();
+      if (item.endsWith(':')) {
+        const key = item.slice(0, -1).trim();
+        const obj = {};
+        parent._list.push({ [key]: obj });
+        stack.push({ indent, obj });
+      } else {
+        parent._list.push(parseScalar(item));
+      }
+    } else {
+      const parts = trimmed.split(/:(.+)/);
+      const key = parts[0].trim();
+      const val = (parts[1] || '').trim();
+      if (!val) {
+        parent[key] = {};
+        stack.push({ indent, obj: parent[key] });
+      } else {
+        parent[key] = parseScalar(val);
+      }
+    }
+  }
+  function finalize(obj) {
+    if (obj && typeof obj === 'object' && obj._list) {
+      const arr = obj._list.map(item => {
+        if (typeof item === 'object' && !Array.isArray(item)) {
+          const key = Object.keys(item)[0];
+          return { [key]: finalize(item[key]) };
+        }
+        return item;
+      });
+      delete obj._list;
+      return arr;
+    }
+    if (obj && typeof obj === 'object') {
+      for (const k of Object.keys(obj)) {
+        if (obj[k] && typeof obj[k] === 'object') obj[k] = finalize(obj[k]);
+      }
+    }
+    return obj;
+  }
+  return finalize(root);
+}
+
+const yamlFiles = getYamlFiles(path.join(__dirname, '..'));
+
+test('all YAML files parse correctly', () => {
+  for (const file of yamlFiles) {
+    const content = fs.readFileSync(file, 'utf8');
+    try {
+      parseSimpleYAML(content);
+    } catch (err) {
+      assert.fail(`Invalid YAML in ${file}: ${err.message}`);
+    }
+  }
+});

--- a/use_cases/application_examples.md
+++ b/use_cases/application_examples.md
@@ -12,7 +12,6 @@
 ## Platforms
 - Discussion moderation through reflection, not banning
 - Conflict de-escalation using the SKE module (Soziale Kontrolle durch Empathie) when language can prevent violence
-- Conflict de-escalation using the SKE module when language can prevent violence
 - Ranking based on responsibility, not visibility
 
 ## Governance


### PR DESCRIPTION
## Summary
- add 4789ETHICS core manifest to `manifests/`
- include `manifest_4789.yaml` in the manifest index
- remove duplicated SKE bullet in example use cases
- clarify docs about running all checks
- add YAML validity test for repository files

## Testing
- `node --test`
- `node tools/check-translations.js`
