### PR TITLE
Add temporary gatekeeper tokens

### DIFF
--- a/DISCLAIMERS.md
+++ b/DISCLAIMERS.md
@@ -8,6 +8,7 @@
 - Humor ist zulässig, sofern Verantwortung und Klarheit gewahrt bleiben.
 - Registrierungsdaten werden offline gehasht gespeichert. Keine Gewährleistung für absolute Anonymität.
 - Gerätedaten werden ebenfalls offline gehasht gespeichert.
+- Temporäre Gatekeeper-Tokens werden ebenfalls gehasht gespeichert.
 - Beim optionalen GitHub-Login erfolgt die Anmeldung über GitHub. Der zurückgegebene Benutzername wird offline gehasht gespeichert.
 - Beim optionalen Google-Login erfolgt die Anmeldung über Google. Die zurückgegebene E-Mail-Adresse wird offline gehasht gespeichert.
 - Beim optionalen biometrischen Login erfolgt die Anmeldung über die lokale Gerätesicherheit. Biometrische Merkmale werden nicht zentral gespeichert.

--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ works, the gatekeeper does too. A decade-old laptop with a single-core CPU and a
 noted in `DISCLAIMERS.md`.
 Confirmed devices are stored hashed in `app/gatekeeper_devices.json`. Once the same controller is used again, no further confirmation is needed.
 The private identity is hashed too and remains local-only. Only you have access to the unhashed string.
+Temporary tokens can be issued with `node tools/gatekeeper.js token` and expire after the configured duration.
+Tokens and device hashes are stored hashed in `app/gatekeeper_devices.json`.
 Registrierungsdaten werden offline gehasht gespeichert. Keine Gewährleistung für absolute Anonymität.
 **4789**
 

--- a/app/gatekeeper_config.yaml
+++ b/app/gatekeeper_config.yaml
@@ -3,3 +3,6 @@ gatekeeper:
   allow_control: false
   local_only: true
   private_identity: "singularity"
+  temp_token_duration: 86400 # seconds
+  authorized_temp:
+    - example_phone

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -17,6 +17,7 @@
   <script src="side-drop.js"></script>
   <script src="op-side-nav.js"></script>
   <script src="ethicom-interface.js"></script>
+  <script src="gatekeeper-temp.js"></script>
   <script src="module-logo.js"></script>
 </head>
 <body>
@@ -57,6 +58,7 @@
         <li>4789 ist ein Standard für Verantwortung, keine Person.</li>
         <li>Nutzung nur reflektiert und mit Konsequenz.</li>
       </ul>
+      <div id="temp_warning" class="note" style="display:none"></div>
     </section>
   </main>
   <script>

--- a/interface/gatekeeper-temp.js
+++ b/interface/gatekeeper-temp.js
@@ -1,0 +1,17 @@
+(function() {
+  function checkToken() {
+    const data = JSON.parse(localStorage.getItem('gate_temp_token') || 'null');
+    if (!data) return;
+    const now = Date.now();
+    const warn = document.getElementById('temp_warning');
+    if (data.expires && data.expires - now < 3600 * 1000 && warn) {
+      warn.textContent = 'Gatekeeper token expires soon';
+      warn.style.display = 'block';
+    }
+    if (data.expires && data.expires <= now) {
+      localStorage.removeItem('gate_temp_token');
+      if (warn) warn.style.display = 'none';
+    }
+  }
+  document.addEventListener('DOMContentLoaded', checkToken);
+})();

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -98,6 +98,11 @@
         <a href="/download.zip" class="accent-button">Download .zip</a>
       </div>
     </details>
+    <details class="card">
+      <summary>Gatekeeper Token</summary>
+      <button id="token_btn" class="accent-button" type="button">Generate Token</button>
+      <p id="token_display" class="note"></p>
+    </details>
     </div><!-- settings-grid -->
   </main>
   <script>
@@ -288,6 +293,19 @@
         });
         fgSlider.addEventListener('change', e => {
           localStorage.setItem('ethicom_fg_opacity', e.target.value);
+        });
+      }
+
+      const tokenBtn = document.getElementById('token_btn');
+      const tokenDisplay = document.getElementById('token_display');
+      if (tokenBtn && tokenDisplay) {
+        tokenBtn.addEventListener('click', () => {
+          fetch('/api/gatekeeper/token')
+            .then(r => r.json())
+            .then(d => {
+              tokenDisplay.textContent = d.token;
+              localStorage.setItem('gate_temp_token', JSON.stringify({ token: d.token, expires: Date.now() + d.expires_in * 1000 }));
+            });
         });
       }
     });

--- a/tools/gatekeeper.js
+++ b/tools/gatekeeper.js
@@ -9,11 +9,27 @@ function parseConfig(filePath) {
     return null;
   }
   const lines = fs.readFileSync(configPath, 'utf8').split(/\r?\n/);
