### PR TITLE
Add offline setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,14 @@ When deploying on another domain, set the environment variable `BASE_URL`
 to that public origin (e.g. `https://4789-alpha.github.io`) so that OAuth
 redirects work properly.
 
+### Optional Setup Helper
+[⇧](#contents)
+
+Run `python3 install.py` and follow the prompts to update `app/app_settings.yaml`.
+The script lets you configure the default interface language, offline mode and
+the port used by `tools/serve-interface.js`. All values are stored locally so
+the helper works without network access.
+
 ### Running Tests
 [⇧](#contents)
 

--- a/app/app_settings.yaml
+++ b/app/app_settings.yaml
@@ -6,4 +6,5 @@ app:
   feedback_enabled: true
   startup_op_level: 0
   theme: "dark"
+  interface_port: 8080
   auto_update_check: false

--- a/install.py
+++ b/install.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Offline setup helper for the 4789 interface."""
+import os
+import re
+
+SETTINGS_FILE = os.path.join('app', 'app_settings.yaml')
+
+
+def prompt(msg, default=None):
+    if default is not None:
+        msg = f"{msg} [{default}] "
+    else:
+        msg = f"{msg} "
+    ans = input(msg).strip()
+    return ans if ans else default
+
+
+def read_current(key, default):
+    if not os.path.exists(SETTINGS_FILE):
+        return default
+    with open(SETTINGS_FILE, 'r', encoding='utf-8') as f:
+        data = f.read()
+    m = re.search(rf"{re.escape(key)}:\s*([^\n]+)", data)
+    if m:
+        val = m.group(1).strip().strip('"')
+        return val
+    return default
+
+
+def is_simple(value: str) -> bool:
+    return value.lower() in {"true", "false"} or value.isdigit()
+
+
+def update_yaml_value(key, value):
+    if value is None:
+        return
+    lines = []
+    found = False
+    if os.path.exists(SETTINGS_FILE):
+        with open(SETTINGS_FILE, 'r', encoding='utf-8') as f:
+            lines = f.read().splitlines()
+    for i, line in enumerate(lines):
+        if line.strip().startswith(f"{key}:"):
+            indent = line[: len(line) - len(line.lstrip())]
+            val = value if is_simple(value) else f'"{value}"'
+            lines[i] = f"{indent}{key}: {val}"
+            found = True
+            break
+    if not found:
+        val = value if is_simple(value) else f'"{value}"'
+        if not any(l.strip().startswith('app:') for l in lines):
+            lines.insert(0, 'app:')
+        lines.append(f"  {key}: {val}")
+    with open(SETTINGS_FILE, 'w', encoding='utf-8') as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def main():
+    lang = prompt("Default interface language", read_current("default_language", "auto"))
+    port = prompt("Interface port", read_current("interface_port", "8080"))
+    offline = prompt("Offline mode (true/false)", read_current("offline_mode", "true"))
+    update_yaml_value("default_language", lang)
+    update_yaml_value("interface_port", port)
+    update_yaml_value("offline_mode", offline)
+    print(f"Updated {SETTINGS_FILE}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `install.py` for optional configuration
- support new `interface_port` in `app/app_settings.yaml`
- document the setup helper in `README.md`

## Testing
- `node --test`
- `node tools/check-translations.js`
