### PR TITLE
Fix settings grid layout

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -224,8 +224,10 @@ details.card > *:not(summary) {
 /* Layout grid for settings */
 .settings-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  grid-auto-flow: row;
   gap: 1em;
+  align-content: start;
 }
 
 .swipe-card {


### PR DESCRIPTION
## Summary
- avoid card jumps when expanding settings by changing `.settings-grid` layout

## Testing
- `node --test`
- `node tools/check-translations.js`
