### PR TITLE
Add doc for alphabetical sublevels

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ OP-9.A is reserved for the original programmer and is no longer awarded.
 New sublevels begin alphabetically with OP-9.B. Only OP-9.A currently
 holds a veto right. Further veto rights are planned when the system is
 secure.
+Each letter can define specialized tasks; see
+[`operator/alphabetical_sublevels.md`](operator/alphabetical_sublevels.md).
+If no sublevel is specified, permissions fall back to the base level.
 
 Only digital agents can advance beyond OP-9.
 Sublevels like OP-5.U, OP-7.U, OP-8.M, and OP-9.M specify user or medical access. Additional expert categories (.T, .S[y], .L, .U) are listed in `operator/expert_classes.md`. See `permissions/op-permissions-expanded.json` for details.

--- a/operator/alphabetical_sublevels.md
+++ b/operator/alphabetical_sublevels.md
@@ -1,0 +1,9 @@
+# Alphabetical Sublevels
+
+Operator levels can include alphabetical subdivisions (e.g., OP-9.B, OP-9.C) for
+specialized tasks. Only **OP-9.A** is explicitly defined and reserved for the
+original developer with a veto right. New letters may describe further duties as
+the structure grows.
+
+If a signature exists but no sublevel is specified, permissions fall back to the
+base level—new registrations default to **OP-1**.

--- a/operator/operator_levels.md
+++ b/operator/operator_levels.md
@@ -21,6 +21,9 @@
 Additional OP-9 sublevels may be created, starting with **OP-9.B**. Expert
 categories such as `.T` for translator or `.S[y]` for scientific fields are
 listed in [expert_classes.md](expert_classes.md).
+Each alphabetical sublevel can specify duties and rights; see
+[alphabetical_sublevels.md](alphabetical_sublevels.md). Without a sublevel,
+permissions default to the base OP level.
 
 Upward movement is not based on knowledge, but on structural consistency and ethical presence.
 

--- a/signaturdesign.md
+++ b/signaturdesign.md
@@ -12,6 +12,9 @@ Formel:
 Array-Anzahl = OP-Stufe + 1
 ```
 
+Fehlt eine spezifizierte Unterstufe (etwa "B" oder "C"), gilt die
+Grundstufe. Neue Anmeldungen beginnen daher mit OP‑1.
+
 Beispiel: Für OP-9 (Signatur 4789) sind zehn verschachtelte Arrays erforderlich. Die Struktur sähe vereinfacht so aus:
 
 ```


### PR DESCRIPTION
## Summary
- document default for unspecified sublevels
- note alphabetical sublevels in operator levels and README
- add short clarification in signaturdesign

## Testing
- `node --test`
- `node tools/check-translations.js`
