### PR TITLE
Add config.json and use in scripts

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,0 +1,16 @@
+# Configuration Overview
+
+The optional `config.json` in the project root bundles default paths and
+server settings used by the local tooling.  Values can be overridden by
+environment variables where applicable.
+
+| Field | Default | Description |
+|------|---------|-------------|
+| `port` | `8080` | Local port used by `tools/serve-interface.js`. Can be overridden via `PORT` env variable. |
+| `baseUrl` | `http://localhost:8080` | Base URL for OAuth callbacks and links. Overridden via `BASE_URL` env variable. |
+| `paths.users` | `app/users.json` | Storage for created user accounts. |
+| `paths.evaluations` | `app/evaluations.json` | Storage for submitted evaluations. |
+| `paths.connections` | `app/connections.json` | Storage for connection requests. |
+| `paths.oauthConfig` | `app/oauth_config.yaml` | OAuth client configuration file. |
+| `paths.gatekeeperConfig` | `app/gatekeeper_config.yaml` | Gatekeeper policy configuration. |
+| `paths.gatekeeperDevices` | `app/gatekeeper_devices.json` | Persistence for recognized devices and tokens. |

--- a/config.json
+++ b/config.json
@@ -1,0 +1,12 @@
+{
+  "port": 8080,
+  "baseUrl": "http://localhost:8080",
+  "paths": {
+    "users": "app/users.json",
+    "evaluations": "app/evaluations.json",
+    "connections": "app/connections.json",
+    "oauthConfig": "app/oauth_config.yaml",
+    "gatekeeperConfig": "app/gatekeeper_config.yaml",
+    "gatekeeperDevices": "app/gatekeeper_devices.json"
+  }
+}

--- a/interface/ratings.js
+++ b/interface/ratings.js
@@ -1,6 +1,16 @@
 // ratings.js - display overall ratings and rating history
 
+async function loadConfig() {
+  try {
+    return await fetch('../config.json').then(r => r.json());
+  } catch {
+    return {};
+  }
+}
+
 async function initRatings() {
+  const cfg = await loadConfig();
+  const baseUrl = (cfg && cfg.baseUrl) || 'http://localhost:8080';
   const summary = document.getElementById('rating_summary');
   const library = document.getElementById('rating_library');
   const categories = document.getElementById('rating_categories');
@@ -131,7 +141,7 @@ async function initRatings() {
     library.innerHTML =
       'Fehler beim Laden der Bibliothek. ' +
       'Bitte rufen Sie die Seite \u00fcber <code>node tools/serve-interface.js</code> ' +
-      'unter <a href="http://localhost:8080/ethicom.html">localhost</a> auf.';
+      `unter <a href="${baseUrl}/ethicom.html">${baseUrl}</a> auf.`;
   }
 }
 


### PR DESCRIPTION
## Summary
- add `config.json` for default settings
- document configuration in `CONFIG.md`
- make `tools/serve-interface.js` consume the new config and serve it
- load `config.json` in `interface/ratings.js`

## Testing
- `node --test`
- `node tools/check-translations.js`