### PR TITLE
Implement global API for sources

### DIFF
--- a/test/sources-api.test.js
+++ b/test/sources-api.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { handleSources } = require('../tools/serve-interface.js');
+
+test('handleSources returns data', () => {
+  let data = null;
+  const req = { url: '/api/sources?type=person&limit=1', headers: {} };
+  const res = {
+    writeHead() {},
+    end(chunk) { data = chunk; }
+  };
+  handleSources(req, res);
+  const arr = JSON.parse(data);
+  assert.ok(Array.isArray(arr));
+  assert.ok(arr.length > 0);
+});

--- a/tools/source-search.js
+++ b/tools/source-search.js
@@ -2,7 +2,12 @@ const fs = require('fs');
 const path = require('path');
 
 function loadSources(type) {
-  const dir = path.join(__dirname, '..', 'sources', type === 'person' ? 'persons' : 'institutions');
+  const dir = path.join(
+    __dirname,
+    '..',
+    'sources',
+    type === 'person' ? 'persons' : type === 'fish' ? 'fish' : 'institutions'
+  );
   if (!fs.existsSync(dir)) return [];
   const files = fs.readdirSync(dir).filter(f => f.endsWith('.json'));
   const items = [];
@@ -82,4 +87,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { search };
+module.exports = { search, loadSources };


### PR DESCRIPTION
## Summary
- make `serve-interface.js` start the server only when executed directly
- export `loadSources` from `source-search.js`
- add `/api/sources` endpoint with search and CORS support
- test new API in `sources-api.test.js`

## Testing
- `node --test`
- `node tools/check-translations.js`