### PR TITLE
Add offline fallback docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ README.md -> GET_STARTED.md -> index.html
 - [Source Manager](#source-manager)
 - [Roadmap](#roadmap)
 - [Local Deployment](#local-deployment)
+- [Strict Offline Mode](#strict-offline-mode)
 - [Running Tests](#running-tests)
 - [Contributing](#contributing)
 
@@ -385,6 +386,14 @@ the provided `localhost` address so that translation files load correctly.
 When deploying on another domain, set the environment variable `BASE_URL`
 to that public origin (e.g. `https://4789-alpha.github.io`) so that OAuth
 redirects work properly.
+
+### Strict Offline Mode
+[⇧](#contents)
+
+In environments without outbound network access delete the `fallback` line in
+`app/llm_config.yaml` or set it to `null`. This disables the automatic fallback
+to the public API and ensures no prompts are sent to external services when the
+local LLM is unreachable.
 
 ### Running Tests
 [⇧](#contents)

--- a/app/llm_config.yaml
+++ b/app/llm_config.yaml
@@ -3,6 +3,9 @@ llm:
   url: "http://localhost:11434/api/generate"
   model: "mistral"
   api_key: null
+  # Fallback URL used when the local endpoint fails.
+  # Removing this or setting it to null prevents prompts from
+  # being sent to the remote service in strict offline mode.
   fallback: "https://api.openrouter.ai/v1/chat/completions"
   timeout: 10
   headers:


### PR DESCRIPTION
## Summary
- document strict offline mode in README
- add explanation for the fallback setting in `app/llm_config.yaml`

## Testing
- `node --test`
- `node tools/check-translations.js`