### PR TITLE
Refactor OP level helpers into shared module

### DIFF
--- a/bewertung.html
+++ b/bewertung.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Bewertung</title>
   <link rel="stylesheet" href="interface/ethicom-style.css" />
+  <script src="utils/op-level.js"></script>
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/accessibility.js"></script>
   <script src="interface/language-selector.js"></script>

--- a/home.html
+++ b/home.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Home</title>
   <link rel="stylesheet" href="interface/ethicom-style.css" />
+  <script src="utils/op-level.js"></script>
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/accessibility.js"></script>
   <script src="interface/color-auth.js"></script>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>4789 Index</title>
   <link rel="stylesheet" href="interface/ethicom-style.css" />
+  <script src="utils/op-level.js"></script>
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/accessibility.js"></script>
   <script src="interface/color-auth.js"></script>

--- a/interface/connect.html
+++ b/interface/connect.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Connect</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="connect.js"></script>
 </head>

--- a/interface/donate.html
+++ b/interface/donate.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Spenden</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="donate.js"></script>

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -121,21 +121,13 @@ function help(text) {
   return `<span class="help-icon" title="${safe}">?</span>`;
 }
 
-// Retrieve stored OP level from localStorage
-function getStoredOpLevel() {
-  try {
-    const sig = JSON.parse(localStorage.getItem("ethicom_signature") || "{}");
-    return sig.op_level || null;
-  } catch (err) {
-    return null;
-  }
-}
-
-// Convert OP-level string to numeric value (OP-8 → 8)
-function opLevelToNumber(level) {
-  if (!level) return 0;
-  const n = parseFloat(String(level).replace("OP-", ""));
-  return isNaN(n) ? 0 : n;
+// Use shared OP helpers
+let opLevelToNumber;
+let getStoredOpLevel;
+if (typeof module !== 'undefined' && module.exports) {
+  ({ opLevelToNumber, getStoredOpLevel } = require('../utils/op-level.js'));
+} else if (typeof window !== 'undefined') {
+  ({ opLevelToNumber, getStoredOpLevel } = window);
 }
 
 function showLoadingBadge(level) {

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Ethicom</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="language-selector.js"></script>

--- a/interface/fish-interface/fischEditor.html
+++ b/interface/fish-interface/fischEditor.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Fische Editor</title>
   <link rel="stylesheet" href="../ethicom-style.css" />
+  <script src="../../utils/op-level.js"></script>
   <script src="../ethicom-utils.js"></script>
   <script src="../accessibility.js"></script>
   <script src="../theme-manager.js"></script>

--- a/interface/fish-interface/fischeBern.html
+++ b/interface/fish-interface/fischeBern.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Fische Bern</title>
   <link rel="stylesheet" href="../ethicom-style.css" />
+  <script src="../../utils/op-level.js"></script>
   <script src="../ethicom-utils.js"></script>
   <script src="../accessibility.js"></script>
   <script src="../theme-manager.js"></script>

--- a/interface/fish.html
+++ b/interface/fish.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Fish Interface</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="theme-manager.js"></script>

--- a/interface/genealogie.html
+++ b/interface/genealogie.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Genealogie</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="genealogie.js"></script>

--- a/interface/hermes.html
+++ b/interface/hermes.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Hermes</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="language-selector.js"></script>

--- a/interface/login.html
+++ b/interface/login.html
@@ -6,6 +6,7 @@
   <title>Login</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>
+  <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="login.js"></script>

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Settings</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="language-selector.js"></script>
   <script src="theme-manager.js"></script>

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -6,6 +6,7 @@
   <title>Registrierung</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>
+  <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="signup.js"></script>

--- a/interface/start.html
+++ b/interface/start.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Ethicom Start</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="accessibility.js"></script>
   <style>

--- a/interface_OLD/about.html
+++ b/interface_OLD/about.html
@@ -6,6 +6,7 @@
   <title>Über das Modul</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>
+  <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="translation-manager.js"></script>
   <script src="interface-loader.js"></script>

--- a/interface_OLD/ethicom-utils.js
+++ b/interface_OLD/ethicom-utils.js
@@ -90,21 +90,13 @@ function help(text) {
   return `<span class="help-icon" title="${safe}">?</span>`;
 }
 
-// Retrieve stored OP level from localStorage
-function getStoredOpLevel() {
-  try {
-    const sig = JSON.parse(localStorage.getItem("ethicom_signature") || "{}");
-    return sig.op_level || null;
-  } catch (err) {
-    return null;
-  }
-}
-
-// Convert OP-level string to numeric value (OP-8 → 8)
-function opLevelToNumber(level) {
-  if (!level) return 0;
-  const n = parseFloat(String(level).replace("OP-", ""));
-  return isNaN(n) ? 0 : n;
+// Use shared OP helpers
+let opLevelToNumber;
+let getStoredOpLevel;
+if (typeof module !== 'undefined' && module.exports) {
+  ({ opLevelToNumber, getStoredOpLevel } = require('../utils/op-level.js'));
+} else if (typeof window !== 'undefined') {
+  ({ opLevelToNumber, getStoredOpLevel } = window);
 }
 
 function showLoadingBadge(level) {

--- a/interface_OLD/ethicom.html
+++ b/interface_OLD/ethicom.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Ethik-Kompass</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="evidence-recorder.js"></script>
   <script src="signature-verifier.js"></script>

--- a/interface_OLD/signup.html
+++ b/interface_OLD/signup.html
@@ -6,6 +6,7 @@
   <title>Registrierung</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>
+  <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="signup.js"></script>
   <script src="color-auth.js"></script>

--- a/start.html
+++ b/start.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Start</title>
   <link rel="stylesheet" href="interface/ethicom-style.css" />
+  <script src="utils/op-level.js"></script>
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/accessibility.js"></script>
   <style>

--- a/tools/api-access.js
+++ b/tools/api-access.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { opLevelToNumber } = require('../utils/op-level.js');
 
 function parseUserState(filePath) {
   const p = filePath || path.join(__dirname, '..', 'app', 'user_state.yaml');
@@ -17,12 +18,6 @@ function parseUserState(filePath) {
     if (et) ethicsTest = et[1].replace(/['"]/g, '') === 'true';
   });
   return { op_level: opLevel, ethics_confirmed: ethicsConfirmed, ethics_test_passed: ethicsTest };
-}
-
-function opLevelToNumber(level) {
-  if (!level) return 0;
-  const n = parseFloat(String(level).replace('OP-', ''));
-  return isNaN(n) ? 0 : n;
 }
 
 function apiAccessAllowed(minLevel = 'OP-3', userStatePath) {

--- a/tools/person-score.js
+++ b/tools/person-score.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { opLevelToNumber } = require('../utils/op-level.js');
 
 function loadRatings(filePath) {
   const p = filePath || path.join(__dirname, '..', 'evidence', 'person-ratings.json');
@@ -11,11 +12,6 @@ function ratingToValue(r) {
   if (r === 'yes') return 1;
   if (r === 'unclear') return 0.5;
   return 0;
-}
-
-function opLevelToNumber(level) {
-  const n = parseFloat(String(level).replace('OP-', ''));
-  return isNaN(n) ? 0 : n;
 }
 
 function computePersonScores(list) {

--- a/utils/op-level.js
+++ b/utils/op-level.js
@@ -1,0 +1,23 @@
+(function(global){
+  function opLevelToNumber(level){
+    if(!level) return 0;
+    const n = parseFloat(String(level).replace('OP-', ''));
+    return isNaN(n) ? 0 : n;
+  }
+
+  function getStoredOpLevel(){
+    try {
+      const sig = JSON.parse(localStorage.getItem('ethicom_signature') || '{}');
+      return sig.op_level || null;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { opLevelToNumber, getStoredOpLevel };
+  } else {
+    global.opLevelToNumber = opLevelToNumber;
+    global.getStoredOpLevel = getStoredOpLevel;
+  }
+})(this);

--- a/wings/index.html
+++ b/wings/index.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="../interface/ethicom-style.css" />
   <link rel="stylesheet" href="wings-style.css" />
+  <script src="../utils/op-level.js"></script>
   <script src="../interface/ethicom-utils.js"></script>
   <script src="../interface/accessibility.js"></script>
   <script src="../interface/interface-loader.js"></script>

--- a/wings/ratings.html
+++ b/wings/ratings.html
@@ -6,6 +6,7 @@
   <title>Bewertungen</title>
   <link rel="stylesheet" href="../interface/ethicom-style.css" />
   <link rel="stylesheet" href="wings-style.css" />
+  <script src="../utils/op-level.js"></script>
   <script src="../interface/ethicom-utils.js"></script>
   <script src="../interface/accessibility.js"></script>
   <script src="../interface/language-selector.js"></script>


### PR DESCRIPTION
## Summary
- add shared `utils/op-level.js` for `opLevelToNumber` and `getStoredOpLevel`
- use shared helpers in browser utilities
- update node tools to require the new module
- include `op-level.js` in all HTML pages

## Testing
- `node --test`
- `node tools/check-translations.js`
