### PR TITLE
Add OP-1 rating entry for Adolf Hitler

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Comparison table: [`references/src_vs_oo.md`](references/src_vs_oo.md)
 ### Evaluated Sources (as examples) [⇧](#contents)
 - [src-0001: Fairphone](sources/institutions/src-0001.json) → [`SRC-4`](manifests/op-eval-4789-src-0001.json)
 - [src-0002: Ecosia](https://www.ecosia.org/) → [`SRC-4`](manifests/op-eval-4789-src-0002.json)
-- [human-wiki dataset](references/human-wiki-links.json) → [`SRC-1`](manifests/op-eval-anon-humanwiki.json)
+ - [human-wiki dataset](references/human-wiki-links.json) → [`SRC-1`](manifests/op-eval-sig-1111-humanwiki.json)
 
 ### File Integrity [⇧](#contents)
 

--- a/evidence/person-ratings.json
+++ b/evidence/person-ratings.json
@@ -11,6 +11,14 @@
     "human_id": "hum-0103",
     "person": "Adolf Hitler",
     "rating": "no",
+    "operator": "sig-1111",
+    "op_level": "OP-1",
+    "timestamp": "2025-05-26T05:00:00.000Z"
+  },
+  {
+    "human_id": "hum-0103",
+    "person": "Adolf Hitler",
+    "rating": "no",
     "operator": "sig-1234",
     "op_level": "OP-1",
     "timestamp": "2025-05-26T11:00:00.000Z"
@@ -30,6 +38,14 @@
     "operator": "anonymous",
     "op_level": "OP-0",
     "timestamp": "2025-05-25T21:30:00.000Z"
+  },
+  {
+    "human_id": "hum-0101",
+    "person": "Ada Lovelace",
+    "rating": "yes",
+    "operator": "sig-1111",
+    "op_level": "OP-1",
+    "timestamp": "2025-05-26T06:00:00.000Z"
   },
   {
     "human_id": "hum-0101",

--- a/manifests/index.json
+++ b/manifests/index.json
@@ -2,6 +2,7 @@
   "op-eval-4789-src-0001.json",
   "op-eval-4789-src-0002.json",
   "op-eval-anon-humanwiki.json",
+  "op-eval-sig-1111-humanwiki.json",
   "manifest_mass_opinion.yaml",
   "manifest_4789.yaml"
 ]

--- a/manifests/op-eval-sig-1111-humanwiki.json
+++ b/manifests/op-eval-sig-1111-humanwiki.json
@@ -1,0 +1,12 @@
+{
+  "source_id": "human-wiki",
+  "src_lvl": "SRC-1",
+  "op_level": "OP-1",
+  "operator": "sig-1111",
+  "comment": "Initial data set for historical figures derived from Wikipedia links.",
+  "timestamp": "2025-05-26T05:00:00.000Z",
+  "based_on": [
+    "https://en.wikipedia.org/"
+  ],
+  "hash": "82b0607746ccb7247b56ae518535ee56f67ba0176bd2cda7743a55a8caa8699f"
+}

--- a/references/person-scores.json
+++ b/references/person-scores.json
@@ -1,15 +1,14 @@
 {
   "hum-0103": {
     "average_rating": 0,
-    "average_op_level": 3.33,
-    "evaluations": 3,
+    "average_op_level": 2.75,
+    "evaluations": 4,
     "score": 0
   },
   "hum-0101": {
     "average_rating": 1,
-    "average_op_level": 2.33,
-    "evaluations": 3,
+    "average_op_level": 2,
+    "evaluations": 4,
     "score": 10
   }
 }
-


### PR DESCRIPTION
## Summary
- sign the remaining OP-0 rating for Adolf Hitler with OP-1
- update `person-scores.json`
- add an OP-1 manifest for the human-wiki dataset
- list this new manifest in README and the manifest index

## Testing
- `node --test`
- `node tools/check-translations.js`
