### PR TITLE
Implement authenticator option

### DIFF
--- a/i18n/ui-text.json
+++ b/i18n/ui-text.json
@@ -25,6 +25,7 @@
     "signup_insecure_warn": "Insecure email host. Allowed only until OP-5.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup complete. ID stored.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -82,6 +83,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored.",
@@ -113,6 +115,7 @@
     "signup_insecure_warn": "Unsicherer E-Mail-Anbieter. Bis OP-5 zulässig.",
     "signup_pw_short": "Passwort muss mindestens 8 Zeichen haben.",
     "signup_saved": "Registrierung abgeschlossen. ID gespeichert.",
+    "signup_secret": "Authenticator-Schlüssel: {secret}",
     "help_title": "Hilfe – Operator-Verhalten",
     "help_items": [
       "Prüfe jederzeit, ob dein Handeln der Verantwortungsethik entspricht.",
@@ -170,6 +173,7 @@
     "login_title": "Anmeldung",
     "login_email": "E-Mail:",
     "login_password": "Passwort:",
+    "login_auth": "Authenticator-Code:",
     "login_btn": "Einloggen",
     "login_invalid": "Anmeldung fehlgeschlagen.",
     "login_saved": "Anmeldung erfolgreich. ID gespeichert."
@@ -200,6 +204,7 @@
     "signup_insecure_warn": "Hôte de courriel non sécurisé. Toléré jusqu'à OP-5.",
     "signup_pw_short": "Le mot de passe doit comporter au moins 8 caractères.",
     "signup_saved": "Informations d'inscription enregistrées localement.",
+    "signup_secret": "Authenticator secret: {secret}",
     "access_title": "Paramètres d'accessibilité",
     "access_label_vision": "Pouvez-vous voir l'écran ?",
     "access_label_hearing": "Pouvez-vous entendre depuis cet appareil ?",
@@ -257,6 +262,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored.",
@@ -293,6 +299,7 @@
     "signup_insecure_warn": "Proveedor de correo inseguro. Permitido solo hasta OP-5.",
     "signup_pw_short": "La contraseña debe tener al menos 8 caracteres.",
     "signup_saved": "Información de registro guardada localmente.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Ayuda – Conducta del Operador",
     "help_items": [
       "Comprueba siempre que tus acciones cumplan la ética de la responsabilidad.",
@@ -345,6 +352,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored.",
@@ -386,6 +394,7 @@
     "signup_insecure_warn": "Host de email inseguro. Permitido apenas até OP-5.",
     "signup_pw_short": "A senha deve ter no mínimo 8 caracteres.",
     "signup_saved": "Informações de cadastro salvas localmente.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Ajuda – Conduta do Operador",
     "help_items": [
       "Verifique sempre se suas ações seguem a ética da responsabilidade.",
@@ -433,6 +442,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -472,6 +482,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -520,6 +531,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored.",
@@ -550,6 +562,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -608,6 +621,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -637,6 +651,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -695,6 +710,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -724,6 +740,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -782,6 +799,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -811,6 +829,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -869,6 +888,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -898,6 +918,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -956,6 +977,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -996,6 +1018,7 @@
     "signup_insecure_warn": "Provider email non sicuro. Consentito solo fino a OP-5.",
     "signup_pw_short": "La password deve essere di almeno 8 caratteri.",
     "signup_saved": "Informazioni di registrazione salvate localmente.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Aiuto – Comportamento dell'Operatore",
     "help_items": [
       "Controlla sempre che le tue azioni rispettino l'etica della responsabilità.",
@@ -1043,6 +1066,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored.",
@@ -1073,6 +1097,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -1131,6 +1156,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -1160,6 +1186,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -1218,6 +1245,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -1247,6 +1275,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -1305,6 +1334,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -1334,6 +1364,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -1392,6 +1423,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -1421,6 +1453,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -1479,6 +1512,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -1508,6 +1542,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -1566,6 +1601,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -1595,6 +1631,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -1653,6 +1690,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -1682,6 +1720,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -1740,6 +1779,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -1769,6 +1809,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -1827,6 +1868,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -1856,6 +1898,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -1914,6 +1957,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -1943,6 +1987,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -2001,6 +2046,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -2030,6 +2076,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -2088,6 +2135,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -2117,6 +2165,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -2175,6 +2224,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -2204,6 +2254,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -2262,6 +2313,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -2291,6 +2343,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -2349,6 +2402,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -2378,6 +2432,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -2436,6 +2491,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored.",
@@ -2466,6 +2522,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -2524,6 +2581,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -2553,6 +2611,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -2611,6 +2670,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -2640,6 +2700,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -2698,6 +2759,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -2727,6 +2789,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -2785,6 +2848,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."
@@ -2814,6 +2878,7 @@
     "signup_unsupported": "Email provider not supported. Use a secure host.",
     "signup_pw_short": "Password must be at least 8 characters.",
     "signup_saved": "Signup information saved locally.",
+    "signup_secret": "Authenticator secret: {secret}",
     "help_title": "Help – Operator Conduct",
     "help_items": [
       "Always check if your actions meet the ethics of responsibility.",
@@ -2872,6 +2937,7 @@
     "login_title": "Login",
     "login_email": "Email:",
     "login_password": "Password:",
+    "login_auth": "Authenticator code:",
     "login_btn": "Log in",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored."

--- a/interface/login.html
+++ b/interface/login.html
@@ -47,6 +47,9 @@
     <label for="pw_input" data-ui="login_password">Password:</label>
     <input type="password" id="pw_input" placeholder="At least 8 characters" />
 
+    <label for="auth_input" data-ui="login_auth">Authenticator code:</label>
+    <input type="text" id="auth_input" placeholder="123456" inputmode="numeric" />
+
     <button id="login_btn" onclick="handleLogin()">Log in</button>
     <pre id="login_status" style="white-space:pre-wrap;margin-top:1em;"></pre>
   </main>

--- a/interface/login.js
+++ b/interface/login.js
@@ -9,6 +9,8 @@ function applyLoginTexts() {
   if (emailLabel) emailLabel.textContent = t.login_email || emailLabel.textContent;
   const pwLabel = document.querySelector('label[for="pw_input"]');
   if (pwLabel) pwLabel.textContent = t.login_password || pwLabel.textContent;
+  const authLabel = document.querySelector('label[for="auth_input"]');
+  if (authLabel) authLabel.textContent = t.login_auth || authLabel.textContent;
   const loginBtn = document.getElementById('login_btn');
   if (loginBtn) loginBtn.textContent = t.login_btn || loginBtn.textContent;
 }
@@ -26,9 +28,11 @@ function initLogin() {
 function handleLogin() {
   const emailInput = document.getElementById('email_input');
   const pwInput = document.getElementById('pw_input');
+  const authInput = document.getElementById('auth_input');
   const statusEl = document.getElementById('login_status');
   const email = emailInput.value.trim();
   const password = pwInput.value;
+  const auth = authInput.value.trim();
   statusEl.textContent = '';
 
   if (!/^[^@]+@[^@]+\.[^@]+$/.test(email)) {
@@ -39,7 +43,7 @@ function handleLogin() {
   fetch('api/login', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, password })
+    body: JSON.stringify({ email, password, auth_code: auth })
   })
     .then(r => {
       if (!r.ok) throw new Error('fail');

--- a/interface/signup.js
+++ b/interface/signup.js
@@ -73,8 +73,10 @@ function handleSignup() {
     .then(data => {
       const sig = { email, id: data.id, op_level: 'OP-1' };
       localStorage.setItem('ethicom_signature', JSON.stringify(sig));
-      statusEl.textContent = uiText.signup_saved || 'Signup complete. ID stored.';
-      setTimeout(() => { window.location.href = 'ethicom.html'; }, 500);
+      const msgSaved = uiText.signup_saved || 'Signup complete. ID stored.';
+      const msgSecret = (uiText.signup_secret || 'Authenticator secret: {secret}')
+        .replace('{secret}', data.secret);
+      statusEl.textContent = msgSaved + '\n' + msgSecret;
     })
     .catch(() => {
       statusEl.textContent = 'Signup failed.';


### PR DESCRIPTION
## Summary
- allow entering an authenticator code during login
- show authenticator secret on signup
- generate and verify TOTP codes in the server
- add translations for new login and signup text

## Testing
- `node --test`
- `node tools/check-translations.js`
