### PR TITLE
Reorder color sliders

### DIFF
--- a/interface/settings.html
+++ b/interface/settings.html
@@ -130,10 +130,10 @@
         const wrap=document.getElementById('color_scheme');
         if(!wrap) return;
         const vars={
-          '--bg-color':'Background','--text-color':'Text','--header-text-color':'Header Text',
-          '--nav-text-color':'Nav Text','--primary-color':'Primary','--card-bg':'Card',
+          '--highlight-text-color':'Highlight','--text-color':'Text','--header-text-color':'Header Text',
+          '--nav-text-color':'Nav Text','--bg-color':'Background','--card-bg':'Card',
           '--header-bg':'Header BG','--nav-bg':'Nav BG','--card-alpha-bg':'Card Alpha',
-          '--accent-color':'Accent','--highlight-text-color':'Highlight'
+          '--primary-color':'Primary','--accent-color':'Accent'
         };
         const textVars=new Set(['--text-color','--header-text-color','--nav-text-color','--highlight-text-color']);
         const stored=JSON.parse(localStorage.getItem('ethicom_colors')||'{}');


### PR DESCRIPTION
## Summary
- reorder color scheme variables so text colors come first, backgrounds next and the rest last

## Testing
- `node --test`
- `node tools/check-translations.js`
