### PR TITLE
Implement slider preview for custom themes

### DIFF
--- a/interface/theme-manager.js
+++ b/interface/theme-manager.js
@@ -51,6 +51,17 @@ function initThemeSelection() {
   }
 }
 
+function parseCol(v){
+  v=(v||'').trim();
+  if(v.startsWith('#')){
+    if(v.length===4) v='#'+v[1]+v[1]+v[2]+v[2]+v[3]+v[3];
+    const n=parseInt(v.slice(1),16);
+    return {r:(n>>16)&255,g:(n>>8)&255,b:n&255};
+  }
+  const m=v.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  return m?{r:+m[1],g:+m[2],b:+m[3]}:{r:0,g:0,b:0};
+}
+
 function createCustomTheme() {
   const overlay = document.createElement('div');
   overlay.style.position = 'fixed';
@@ -65,26 +76,54 @@ function createCustomTheme() {
   form.className = 'card';
   form.style.background = '#fff';
   form.style.color = '#000';
-  form.innerHTML = `
-    <h3>Custom Colors</h3>
-    <label>Background: <input type="color" id="cc_bg" aria-label="background color"></label><br>
-    <label>Text: <input type="color" id="cc_text" aria-label="text color" value="#ffffff"></label><br>
-    <label>Primary: <input type="color" id="cc_primary" aria-label="primary color" value="#228B22"></label><br>
-    <label>Accent: <input type="color" id="cc_accent" aria-label="accent color" value="#ccaa22"></label><br>
-    <button id="cc_save">Save</button>
-    <button id="cc_cancel">Cancel</button>
-  `;
+  form.innerHTML = `<h3>Custom Colors</h3>`;
+
+  const vars = {
+    '--bg-color': 'Background',
+    '--text-color': 'Text',
+    '--primary-color': 'Primary',
+    '--accent-color': 'Accent'
+  };
+  const groups = [];
+  const stored = JSON.parse(localStorage.getItem('ethicom_custom_theme') || '{}');
+  for(const [name,label] of Object.entries(vars)){
+    const base = parseCol(stored[name] || getComputedStyle(document.documentElement).getPropertyValue(name));
+    const wrap = document.createElement('div');
+    wrap.innerHTML = `<strong>${label}</strong><br>
+      <label>R: <input type="range" min="0" max="255" value="${base.r}"> <span>${base.r}</span></label><br>
+      <label>G: <input type="range" min="0" max="255" value="${base.g}"> <span>${base.g}</span></label><br>
+      <label>B: <input type="range" min="0" max="255" value="${base.b}"> <span>${base.b}</span></label>
+      <span class="color-preview"></span>`;
+    const inputs = wrap.querySelectorAll('input');
+    const spans = wrap.querySelectorAll('span');
+    const preview = wrap.querySelector('.color-preview');
+    function upd(){
+      const r=+inputs[0].value,g=+inputs[1].value,b=+inputs[2].value;
+      spans[0].textContent=r;spans[1].textContent=g;spans[2].textContent=b;
+      const col=`rgb(${r},${g},${b})`;
+      preview.style.backgroundColor=col;
+    }
+    inputs.forEach(i=>i.addEventListener('input',upd));
+    upd();
+    groups.push({name,getColor:()=>`rgb(${inputs[0].value},${inputs[1].value},${inputs[2].value})`});
+    form.appendChild(wrap);
+  }
+
+  const save = document.createElement('button');
+  save.id = 'cc_save';
+  save.textContent = 'Save';
+  const cancel = document.createElement('button');
+  cancel.id = 'cc_cancel';
+  cancel.textContent = 'Cancel';
+  form.appendChild(save);
+  form.appendChild(cancel);
   overlay.appendChild(form);
   document.body.appendChild(overlay);
 
-  document.getElementById('cc_cancel').addEventListener('click', () => overlay.remove());
-  document.getElementById('cc_save').addEventListener('click', () => {
-    const custom = {
-      '--bg-color': document.getElementById('cc_bg').value,
-      '--text-color': document.getElementById('cc_text').value,
-      '--primary-color': document.getElementById('cc_primary').value,
-      '--accent-color': document.getElementById('cc_accent').value
-    };
+  cancel.addEventListener('click', () => overlay.remove());
+  save.addEventListener('click', () => {
+    const custom = {};
+    groups.forEach(g=>custom[g.name]=g.getColor());
     localStorage.setItem('ethicom_custom_theme', JSON.stringify(custom));
     localStorage.setItem('ethicom_theme', 'custom');
     applyTheme('custom');


### PR DESCRIPTION
## Summary
- add parseCol helper to theme-manager
- implement RGB sliders with live preview when creating a custom theme

## Testing
- `node --test`
- `node tools/check-translations.js`