-  const cfg = {};
+  const cfg = { authorized_temp: [] };
+  let inList = false;
   lines.forEach(line => {
-    const m = line.trim().match(/^(controller|allow_control|local_only|private_identity):\s*(.*)$/);
+    const trimmed = line.trim();
+    if (inList) {
+      const m = trimmed.match(/^-(.*)$/);
+      if (m) {
+        cfg.authorized_temp.push(m[1].trim().replace(/['"]/g, ''));
+        return;
+      }
+      inList = false;
+    }
+    const m = trimmed.match(/^(controller|allow_control|local_only|private_identity|temp_token_duration):\s*(.*)$/);
     if (m) {
       cfg[m[1]] = m[2].replace(/['"]/g, '');
+      return;
+    }
+    if (trimmed.startsWith('authorized_temp:')) {
+      const val = trimmed.split(':')[1].trim();
+      if (val) cfg.authorized_temp.push(val.replace(/['"]/g, ''));
+      inList = true;
     }
   });
   return cfg;
@@ -58,7 +74,7 @@ function rememberDevice(controller, storePath, idHash) {
   const hash = deviceHash();
   const devices = readDevices(storePath);
   if (!devices[controller]) {
-    devices[controller] = { identity: idHash || null, devices: [] };
+    devices[controller] = { identity: idHash || null, devices: [], tokens: {} };
   }
   if (idHash) devices[controller].identity = idHash;
   const list = devices[controller].devices;
@@ -69,7 +85,35 @@ function rememberDevice(controller, storePath, idHash) {
   }
 }
 
-function gateCheck(configPath, devicesPath) {
+function issueTempToken(controller, storePath, idHash, durationSec) {
+  const token = crypto.randomBytes(16).toString('hex');
+  const hash = crypto.createHash('sha256').update(token).digest('hex');
+  const exp = Date.now() + (durationSec || 86400) * 1000;
+  const devices = readDevices(storePath);
+  if (!devices[controller]) {
+    devices[controller] = { identity: idHash || null, devices: [], tokens: {} };
+  }
+  if (!devices[controller].tokens) devices[controller].tokens = {};
+  devices[controller].tokens[hash] = exp;
+  writeDevices(devices, storePath);
+  return token;
+}
+
+function verifyTempToken(controller, storePath, token) {
+  const hash = crypto.createHash('sha256').update(String(token)).digest('hex');
+  const devices = readDevices(storePath);
+  const entry = devices[controller];
+  if (!entry || !entry.tokens) return false;
+  const now = Date.now();
+  for (const [h, exp] of Object.entries(entry.tokens)) {
+    if (exp < now) delete entry.tokens[h];
+  }
+  writeDevices(devices, storePath);
+  const exp = entry.tokens[hash];
+  return !!(exp && exp > now);
+}
+
+function gateCheck(configPath, devicesPath, tempToken) {
   const cfg = parseConfig(configPath);
   if (!cfg) {
     console.log('Gatekeeper: configuration missing.');
@@ -88,6 +132,11 @@ function gateCheck(configPath, devicesPath) {
     return true;
   }
 
+  if (tempToken && verifyTempToken(cfg.controller, deviceFile, tempToken)) {
+    rememberDevice(cfg.controller, deviceFile, idHash);
+    return true;
+  }
+
   const allowed = cfg.allow_control === 'true';
   const result = allowed && controllerOK && local;
 
@@ -99,13 +148,24 @@ function gateCheck(configPath, devicesPath) {
 }
 
 if (require.main === module) {
-  if (gateCheck()) {
-    console.log('Gatekeeper: gstekeeper.local control allowed (local only).');
-    process.exit(0);
+  const cmd = process.argv[2];
+  const cfgPath = path.join(__dirname, '..', 'app', 'gatekeeper_config.yaml');
+  const storePath = path.join(__dirname, '..', 'app', 'gatekeeper_devices.json');
+  const cfg = parseConfig(cfgPath) || {};
+  const idHash = identityHash(cfg.private_identity);
+  if (cmd === 'token') {
+    const dur = parseInt(cfg.temp_token_duration || '86400', 10);
+    const tok = issueTempToken(cfg.controller || 'gstekeeper.local', storePath, idHash, dur);
+    console.log(tok);
   } else {
-    console.log('Gatekeeper: control denied.');
-    process.exit(1);
+    if (gateCheck(cfgPath, storePath, cmd)) {
+      console.log('Gatekeeper: gstekeeper.local control allowed (local only).');
+      process.exit(0);
+    } else {
+      console.log('Gatekeeper: control denied.');
+      process.exit(1);
+    }
   }
 }
 
-module.exports = { gateCheck };
+module.exports = { gateCheck, issueTempToken, verifyTempToken, parseConfig };


### PR DESCRIPTION
## Summary
- configure temp gatekeepers
- store hashed temp tokens in gatekeeper_devices
- allow issuing/verifying temp tokens
- generate tokens via serve-interface
- warn about expiring tokens in the web UI
- document new token flow and add disclaimer
- test token creation and expiry

## Testing
- `node --test`
- `node tools/check-translations.js`
