### PR TITLE
Remove binary placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 | `sources/persons/` | Lists of historical persons |
 | `sources/institutions/` | Evaluated organizations and candidate sources |
 | `sources/images/` | Pictures for institutions (`institutions/`), persons (`persons/`), and fish (`fish/`) |
+| `sources/fish/ch/` | Text placeholders for Swiss fish images (e.g., `esox_ch.png`) |
 | `test/` | Node.js test suite |
 | `tools/` | Utility scripts (e.g., trust-demotion engine, Python API example) |
 | `use_cases/` | Example scenarios and dissemination ideas |

--- a/interface/fish-interface/README.md
+++ b/interface/fish-interface/README.md
@@ -2,7 +2,9 @@
 
 This folder holds the regional interfaces and data sources for ethical fish awareness.
 The starting region is Bern, but additional regions can be added under this folder
+
 by supplying new HTML/JS files and corresponding JSON sources in `sources/fish`.
+Text placeholders for Swiss fish images reside in `sources/fish/ch/`, named like `esox_ch.png`.
 
 The goal is to promote respectful and transparent handling of fish populations
 worldwide. Contributions should follow the 4789 principles and the

--- a/sources/fish/ch/README.md
+++ b/sources/fish/ch/README.md
@@ -1,0 +1,3 @@
+This folder stores placeholder files for Swiss fish images.
+They use the `.png` extension but contain no binary data.
+Use lowercase names with `_ch`, e.g., `esox_ch.png` or `bachforelle_ch.png`.

--- a/sources/fish/ch/bachforelle_ch.png
+++ b/sources/fish/ch/bachforelle_ch.png
@@ -1,0 +1,1 @@
+Placeholder for bachforelle

--- a/sources/fish/ch/esox_ch.png
+++ b/sources/fish/ch/esox_ch.png
@@ -1,0 +1,1 @@
+Placeholder for esox


### PR DESCRIPTION
## Summary
- replace PNG binary placeholders with small text files
- clarify placeholder directory usage for Swiss fish

## Testing
- `node --test`
- `node tools/check-translations.js`
