### PR TITLE
Add shared SHA-256 helper

### DIFF
--- a/bewertung.html
+++ b/bewertung.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Bewertung</title>
   <link rel="stylesheet" href="interface/ethicom-style.css" />
+  <script src="interface/hash-utils.js"></script>
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/accessibility.js"></script>
   <script src="interface/language-selector.js"></script>

--- a/home.html
+++ b/home.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Home</title>
   <link rel="stylesheet" href="interface/ethicom-style.css" />
+  <script src="interface/hash-utils.js"></script>
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/accessibility.js"></script>
   <script src="interface/color-auth.js"></script>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>4789 Index</title>
   <link rel="stylesheet" href="interface/ethicom-style.css" />
+  <script src="interface/hash-utils.js"></script>
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/accessibility.js"></script>
   <script src="interface/color-auth.js"></script>

--- a/interface/connect.html
+++ b/interface/connect.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Connect</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="hash-utils.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="connect.js"></script>
 </head>

--- a/interface/donate.html
+++ b/interface/donate.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Spenden</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="hash-utils.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="donate.js"></script>

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -1,5 +1,6 @@
 
 // ethicom-utils.js – Hilfsfunktionen für Interface-Anzeige
+const { sha256 } = typeof module !== "undefined" && module.exports ? require("./hash-utils.js") : window;
 (function() {
   const FG_OPACITY_MAX = 65;
   function setForegroundOpacity(percent) {
@@ -97,23 +98,6 @@ function renderAllBadges() {
   });
 }
 
-// Calculate a SHA-256 hash in both browser and Node.js environments
-async function sha256(message) {
-  if (typeof window !== "undefined" && window.crypto && window.crypto.subtle) {
-    const data = new TextEncoder().encode(message);
-    const buffer = await window.crypto.subtle.digest("SHA-256", data);
-    return Array.from(new Uint8Array(buffer))
-      .map(b => b.toString(16).padStart(2, "0"))
-      .join("");
-  }
-
-  if (typeof require !== "undefined") {
-    const crypto = require("crypto");
-    return crypto.createHash("sha256").update(message).digest("hex");
-  }
-
-  throw new Error("SHA-256 hashing not supported in this environment");
-}
 
 // Return HTML for a help icon with tooltip text
 function help(text) {

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Ethicom</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="hash-utils.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="language-selector.js"></script>

--- a/interface/fish-interface/fischEditor.html
+++ b/interface/fish-interface/fischEditor.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Fische Editor</title>
   <link rel="stylesheet" href="../ethicom-style.css" />
+  <script src="../hash-utils.js"></script>
   <script src="../ethicom-utils.js"></script>
   <script src="../accessibility.js"></script>
   <script src="../theme-manager.js"></script>

--- a/interface/fish-interface/fischeBern.html
+++ b/interface/fish-interface/fischeBern.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Fische Bern</title>
   <link rel="stylesheet" href="../ethicom-style.css" />
+  <script src="../hash-utils.js"></script>
   <script src="../ethicom-utils.js"></script>
   <script src="../accessibility.js"></script>
   <script src="../theme-manager.js"></script>

--- a/interface/fish.html
+++ b/interface/fish.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Fish Interface</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="hash-utils.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="theme-manager.js"></script>

--- a/interface/genealogie.html
+++ b/interface/genealogie.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Genealogie</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="hash-utils.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="genealogie.js"></script>

--- a/interface/hash-utils.js
+++ b/interface/hash-utils.js
@@ -1,0 +1,22 @@
+async function sha256(message) {
+  if (typeof window !== 'undefined' && window.crypto && window.crypto.subtle) {
+    const data = new TextEncoder().encode(message);
+    const buffer = await window.crypto.subtle.digest('SHA-256', data);
+    return Array.from(new Uint8Array(buffer))
+      .map(b => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+  if (typeof require !== 'undefined') {
+    const crypto = require('crypto');
+    return crypto.createHash('sha256').update(message).digest('hex');
+  }
+  throw new Error('SHA-256 hashing not supported in this environment');
+}
+
+if (typeof window !== 'undefined') {
+  window.sha256 = sha256;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { sha256 };
+}

--- a/interface/hermes.html
+++ b/interface/hermes.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Hermes</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="hash-utils.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="language-selector.js"></script>

--- a/interface/login.html
+++ b/interface/login.html
@@ -6,6 +6,7 @@
   <title>Login</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>
+  <script src="hash-utils.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="login.js"></script>

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Settings</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="hash-utils.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="language-selector.js"></script>
   <script src="theme-manager.js"></script>

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -6,6 +6,7 @@
   <title>Registrierung</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>
+  <script src="hash-utils.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="signup.js"></script>

--- a/interface/start.html
+++ b/interface/start.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Ethicom Start</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="hash-utils.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="accessibility.js"></script>
   <style>

--- a/interface_OLD/about.html
+++ b/interface_OLD/about.html
@@ -6,6 +6,7 @@
   <title>Über das Modul</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>
+  <script src="../interface/hash-utils.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="translation-manager.js"></script>
   <script src="interface-loader.js"></script>

--- a/interface_OLD/ethicom-utils.js
+++ b/interface_OLD/ethicom-utils.js
@@ -1,6 +1,7 @@
 
 // ethicom-utils.js – Hilfsfunktionen für Interface-Anzeige
 
+const { sha256 } = typeof module !== "undefined" && module.exports ? require("../interface/hash-utils.js") : window;
 function getReadmePath(lang) {
   const prefix = window.location.pathname.includes('/interface/') ? '..' : '.';
   return lang === 'en'
@@ -66,23 +67,6 @@ function renderAllBadges() {
   });
 }
 
-// Calculate a SHA-256 hash in both browser and Node.js environments
-async function sha256(message) {
-  if (typeof window !== "undefined" && window.crypto && window.crypto.subtle) {
-    const data = new TextEncoder().encode(message);
-    const buffer = await window.crypto.subtle.digest("SHA-256", data);
-    return Array.from(new Uint8Array(buffer))
-      .map(b => b.toString(16).padStart(2, "0"))
-      .join("");
-  }
-
-  if (typeof require !== "undefined") {
-    const crypto = require("crypto");
-    return crypto.createHash("sha256").update(message).digest("hex");
-  }
-
-  throw new Error("SHA-256 hashing not supported in this environment");
-}
 
 // Return HTML for a help icon with tooltip text
 function help(text) {

--- a/interface_OLD/ethicom.html
+++ b/interface_OLD/ethicom.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Ethik-Kompass</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="../interface/hash-utils.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="evidence-recorder.js"></script>
   <script src="signature-verifier.js"></script>

--- a/interface_OLD/signup.html
+++ b/interface_OLD/signup.html
@@ -6,6 +6,7 @@
   <title>Registrierung</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>
+  <script src="../interface/hash-utils.js"></script>
   <script src="ethicom-utils.js"></script>
   <script src="signup.js"></script>
   <script src="color-auth.js"></script>

--- a/start.html
+++ b/start.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Start</title>
   <link rel="stylesheet" href="interface/ethicom-style.css" />
+  <script src="interface/hash-utils.js"></script>
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/accessibility.js"></script>
   <style>

--- a/wings/index.html
+++ b/wings/index.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="../interface/ethicom-style.css" />
   <link rel="stylesheet" href="wings-style.css" />
+  <script src="../interface/hash-utils.js"></script>
   <script src="../interface/ethicom-utils.js"></script>
   <script src="../interface/accessibility.js"></script>
   <script src="../interface/interface-loader.js"></script>

--- a/wings/ratings.html
+++ b/wings/ratings.html
@@ -6,6 +6,7 @@
   <title>Bewertungen</title>
   <link rel="stylesheet" href="../interface/ethicom-style.css" />
   <link rel="stylesheet" href="wings-style.css" />
+  <script src="../interface/hash-utils.js"></script>
   <script src="../interface/ethicom-utils.js"></script>
   <script src="../interface/accessibility.js"></script>
   <script src="../interface/language-selector.js"></script>


### PR DESCRIPTION
## Summary
- add `interface/hash-utils.js` containing the common `sha256` helper
- import helper in `ethicom-utils.js` files and remove duplicate code
- load new helper in HTML pages so `sha256` is available in the browser

## Testing
- `node --test`
- `node tools/check-translations.js`
