### PR TITLE
Add ratings library link with search

### DIFF
--- a/README.html
+++ b/README.html
@@ -23,6 +23,7 @@
     <a href="bewertung.html">Bewertung</a>
     <a href="interface/settings.html" class="icon-only">⚙</a>
     <a href="interface/login.html">Login</a>
+    <a href="wings/ratings.html">Ratings</a>
     <a href="interface/signup.html">Signup</a>
     <a aria-current="page" class="readme-link">README</a>
   </nav>

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 | [interface/README.html](interface/README.html) | HTML version of the interface docs |
 | [interface/features_de.md](interface/features_de.md) | Funktionale Übersicht zum Interface |
 | [wings/index.html](wings/index.html) | Mobile interface "Wings" |
-| [wings/ratings.html](wings/ratings.html) | Mobile ratings summary |
+| [wings/ratings.html](wings/ratings.html) | Library of all ratings with search |
 | `interface_OLD/` | Historical demo of the first interface generation |
 **Settings are stored per device using browser localStorage and are not synced globally.**
 **Ratings from OP-1 onward are stored globally with the assigned signature ID. The email used during signup is hashed and never exposed.**

--- a/bewertung.html
+++ b/bewertung.html
@@ -28,6 +28,7 @@
       <a href="home.html">Home</a>
       <a href="bewertung.html" aria-current="page">Bewertung</a>
       <a href="interface/settings.html" class="icon-only">⚙</a>
+      <a href="wings/ratings.html">Ratings</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="readme-link">README</a>
     </nav>

--- a/home.html
+++ b/home.html
@@ -33,6 +33,7 @@
     <a href="bewertung.html">Bewertung</a>
     <a href="interface/settings.html" class="icon-only">⚙</a>
     <a href="interface/login.html">Login</a>
+    <a href="wings/ratings.html">Ratings</a>
     <a href="interface/signup.html">Signup</a>
     <a href="interface/donate.html">Spenden</a>
     <a href="README.html" class="readme-link">README</a>

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
     <a href="bewertung.html">Bewertung</a>
     <a href="interface/settings.html" class="icon-only">⚙</a>
     <a href="interface/login.html">Login</a>
+    <a href="wings/ratings.html">Ratings</a>
     <a href="interface/signup.html">Signup</a>
     <a href="interface/shneiderman.html">Designregeln</a>
     <a href="README.html" class="readme-link">README</a>

--- a/interface/donate.html
+++ b/interface/donate.html
@@ -24,6 +24,7 @@
       <a href="../bewertung.html">Bewertung</a>
       <a href="settings.html" class="icon-only">⚙</a>
       <a href="login.html">Login</a>
+      <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>
       <a href="../README.html" class="readme-link">README</a>
     </nav>

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -32,6 +32,7 @@
     <a href="../bewertung.html">Bewertung</a>
     <a href="settings.html" class="icon-only">⚙</a>
     <a href="login.html">Login</a>
+    <a href="../wings/ratings.html">Ratings</a>
     <a href="signup.html">Signup</a>
     <a href="../README.html" class="readme-link">README</a>
   </nav>

--- a/interface/fish-interface/fischEditor.html
+++ b/interface/fish-interface/fischEditor.html
@@ -24,6 +24,7 @@
       <a href="../../bewertung.html">Bewertung</a>
       <a href="../settings.html" class="icon-only">⚙</a>
       <a href="../login.html">Login</a>
+      <a href="../wings/ratings.html">Ratings</a>
       <a href="../signup.html">Signup</a>
       <a href="../../README.html" class="readme-link">README</a>
     </nav>

--- a/interface/fish-interface/fischeBern.html
+++ b/interface/fish-interface/fischeBern.html
@@ -24,6 +24,7 @@
       <a href="../../bewertung.html">Bewertung</a>
       <a href="../settings.html" class="icon-only">⚙</a>
       <a href="../login.html">Login</a>
