### PR TITLE
Implement private color storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 **Settings are stored per device using browser localStorage and are not synced globally.**
 **Ratings from OP-1 onward are stored globally with the assigned signature ID. The email used during signup is hashed and never exposed.**
 **Color verification of the chosen primary color starts once a user holds an OP-1 signature.**
+**From that level, the color choice is stored privately inside the user's signature and never shown publicly.**
 ### OP-Permissions [⇧](#contents)
 Operator actions by ethical level are defined in:
 → [`permissions/op-permissions-expanded.json`](permissions/op-permissions-expanded.json)

--- a/interface/color-auth.js
+++ b/interface/color-auth.js
@@ -158,7 +158,9 @@ function verifyColorAuth(locale) {
 
   localStorage.setItem('ethicom_color_time', String(now));
 
-  const stored = localStorage.getItem('ethicom_color');
+  const sig = JSON.parse(localStorage.getItem('ethicom_signature') || '{}');
+  const stored =
+    (sig.private && sig.private.color) || localStorage.getItem('ethicom_color');
   const colors = Object.keys(locale.map);
   const list = colors.join(', ');
   const question = stored
@@ -179,7 +181,10 @@ function verifyColorAuth(locale) {
       alert(locale.mismatch);
     }
   } else {
-    localStorage.setItem('ethicom_color', normalized);
+    if (!sig.private) sig.private = {};
+    sig.private.color = normalized;
+    localStorage.setItem('ethicom_signature', JSON.stringify(sig));
+    localStorage.removeItem('ethicom_color');
     alert(locale.saved.replace('{color}', normalized));
   }
 }


### PR DESCRIPTION
## Summary
- store chosen color inside the user's private signature
- clarify in README that the color choice remains private

## Testing
- `node --test`
- `node tools/check-translations.js`
