### PR TITLE
Limit UI opacity

### DIFF
--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -1,11 +1,12 @@
 
 // ethicom-utils.js – Hilfsfunktionen für Interface-Anzeige
 (function() {
+  const FG_OPACITY_MAX = 80;
   function setForegroundOpacity(percent) {
     let p = parseInt(percent, 10);
     if (isNaN(p)) p = 0;
     if (p < 0) p = 0;
-    if (p > 100) p = 100;
+    if (p > FG_OPACITY_MAX) p = FG_OPACITY_MAX;
     document.documentElement.style.setProperty('--foreground-opacity', (p / 100).toString());
   }
   function applyTextColor(obj) {
@@ -16,7 +17,8 @@
   window.setForegroundOpacity = setForegroundOpacity;
   window.applyTextColor = applyTextColor;
   document.addEventListener('DOMContentLoaded', () => {
-    const stored = parseInt(localStorage.getItem('ethicom_fg_opacity') || '0', 10);
+    let stored = parseInt(localStorage.getItem('ethicom_fg_opacity') || '0', 10);
+    if (stored > FG_OPACITY_MAX) stored = FG_OPACITY_MAX;
     setForegroundOpacity(stored);
     try {
       const tc = JSON.parse(localStorage.getItem('ethicom_text_color') || 'null');

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -86,7 +86,7 @@
       <summary>Foreground Transparency</summary>
       <div id="foreground_opacity">
         <label for="fg_opacity">Foreground transparency: <span id="fg_opacity_val">0</span>%</label>
-        <input type="range" id="fg_opacity" min="0" max="100" step="1" value="0" />
+        <input type="range" id="fg_opacity" min="0" max="80" step="1" value="0" />
       </div>
     </details>
     <details class="card">
@@ -296,7 +296,8 @@
       const fgSlider = document.getElementById('fg_opacity');
       const fgVal = document.getElementById('fg_opacity_val');
       if (fgSlider && fgVal) {
-        const storedFg = parseInt(localStorage.getItem('ethicom_fg_opacity') || '0', 10);
+        let storedFg = parseInt(localStorage.getItem('ethicom_fg_opacity') || '0', 10);
+        if (storedFg > 80) storedFg = 80;
         fgSlider.value = storedFg;
         fgVal.textContent = storedFg;
         fgSlider.addEventListener('input', e => {


### PR DESCRIPTION
## Summary
- restrict foreground transparency setting to 80%

## Testing
- `node --test`
- `node tools/check-translations.js`
