### PR TITLE
Remove violent comment phrasing and clarify canvas prereqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ Install the JavaScript dependencies once:
 npm install
 ```
 
+Some tools rely on the `canvas` package. On Linux, you may need system packages
+such as `libcairo2-dev` and `build-essential` to compile it.
+
 For optional Python utilities run:
 
 ```bash

--- a/ethics_modules/public_trust_i.md
+++ b/ethics_modules/public_trust_i.md
@@ -12,4 +12,4 @@
 ## Active: conditional
 Triggered when public trust or signature validation is necessary.
 
-> Shell-Kommentar: kill all show, show the kill, kill the unethic root
+> Shell-Kommentar: purge all noise, show the cleanup, remove unethical roots

--- a/tools/eptl.js
+++ b/tools/eptl.js
@@ -1,5 +1,5 @@
 // eptl.js – Bluetooth Trust Layer integration
-// Shell-Kommentar: kill all show, show the kill, kill the unethic root
+// Shell-Kommentar: purge all noise, show the cleanup, remove unethical roots
 
 function verifyHandshake(code) {
   if (typeof code !== 'string') return false;


### PR DESCRIPTION
## Summary
- clean up violent wording in `eptl.js` and `public_trust_i.md`
- document system packages for the `canvas` dependency

## Testing
- `node --test`
- `node tools/check-translations.js`
