### PR TITLE
Add fish mode gating

### DIFF
--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -145,3 +145,14 @@ window.getReadmePath = getReadmePath;
 window.showLoadingBadge = showLoadingBadge;
 window.hideLoadingBadge = hideLoadingBadge;
 
+// Check if user confirmed responsibility via "Sana"
+function getSanaConfirmed() {
+  try {
+    return localStorage.getItem('sana_confirmed') === 'true';
+  } catch (err) {
+    return false;
+  }
+}
+
+window.getSanaConfirmed = getSanaConfirmed;
+

--- a/interface/fish-interface/README.md
+++ b/interface/fish-interface/README.md
@@ -7,3 +7,7 @@ by supplying new HTML/JS files and corresponding JSON sources in `sources/fish`.
 The goal is to promote respectful and transparent handling of fish populations
 worldwide. Contributions should follow the 4789 principles and the
 Open-Ethics License.
+
+## Access Control
+
+Editing functions are only available from OP-5 upward once `sana_confirmed` is stored in `localStorage`.

--- a/interface/fish-interface/fischEditor.js
+++ b/interface/fish-interface/fischEditor.js
@@ -1,4 +1,8 @@
 async function initFischEditor() {
+  if (opLevelToNumber(getStoredOpLevel()) < 5 || !getSanaConfirmed()) {
+    document.body.innerHTML = '<p>Fisch-Modus erfordert OP-5 und Sana-Bestätigung.</p>';
+    return;
+  }
   const table = document.getElementById('fisch_table');
   const addBtn = document.getElementById('add_fish_btn');
   if (!table || !addBtn) return;

--- a/use_cases/application_examples.md
+++ b/use_cases/application_examples.md
@@ -1,7 +1,8 @@
 # Application Examples – Ethics Structure 4789
 
 ## Education
-- Decision reflection modules in school settings  
+- Decision reflection modules in school settings
+- Teachers at OP-6 can create subject modules (e.g. French or math)
 - Evaluation through responsibility, not correctness
 
 ## AI Systems

--- a/use_cases/education_module_integration.md
+++ b/use_cases/education_module_integration.md
@@ -1,0 +1,9 @@
+# Education Module Integration
+
+Teachers at OP-6 can create new subject modules such as language or math. Start from `interface/` templates and adjust the content for each lesson.
+
+1. Duplicate an existing HTML/JS pair, e.g. `fischeBern.html` and `fischeBern.js`.
+2. Adjust titles and data paths to your subject.
+3. Include the module in the navigation once reviewed.
+
+The fish editor demonstrates OP-5 access control with confirmed responsibility (`sana_confirmed`).


### PR DESCRIPTION
## Summary
- restrict fish editor to OP-5 with `sana_confirmed`
- expose `getSanaConfirmed()` in utility functions
- document access control for fish mode
- mention OP-6 modules in application examples
- add short guide for new education modules

## Testing
- `node --test`
- `node tools/check-translations.js`
