### PR TITLE
Add source manager script

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 - [OP Function Bundles](#op-function-bundles)
 - [Currency Synchronization](#currency-synchronization)
 - [Wiki Image Loader](#wiki-image-loader)
+- [Source Manager](#source-manager)
 - [Roadmap](#roadmap)
 - [Local Deployment](#local-deployment)
 - [Running Tests](#running-tests)
@@ -243,6 +244,13 @@ Run `node tools/fetch-wiki-images.js` to download public thumbnails from
 Wikipedia. The script saves each file in `sources/images/persons/` and updates
 `sources/persons/human-op0-candidates.json`. Review the licenses of all
 downloaded images as noted in `LICENSE.txt` and `DISCLAIMERS.md`.
+
+### Source Manager [⇧](#contents)
+
+Run `node tools/source-manager.js list` to view all sources. Use
+`--type=person` or `--type=org` to filter and `--sort=name` or
+`--sort=category` to control the order. This keeps the candidate lists
+organized and easy to review.
 
 
 ## Roadmap [⇧](#contents)

--- a/test/source-manager.test.js
+++ b/test/source-manager.test.js
@@ -1,0 +1,15 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { list } = require('../tools/source-manager.js');
+
+test('lists persons sorted by name', () => {
+  const res = list({ type: 'person', sort: 'name' });
+  assert.ok(res.length > 1, 'not enough persons');
+  assert.ok(res[0].name <= res[1].name, 'not sorted by name');
+});
+
+test('lists orgs sorted by category', () => {
+  const res = list({ type: 'org', sort: 'category' });
+  assert.ok(res.length > 1, 'not enough orgs');
+  assert.ok(res[0].category <= res[1].category, 'not sorted by category');
+});

--- a/tools/source-manager.js
+++ b/tools/source-manager.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+
+function readJSON(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function loadPersons() {
+  const dir = path.join(__dirname, '..', 'sources', 'persons');
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir)
+    .filter(f => f.endsWith('.json'))
+    .flatMap(f => readJSON(path.join(dir, f)));
+}
+
+function loadInstitutions() {
+  const dir = path.join(__dirname, '..', 'sources', 'institutions');
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir)
+    .filter(f => f.endsWith('.json'))
+    .flatMap(f => readJSON(path.join(dir, f)));
+}
+
+function list(opts = {}) {
+  const type = opts.type || 'all';
+  let items = [];
+  if (type === 'person' || type === 'all') items.push(...loadPersons());
+  if (type === 'org' || type === 'all') items.push(...loadInstitutions());
+  const sort = opts.sort;
+  if (sort === 'name') {
+    items.sort((a, b) => (a.name || a.title || '').localeCompare(b.name || b.title || ''));
+  } else if (sort === 'category') {
+    items.sort((a, b) => (a.category || '').localeCompare(b.category || ''));
+  } else {
+    items.sort((a, b) => String(a.human_id || a.source_id || '').localeCompare(String(b.human_id || b.source_id || '')));
+  }
+  return items;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (!args.length || args[0] === '--help' || args[0] === '-h') {
+    console.log('Usage: node tools/source-manager.js list [--type=person|org|all] [--sort=name|category]');
+    process.exit(0);
+  }
+  const cmd = args.shift();
+  if (cmd !== 'list') {
+    console.error('Unknown command:', cmd);
+    process.exit(1);
+  }
+  const opts = {};
+  args.forEach(arg => {
+    const [k, v] = arg.replace(/^--/, '').split('=');
+    if (k === 'type') opts.type = v;
+    else if (k === 'sort') opts.sort = v;
+  });
+  const items = list(opts);
+  items.forEach((it, i) => {
+    const id = it.human_id || it.source_id || '';
+    const name = it.name || it.title;
+    console.log(`${String(i + 1).padStart(3, ' ')} ${id} ${name}`);
+  });
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { loadPersons, loadInstitutions, list };


### PR DESCRIPTION
## Summary
- add `tools/source-manager.js` to list, filter and sort source files
- document Source Manager usage in README
- test new functionality

## Testing
- `node --test`
- `node tools/check-translations.js`
