### PR TITLE
Implement color settings pop‑in

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -13,6 +13,7 @@
   --nav-bg: rgba(51, 51, 51, 0.9);
   --card-alpha-bg: rgba(43, 43, 43, 0.92);
   --accent-color: #ccaa22;
+  --module-color: #228B22;
   --highlight-text-color: var(--accent-color);
   --foreground-opacity: 0;
 }
@@ -29,6 +30,7 @@
   --nav-bg: rgba(51, 51, 51, 0.9);
   --card-alpha-bg: rgba(43, 43, 43, 0.92);
   --accent-color: #ccaa22;
+  --module-color: #228B22;
   --foreground-opacity: 0;
 }
 
@@ -43,6 +45,7 @@
   --nav-bg: rgba(51, 51, 51, 0.9);
   --card-alpha-bg: rgba(255, 255, 255, 0.92);
   --accent-color: #228B22;
+  --module-color: #228B22;
 }
 
 /* Higher contrast variants for the Tanna look */
@@ -57,6 +60,7 @@
   --nav-bg: rgba(0, 0, 0, 0.85);
   --card-alpha-bg: rgba(34, 34, 34, 0.9);
   --accent-color: #33cc33;
+  --module-color: #228B22;
   --foreground-opacity: 0;
 }
 
@@ -71,6 +75,7 @@
   --nav-bg: rgba(34, 34, 34, 0.95);
   --card-alpha-bg: rgba(255, 255, 255, 0.95);
   --accent-color: #228B22;
+  --module-color: #228B22;
 }
 
 .theme-ocean {
@@ -84,6 +89,7 @@
   --nav-bg: rgba(0, 85, 119, 0.9);
   --card-alpha-bg: rgba(255, 255, 255, 0.95);
   --accent-color: #0099cc;
+  --module-color: #0077aa;
 }
 
 .theme-desert {
@@ -97,6 +103,7 @@
   --nav-bg: rgba(153, 102, 0, 0.9);
   --card-alpha-bg: rgba(255, 255, 255, 0.95);
   --accent-color: #e6b800;
+  --module-color: #cc9900;
 }
 
 .theme-transparent {
@@ -110,6 +117,7 @@
   --nav-bg: rgba(51, 51, 51, 0.7);
   --card-alpha-bg: rgba(43, 43, 43, 0.75);
   --accent-color: #ccaa22;
+  --module-color: #228B22;
 }
 
 .theme-custom {
@@ -228,6 +236,12 @@ details.card > *:not(summary) {
   grid-auto-flow: row;
   gap: 1em;
   align-content: start;
+}
+
+.module {
+  background-color: var(--module-color);
+  color: var(--text-color);
+  padding: 1em;
 }
 
 .swipe-card {

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -44,17 +44,7 @@
       </div>
     </details>
     <!-- Theme selection removed -->
-    <details class="card">
-      <summary>Colors</summary>
-      <div id="color_scheme"></div>
-      <div id="tanna_color" style="display:none;">
-        <label>R: <input type="range" id="tanna_r" min="0" max="255" value="34"/> <span id="tanna_r_val">34</span></label><br/>
-        <label>G: <input type="range" id="tanna_g" min="0" max="255" value="139"/> <span id="tanna_g_val">139</span></label><br/>
-        <label>B: <input type="range" id="tanna_b" min="0" max="255" value="34"/> <span id="tanna_b_val">34</span></label>
-        <span id="tanna_preview" class="color-preview"></span><br/>
-        <span id="tanna_contrast" style="color:red;display:none;">Low contrast with logos</span>
-      </div>
-    </details>
+    <button id="color_settings_btn" class="accent-button" type="button" onclick="openColorSettingsPopin()">Color Settings</button>
     <details class="card">
       <summary>Background</summary>
       <div id="background_settings">
@@ -72,15 +62,6 @@
           <label><input type="checkbox" id="bg_enable_collisions" checked/> Enable Tanna collisions</label>
             <small class="note">Reload to apply.</small>
         </div>
-      </div>
-    </details>
-    <details class="card">
-      <summary>Content Text Color</summary>
-      <div id="text_color">
-        <label>R: <input type="range" id="text_r" min="0" max="255" value="0"/> <span id="text_r_val">0</span></label><br/>
-        <label>G: <input type="range" id="text_g" min="0" max="255" value="0"/> <span id="text_g_val">0</span></label><br/>
-        <label>B: <input type="range" id="text_b" min="0" max="255" value="0"/> <span id="text_b_val">0</span></label>
-        <span id="text_preview" class="color-preview"></span>
       </div>
     </details>
     <details class="card">


### PR DESCRIPTION
## Summary
- add `openColorSettingsPopin` in `theme-manager.js`
- replace inline color controls with **Color Settings** button in `settings.html`
- introduce `--module-color` CSS variable and `.module` style

## Testing
- `node --test`
- `node tools/check-translations.js`
