### PR TITLE
Add translation notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ node tools/check-translations.js
 ```
 
 This prints a list of language codes and the fields that still require translation or are unchanged from German. In the interface dropdown, languages with missing fields show an asterisk (`*`) so users know the translation is not complete.
+When a partially translated language is selected, the interface displays a notice and falls back to English for missing text. Contributions for additional translations are welcome.
 
 ### Generating Interface README [⇧](#contents)
 

--- a/i18n/ui-text.json
+++ b/i18n/ui-text.json
@@ -84,7 +84,8 @@
     "login_password": "Password:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
-    "login_saved": "Login successful. ID stored."
+    "login_saved": "Login successful. ID stored.",
+    "translation_notice": "Language not fully implemented. Contributions welcome."
   },
   "de": {
     "title": "Ethicom: Bewertung durch Menschen",
@@ -258,7 +259,8 @@
     "login_password": "Password:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
-    "login_saved": "Login successful. ID stored."
+    "login_saved": "Login successful. ID stored.",
+    "translation_notice": "Langue pas encore pleinement implémentée. Participation bienvenue."
   },
   "es": {
     "title": "Ethicom: Evaluación Humana",
@@ -345,7 +347,8 @@
     "login_password": "Password:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
-    "login_saved": "Login successful. ID stored."
+    "login_saved": "Login successful. ID stored.",
+    "translation_notice": "Idioma aún no implementado por completo. Se agradece colaboración."
   },
   "pt": {
     "title": "Ethicom: Avaliação Humana",
@@ -519,7 +522,8 @@
     "login_password": "Password:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
-    "login_saved": "Login successful. ID stored."
+    "login_saved": "Login successful. ID stored.",
+    "translation_notice": "Idioma ainda não totalmente implementado. Colaboração bem-vinda."
   },
   "hi": {
     "title": "Ethicom: मानवीय मूल्यांकन",
@@ -1041,7 +1045,8 @@
     "login_password": "Password:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
-    "login_saved": "Login successful. ID stored."
+    "login_saved": "Login successful. ID stored.",
+    "translation_notice": "Lingua non ancora completamente implementata. Collaborazione ben accetta."
   },
   "ko": {
     "title": "Ethicom: 인간 평가",
@@ -2433,7 +2438,8 @@
     "login_password": "Password:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
-    "login_saved": "Login successful. ID stored."
+    "login_saved": "Login successful. ID stored.",
+    "translation_notice": "语言尚未完全实现，欢迎协助翻译。"
   },
   "vi": {
     "title": "Ethicom: Human Evaluation",

--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -584,3 +584,9 @@ body.left-layout main {
   z-index: 5;
 }
 
+.lang-notice {
+  color: var(--accent-color);
+  font-size: 0.9em;
+  margin-top: 0.5em;
+}
+

--- a/interface/language-selector.js
+++ b/interface/language-selector.js
@@ -56,6 +56,28 @@ function initLanguageDropdown(selectId = "lang_select", textPath = getUiTextPath
         if (Array.isArray(v)) return v.length === 0 || v.every(x => !x);
         return v === undefined || v === null || v === "";
       }
+      function isIncomplete(obj) {
+        return keys.some(k =>
+          !Object.prototype.hasOwnProperty.call(obj, k) ||
+          isEmpty(obj[k]) ||
+          JSON.stringify(obj[k]) === JSON.stringify(base[k])
+        );
+      }
+
+      function displayLangNotice(msg) {
+        let el = document.getElementById('lang_notice');
+        if (!msg) {
+          if (el) el.remove();
+          return;
+        }
+        if (!el) {
+          el = document.createElement('p');
+          el.id = 'lang_notice';
+          el.className = 'lang-notice';
+          select.parentElement.appendChild(el);
+        }
+        el.textContent = msg;
+      }
 
       Object.keys(texts)
         .sort()
@@ -70,10 +92,13 @@ function initLanguageDropdown(selectId = "lang_select", textPath = getUiTextPath
         });
       const current = getLanguage();
       select.value = current;
-      select.addEventListener("change", e => {
-        const lang = e.target.value.replace(/\*$/, "");
-        localStorage.setItem("ethicom_lang", lang);
+      function applyLanguage(lang) {
         const t = texts[lang] || texts.en || {};
+        const notice = isIncomplete(t)
+          ? t.translation_notice ||
+            'Language not fully implemented. Contributions welcome.'
+          : '';
+        displayLangNotice(notice);
         if (typeof applyTexts === "function") {
           applyTexts(t);
         }
@@ -82,6 +107,13 @@ function initLanguageDropdown(selectId = "lang_select", textPath = getUiTextPath
           applySignupTexts();
         }
         if (typeof updateReadmeLinks === 'function') updateReadmeLinks(lang);
+      }
+
+      applyLanguage(current);
+      select.addEventListener("change", e => {
+        const lang = e.target.value.replace(/\*$/, "");
+        localStorage.setItem("ethicom_lang", lang);
+        applyLanguage(lang);
       });
     });
 }


### PR DESCRIPTION
## Summary
- add UI notice when language is incomplete
- style for new language notice
- update README on language fallback
- add `translation_notice` entries in example locales

## Testing
- `node --test`
- `node tools/check-translations.js`
