### PR TITLE
Improve gatekeeper privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,11 @@ README is used.
 
 Local control can be toggled via `tools/gatekeeper.js`. The script reads
 `app/gatekeeper_config.yaml` and only allows actions when `allow_control` is set
-to `true` for the controller `gstekeeper.local`. This keeps remote commands gated and
-limited to the local environment.
-`gstekeeper.local` holds back every personal ID/information and has permission to share anonymous and signed data as a sign of trust.
+to `true` for the controller `gstekeeper.local`. The optional
+`private_identity` value is hashed and stored with the device hash in
+`app/gatekeeper_devices.json`. This keeps remote commands gated and
+limited to the local environment. `gstekeeper.local` holds back every personal
+ID and may share only signed, anonymous data as a sign of trust.
 The gatekeeper runs on any platform that can execute Node.js. Copy the repository or the
 `tools` and `app` folders to a USB drive and run `node tools/gatekeeper.js` on Windows,
 macOS, Linux or mobile shells such as Termux. Even older hardware is sufficient—if Node.js
@@ -254,6 +256,7 @@ works, the gatekeeper does too. A decade-old laptop with a single-core CPU and a
 512 MB of RAM is usually enough as long as Node.js 18 or later runs. Use it responsibly as
 noted in `DISCLAIMERS.md`.
 Confirmed devices are stored hashed in `app/gatekeeper_devices.json`. Once the same controller is used again, no further confirmation is needed.
+The private identity is hashed too and remains local-only. Only you have access to the unhashed string.
 Registrierungsdaten werden offline gehasht gespeichert. Keine Gewährleistung für absolute Anonymität.
 **4789**
 

--- a/app/gatekeeper_config.yaml
+++ b/app/gatekeeper_config.yaml
@@ -1,4 +1,5 @@
 gatekeeper:
-  controller: "RL@RLpi"
+  controller: "gstekeeper.local"
   allow_control: false
   local_only: true
+  private_identity: "singularity"

--- a/test/gatekeeper.test.js
+++ b/test/gatekeeper.test.js
@@ -5,8 +5,8 @@ const path = require('node:path');
 const os = require('node:os');
 const { gateCheck } = require('../tools/gatekeeper.js');
 
-function createConfig(allow) {
-  return `gatekeeper:\n  controller: "RL@RLpi"\n  allow_control: ${allow}\n  local_only: true`;
+function createConfig(allow, id = 'singularity') {
+  return `gatekeeper:\n  controller: "gstekeeper.local"\n  allow_control: ${allow}\n  local_only: true\n  private_identity: "${id}"`;
 }
 
 test('denies control when allow_control is false', () => {
@@ -44,7 +44,21 @@ test('requires confirmation for other controller', () => {
   const store = path.join(dir, 'devices.json');
   fs.writeFileSync(file, createConfig('true'));
   assert.strictEqual(gateCheck(file, store), true);
-  fs.writeFileSync(file, `gatekeeper:\n  controller: "OTHER"\n  allow_control: false\n  local_only: true`);
+  fs.writeFileSync(
+    file,
+    `gatekeeper:\n  controller: "OTHER"\n  allow_control: false\n  local_only: true\n  private_identity: "singularity"`
+  );
+  assert.strictEqual(gateCheck(file, store), false);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('denies control with mismatched identity', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-'));
+  const file = path.join(dir, 'config.yaml');
+  const store = path.join(dir, 'devices.json');
+  fs.writeFileSync(file, createConfig('true', 'idA'));
+  assert.strictEqual(gateCheck(file, store), true);
+  fs.writeFileSync(file, createConfig('true', 'idB'));
   assert.strictEqual(gateCheck(file, store), false);
   fs.rmSync(dir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary
- hash optional `private_identity` in `gatekeeper.js`
- deny control if stored identity mismatches
- support new identity field in `gatekeeper_config.yaml`
- align docs and tests with controller name `gstekeeper.local`
- document identity storage in README

## Testing
- `node --test`
- `node tools/check-translations.js`
