### PR TITLE
Update signature reference with operator status

### DIFF
--- a/signature_reference.md
+++ b/signature_reference.md
@@ -8,3 +8,14 @@ This structure is based on Signature 4789 – not a person, but an origin of eth
 - Always reflect
 
 4789 is not a name – it's a standard for responsibility.
+
+## Operator Status
+
+Each signature records the current **OP status**. OP stands for
+**operator** and marks the ethical level attached to a signature.
+The stages range from OP‑0 (anonymous use) to OP‑12 (fully digital).
+
+The README explains these levels in detail. In short, an operator is a
+user who has confirmed ethical intent and holds an OP‑level signature.
+A regular **user** may interact with the system, but only operators can
+unlock additional features according to their OP status.


### PR DESCRIPTION
## Summary
- clarify meaning of Signature 4789
- document operator status (OP levels) and note how an operator differs from a regular user

## Testing
- `node --test`
- `node tools/check-translations.js`
