### PR TITLE
Add gatekeeper hash verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,11 @@ Confirmed devices are stored hashed in `app/gatekeeper_devices.json`. Once the s
 The private identity is hashed too and remains local-only. Only you have access to the unhashed string.
 Temporary tokens can be issued with `node tools/gatekeeper.js token` and expire after the configured duration.
 Tokens and device hashes are stored hashed in `app/gatekeeper_devices.json`.
+Verify the stored hashes after updates with:
+
+```bash
+node tools/verify-gatekeeper.js
+```
 Registrierungsdaten werden offline gehasht gespeichert. Keine Gewährleistung für absolute Anonymität.
 **4789**
 

--- a/tools/verify-gatekeeper.js
+++ b/tools/verify-gatekeeper.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const files = {
+  config: path.join(__dirname, '..', 'app', 'gatekeeper_config.yaml'),
+  devices: path.join(__dirname, '..', 'app', 'gatekeeper_devices.json')
+};
+
+const expected = {
+  config: '31ec110351ccb7173d6b37ad72e2ff51e0f492f95d41cf8541132285bf1e62ba',
+  devices: 'ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356'
+};
+
+function sha256(file) {
+  if (!fs.existsSync(file)) return null;
+  const data = fs.readFileSync(file);
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+let ok = true;
+for (const [key, file] of Object.entries(files)) {
+  const hash = sha256(file);
+  if (!hash) {
+    console.log(`${file} missing.`);
+    ok = false;
+    continue;
+  }
+  if (hash !== expected[key]) {
+    console.log(`${path.basename(file)} mismatch: ${hash}`);
+    ok = false;
+  } else {
+    console.log(`${path.basename(file)} OK`);
+  }
+}
+
+if (!ok) {
+  process.exit(1);
+} else {
+  console.log('Gatekeeper files verified.');
+}


### PR DESCRIPTION
## Summary
- add `tools/verify-gatekeeper.js` to check gatekeeper config and device hashes
- mention running the script in README

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/verify-gatekeeper.js`
