### PR TITLE
Limit foreground overlay to 65

### DIFF
--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -1,7 +1,7 @@
 
 // ethicom-utils.js – Hilfsfunktionen für Interface-Anzeige
 (function() {
-  const FG_OPACITY_MAX = 80;
+  const FG_OPACITY_MAX = 65;
   function setForegroundOpacity(percent) {
     let p = parseInt(percent, 10);
     if (isNaN(p)) p = 0;


### PR DESCRIPTION
## Summary
- cap foreground opacity at 65 so the Tanna theme remains visible

## Testing
- `node --test`
- `node tools/check-translations.js`
