### PR TITLE
Add dynamic tanna density setting

### DIFF
--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -77,9 +77,13 @@ function initLogoBackground() {
   });
 
   const symbols = [];
-  // Number of floating symbols can be customized via settings
-  const stored = parseInt(localStorage.getItem('ethicom_bg_count') || '40', 10);
-  const total = Number.isFinite(stored) ? stored : 40;
+  // Density of floating symbols can be customized via settings
+  const storedPct = parseInt(localStorage.getItem('ethicom_bg_fill') || '40', 10);
+  const fillRatio = Number.isFinite(storedPct) ? storedPct / 100 : 0.4;
+  const avgSize = levels.reduce((sum, lvl) => sum + 30 + lvl * 10 + 5, 0) / levels.length;
+  const avgArea = avgSize * avgSize;
+  const maxSymbols = Math.floor(canvas.width * canvas.height / avgArea);
+  const total = Math.max(20, Math.floor(maxSymbols * fillRatio));
   const collisionsEnabled = localStorage.getItem('ethicom_bg_collisions') !== '0';
   for (let i = 0; i < total; i++) {
     const lvl = levels[i % levels.length];

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -57,8 +57,8 @@
       <summary>Background</summary>
       <div id="background_settings">
         <div id="background_count">
-          <label for="bg_symbol_count">Tanna symbols in background: <span id="bg_symbol_count_val">40</span></label>
-          <input type="range" id="bg_symbol_count" min="10" max="400" step="10" value="40" />
+          <label for="bg_fill_ratio">Tanna background fill: <span id="bg_fill_ratio_val">40</span>%</label>
+          <input type="range" id="bg_fill_ratio" min="20" max="99" step="1" value="40" />
         </div>
         <div id="same_level_count" style="display:none;">
           <label for="bg_same_level_count">Your level Tannas: <span id="bg_same_level_val">1</span></label>
@@ -220,15 +220,15 @@
       }
       if(tr&&tg&&tb){const s=JSON.parse(localStorage.getItem('ethicom_tanna_color')||'{"r":34,"g":139,"b":34}');tr.value=s.r;tg.value=s.g;tb.value=s.b;upd();[tr,tg,tb].forEach(el=>el.addEventListener('input',upd));}
 
-      const slider = document.getElementById('bg_symbol_count');
-      const val = document.getElementById('bg_symbol_count_val');
+      const slider = document.getElementById('bg_fill_ratio');
+      const val = document.getElementById('bg_fill_ratio_val');
       if (slider && val) {
-        const stored = parseInt(localStorage.getItem('ethicom_bg_count') || '40', 10);
+        const stored = parseInt(localStorage.getItem('ethicom_bg_fill') || '40', 10);
         slider.value = stored;
         val.textContent = stored;
         slider.addEventListener('input', e => val.textContent = e.target.value);
         slider.addEventListener('change', e => {
-          localStorage.setItem('ethicom_bg_count', e.target.value);
+          localStorage.setItem('ethicom_bg_fill', e.target.value);
           alert('Reload the page to apply.');
         });
       }

--- a/interface_OLD/settings.html
+++ b/interface_OLD/settings.html
@@ -59,8 +59,8 @@
       <button id="custom_theme_btn" style="display:none;margin-top:0.5em;" class="accent-button">Create Custom Scheme</button>
     </div>
     <div id="background_count" class="card">
-      <label for="bg_symbol_count">Tanna symbols in background: <span id="bg_symbol_count_val">40</span></label>
-      <input type="range" id="bg_symbol_count" min="10" max="400" step="10" value="40"/>
+      <label for="bg_fill_ratio">Tanna background fill: <span id="bg_fill_ratio_val">40</span>%</label>
+      <input type="range" id="bg_fill_ratio" min="20" max="99" step="1" value="40"/>
     </div>
     <div id="touch_features" class="card">
       <h3 data-ui="touch_settings_title">Touch Features</h3>
@@ -121,17 +121,17 @@
       if (aw) aw.addEventListener('change', e => attentionSettings.toggleWiggle(e.target.checked));
       if (ab) ab.addEventListener('change', e => attentionSettings.toggleBeep(e.target.checked));
 
-      const countSlider = document.getElementById('bg_symbol_count');
-      const countVal = document.getElementById('bg_symbol_count_val');
+      const countSlider = document.getElementById('bg_fill_ratio');
+      const countVal = document.getElementById('bg_fill_ratio_val');
       if (countSlider && countVal) {
-        const stored = parseInt(localStorage.getItem('ethicom_bg_count') || '40', 10);
+        const stored = parseInt(localStorage.getItem('ethicom_bg_fill') || '40', 10);
         countSlider.value = stored;
         countVal.textContent = stored;
         countSlider.addEventListener('input', e => {
           countVal.textContent = e.target.value;
         });
         countSlider.addEventListener('change', e => {
-          localStorage.setItem('ethicom_bg_count', e.target.value);
+          localStorage.setItem('ethicom_bg_fill', e.target.value);
           alert('Reload the page to apply.');
         });
       }


### PR DESCRIPTION
## Summary
- update logo background generator to use density setting
- rename BG slider to `bg_fill_ratio` for percent control
- mirror updates in old settings page

## Testing
- `node --test`
- `node tools/check-translations.js`
