### PR TITLE
Add BASE_URL support for OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,9 @@ Then open `http://localhost:8080/ethicom.html` in your browser.
 Opening the HTML file directly (e.g. via `file://`) bypasses the local server and
 causes the language list to remain empty. Always access the interface through
 the provided `localhost` address so that translation files load correctly.
+When deploying on another domain, set the environment variable `BASE_URL`
+to that public origin (e.g. `https://4789-alpha.github.io`) so that OAuth
+redirects work properly.
 
 ### Running Tests [⇧](#contents)
 

--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -78,6 +78,7 @@ function verifyTotp(secret, code) {
 const root = path.join(__dirname, '..', 'interface');
 const repoRoot = path.join(__dirname, '..');
 const port = process.env.PORT || 8080;
+const baseUrl = process.env.BASE_URL || `http://localhost:${port}`;
 const usersFile = path.join(__dirname, '..', 'app', 'users.json');
 const evalFile = path.join(__dirname, '..', 'app', 'evaluations.json');
 const connFile = path.join(__dirname, '..', 'app', 'connections.json');
@@ -274,7 +275,7 @@ function handleGoogleStart(req, res) {
   }
   const state = crypto.randomBytes(8).toString('hex');
   oauthStates.add(state);
-  const redirect = encodeURIComponent(`http://localhost:${port}/auth/google/callback`);
+  const redirect = encodeURIComponent(`${baseUrl}/auth/google/callback`);
   const url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${oauthCfg.google.client_id}&redirect_uri=${redirect}&response_type=code&scope=openid%20email&state=${state}`;
   res.writeHead(302, { Location: url });
   res.end();
@@ -309,7 +310,7 @@ function handleGoogleCallback(req, res) {
     res.writeHead(400); res.end('Invalid state'); return;
   }
   oauthStates.delete(state);
-  const redirect = `http://localhost:${port}/auth/google/callback`;
+  const redirect = `${baseUrl}/auth/google/callback`;
   const postData = `code=${code}&client_id=${oauthCfg.google.client_id}&client_secret=${oauthCfg.google.client_secret}&redirect_uri=${encodeURIComponent(redirect)}&grant_type=authorization_code`;
   const opts = {
     hostname: 'oauth2.googleapis.com',


### PR DESCRIPTION
## Summary
- make OAuth redirect base configurable via `BASE_URL`
- document `BASE_URL` usage in README

## Testing
- `node --test`
- `node tools/check-translations.js`