+      <a href="../wings/ratings.html">Ratings</a>
       <a href="../signup.html">Signup</a>
       <a href="../../README.html" class="readme-link">README</a>
     </nav>

--- a/interface/login.html
+++ b/interface/login.html
@@ -31,6 +31,7 @@
     <a href="../bewertung.html">Bewertung</a>
     <a href="settings.html" class="icon-only">⚙</a>
     <a href="login.html" aria-current="page">Login</a>
+    <a href="../wings/ratings.html">Ratings</a>
     <a href="signup.html">Signup</a>
     <a href="../README.html" class="readme-link">README</a>
   </nav>

--- a/interface/op0-navigation.js
+++ b/interface/op0-navigation.js
@@ -21,6 +21,7 @@
       `<a href="${base}bewertung.html">Bewertung</a>`+
       `<a href="${base}interface/settings.html">Settings</a>`+
       `<a href="${base}interface/login.html">Login</a>`+
+      `<a href="${base}wings/ratings.html">Ratings</a>`+
       `<a href="${base}interface/signup.html">Signup</a>`+
       `<a href="${base}interface/shneiderman.html">Designregeln</a>`+
       `<a href="${base}README.html">README</a>`+

--- a/interface/ratings.js
+++ b/interface/ratings.js
@@ -86,6 +86,16 @@ async function initRatings() {
     table.appendChild(tbody);
     library.appendChild(table);
 
+    const searchInput = document.getElementById('rating_search');
+    if (searchInput) {
+      searchInput.addEventListener('input', e => {
+        const q = e.target.value.toLowerCase();
+        Array.from(tbody.rows).forEach(r => {
+          r.style.display = r.textContent.toLowerCase().includes(q) ? '' : 'none';
+        });
+      });
+    }
+
     const list = document.createElement('ul');
     for (const [src, nums] of Object.entries(perSource)) {
       const avg = nums.reduce((a, b) => a + b, 0) / nums.length;

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -27,6 +27,7 @@
     <a href="../home.html">Home</a>
     <a href="../bewertung.html">Bewertung</a>
     <a href="settings.html" aria-current="page" class="icon-only">⚙</a>
+    <a href="../wings/ratings.html">Ratings</a>
     <a href="signup.html">Signup</a>
     <a href="../README.html" class="readme-link">README</a>
   </nav>

--- a/interface/shneiderman.html
+++ b/interface/shneiderman.html
@@ -20,6 +20,7 @@
       <a href="../bewertung.html">Bewertung</a>
       <a href="settings.html" class="icon-only">⚙</a>
       <a href="login.html">Login</a>
+      <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>
       <a href="../README.html" class="readme-link">README</a>
     </nav>

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -30,6 +30,7 @@
     <a href="../home.html">Home</a>
     <a href="../bewertung.html">Bewertung</a>
     <a href="settings.html" class="icon-only">⚙</a>
+    <a href="../wings/ratings.html">Ratings</a>
     <a href="signup.html" aria-current="page">Signup</a>
     <a href="../README.html" class="readme-link">README</a>
   </nav>

--- a/interface/start.html
+++ b/interface/start.html
@@ -27,6 +27,7 @@
       <a href="../bewertung.html">Bewertung</a>
       <a href="settings.html" class="icon-only">⚙</a>
       <a href="login.html">Login</a>
+      <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>
       <a href="../README.html" class="readme-link">README</a>
     </nav>

--- a/wings/ratings.html
+++ b/wings/ratings.html
@@ -52,6 +52,8 @@
     </section>
     <section id="rating_library" class="card">
       <h2>Library – Rating History</h2>
+      <label for="rating_search">Search:</label>
+      <input type="text" id="rating_search" placeholder="ID or keyword" />
       <p>All ratings listed chronologically.</p>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- link to ratings library page before the signup link
- allow OP‑0 nav to show the ratings link
- enable search filtering on the ratings library page
- mention the library page in docs

## Testing
- `node --test`
- `node tools/check-translations.js`
