### PR TITLE
Add token pruning to gatekeeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Confirmed devices are stored hashed in `app/gatekeeper_devices.json`. Once the s
 The private identity is hashed too and remains local-only. Only you have access to the unhashed string.
 Temporary tokens can be issued with `node tools/gatekeeper.js token` and expire after the configured duration.
 Tokens and device hashes are stored hashed in `app/gatekeeper_devices.json`.
+Expired tokens can be removed with `node tools/gatekeeper.js prune`.
 Registrierungsdaten werden offline gehasht gespeichert. Keine Gewährleistung für absolute Anonymität.
 **4789**
 


### PR DESCRIPTION
## Summary
- add `pruneExpiredTokens()` to remove outdated tokens
- expose CLI command `node tools/gatekeeper.js prune`
- test pruning behavior
- document cleanup step in Gatekeeper section

## Testing
- `node --test`
- `node tools/check-translations.js`