### PR TITLE
Fix color setting persistence and close button layout

### DIFF
--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -14,8 +14,56 @@
     const css = `rgb(${obj.r},${obj.g},${obj.b})`;
     document.documentElement.style.setProperty('--text-color', css);
   }
+
+  function applyStoredColors() {
+    try {
+      const bg = JSON.parse(localStorage.getItem('ethicom_bg_color') || 'null');
+      if (bg) {
+        document.documentElement.style.setProperty(
+          '--bg-color',
+          `rgb(${bg.r},${bg.g},${bg.b})`
+        );
+      }
+    } catch {}
+
+    try {
+      const mod = JSON.parse(
+        localStorage.getItem('ethicom_module_color') || 'null'
+      );
+      if (mod) {
+        document.documentElement.style.setProperty(
+          '--module-color',
+          `rgb(${mod.r},${mod.g},${mod.b})`
+        );
+      }
+    } catch {}
+
+    try {
+      const tanna = JSON.parse(
+        localStorage.getItem('ethicom_tanna_color') || 'null'
+      );
+      if (
+        tanna &&
+        (document.body.classList.contains('theme-tanna') ||
+          document.body.classList.contains('theme-tanna-dark'))
+      ) {
+        const css = `rgb(${tanna.r},${tanna.g},${tanna.b})`;
+        document.documentElement.style.setProperty('--primary-color', css);
+        document.documentElement.style.setProperty('--accent-color', css);
+        const h = `rgba(${Math.round(tanna.r * 0.2)},${Math.round(
+          tanna.g * 0.2
+        )},${Math.round(tanna.b * 0.2)},0.9)`;
+        const n = `rgba(${Math.round(tanna.r * 0.3)},${Math.round(
+          tanna.g * 0.3
+        )},${Math.round(tanna.b * 0.3)},0.9)`;
+        document.documentElement.style.setProperty('--header-bg', h);
+        document.documentElement.style.setProperty('--nav-bg', n);
+      }
+    } catch {}
+  }
   window.setForegroundOpacity = setForegroundOpacity;
   window.applyTextColor = applyTextColor;
+  window.applyStoredColors = applyStoredColors;
   document.addEventListener('DOMContentLoaded', () => {
     let stored = parseInt(localStorage.getItem('ethicom_fg_opacity') || '0', 10);
     if (stored > FG_OPACITY_MAX) stored = FG_OPACITY_MAX;
@@ -24,6 +72,7 @@
       const tc = JSON.parse(localStorage.getItem('ethicom_text_color') || 'null');
       if (tc) applyTextColor(tc);
     } catch {}
+    applyStoredColors();
   });
 })();
 

--- a/interface/theme-manager.js
+++ b/interface/theme-manager.js
@@ -161,6 +161,11 @@ function openColorSettingsPopin(){
   overlay.style.position='fixed';overlay.style.top=0;overlay.style.left=0;
   overlay.style.right=0;overlay.style.bottom=0;overlay.style.background='rgba(0,0,0,0.5)';
   overlay.style.zIndex=1000;
+  overlay.style.display='flex';
+  overlay.style.alignItems='center';
+  overlay.style.justifyContent='center';
+  overlay.style.padding='1em';
+
 
   const box=document.createElement('div');
   box.className='card';
@@ -168,7 +173,7 @@ function openColorSettingsPopin(){
   box.style.maxHeight='90vh';box.style.overflowY='auto';
   box.style.position='relative';
 
-  box.innerHTML=`<button id="color_popin_close" style="position:absolute;top:0.5em;right:0.5em;z-index:1">X</button>
+  box.innerHTML=`
 <details class="card"><summary>Fonts</summary>
  <div id="text_color_pop">
   <label>R: <input type="range" id="text_r_p" min="0" max="255"> <span id="text_r_p_val"></span></label><br/>
@@ -199,9 +204,17 @@ function openColorSettingsPopin(){
   <span id="module_preview" class="color-preview"></span>
  </div></details>`;
 
-  overlay.appendChild(box);document.body.appendChild(overlay);
+  overlay.appendChild(box);
+  const closeBtn=document.createElement('button');
+  closeBtn.id='color_popin_close';
+  closeBtn.textContent='X';
+  closeBtn.style.position='absolute';
+  closeBtn.style.top='0.5em';
+  closeBtn.style.right='0.5em';
+  overlay.appendChild(closeBtn);
+  document.body.appendChild(overlay);
 
-  document.getElementById('color_popin_close').addEventListener('click',()=>overlay.remove());
+  closeBtn.addEventListener('click',()=>overlay.remove());
 
   initSliderSet('text_r_p','text_g_p','text_b_p','text_r_p_val','text_g_p_val','text_b_p_val','text_preview_p','ethicom_text_color','--text-color');
   initSliderSet('bg_r','bg_g','bg_b','bg_r_val','bg_g_val','bg_b_val','bg_preview','ethicom_bg_color','--bg-color');


### PR DESCRIPTION
## Summary
- persist custom colors on every page by applying stored values on DOMContentLoaded
- update color popin layout so the close button is placed in the overlay corner without blocking other controls

## Testing
- `node --test`
- `node tools/check-translations.js`
