### PR TITLE
Add help flags and document shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 - [Source Manager](#source-manager)
 - [Roadmap](#roadmap)
 - [Local Deployment](#local-deployment)
+- [Keyboard Shortcuts](#keyboard-shortcuts)
 - [Running Tests](#running-tests)
 - [Contributing](#contributing)
 
@@ -357,8 +358,10 @@ pip install -r requirements.txt
 Serve the Ethicom interface locally with:
 
 ```bash
-node tools/serve-interface.js
+node tools/serve-interface.js [--port <number>]
 ```
+
+Run `node tools/serve-interface.js --help` to see all options.
 
 Then open `http://localhost:8080/ethicom.html` in your browser.
 Opening the HTML file directly (e.g. via `file://`) bypasses the local server and
@@ -367,6 +370,16 @@ the provided `localhost` address so that translation files load correctly.
 When deploying on another domain, set the environment variable `BASE_URL`
 to that public origin (e.g. `https://4789-alpha.github.io`) so that OAuth
 redirects work properly.
+
+### Keyboard Shortcuts
+[⇧](#contents)
+
+Cards in the Ethicom interface react to arrow keys and swipe gestures:
+
+- **Left** → sets the rating to *Unclear*
+- **Up** → sets the rating to *Yes*
+- **Down** → sets the rating to *No*
+- **Right** → shows an info alert about the selected name
 
 ### Running Tests
 [⇧](#contents)

--- a/interface/dynamic-help.js
+++ b/interface/dynamic-help.js
@@ -10,7 +10,8 @@ const helpMap = {
       'Responsibility outweighs convenience.',
       'Create signatures locally and confirm them structurally.',
       'Withdrawals or corrections are part of the process, not weakness.',
-      'Maintain transparency at every step, even with anonymous use.'
+      'Maintain transparency at every step, even with anonymous use.',
+      'Use arrow keys or swipe gestures (left=Unclear, up=Yes, down=No, right=Info) to adjust the current card.'
     ]
   },
   'OP-0': { title: 'OP-0 Tips', items: [

--- a/tools/op-functions.js
+++ b/tools/op-functions.js
@@ -40,8 +40,13 @@ function getOpFunction(name, userStatePath) {
 }
 
 if (require.main === module) {
-  const name = process.argv[2] || 'info';
-  const fn = getOpFunction(name);
+  const [arg1, arg2] = process.argv.slice(2);
+  if (arg1 === '--help' || arg1 === '-h') {
+    console.log('Usage: node tools/op-functions.js <function> [statePath]');
+    process.exit(0);
+  }
+  const name = arg1 || 'info';
+  const fn = getOpFunction(name, arg2);
   if (fn) {
     console.log(fn());
   } else {

--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -78,12 +78,25 @@ function verifyTotp(secret, code) {
 
 const root = path.join(__dirname, '..', 'interface');
 const repoRoot = path.join(__dirname, '..');
-const port = process.env.PORT || 8080;
+const args = process.argv.slice(2);
+function getArg(name) {
+  const idx = args.findIndex(a => a === name || a.startsWith(name + '='));
+  if (idx === -1) return null;
+  const val = args[idx].includes('=') ? args[idx].split('=')[1] : args[idx + 1];
+  return val || null;
+}
+if (args.includes('--help') || args.includes('-h')) {
+  console.log('Usage: node tools/serve-interface.js [--port <number>] [--oauth <file>]');
+  console.log('Starts a local server for the Ethicom interface.');
+  console.log('Set BASE_URL to your public origin when testing OAuth.');
+  process.exit(0);
+}
+const port = parseInt(getArg('--port') || process.env.PORT || '8080', 10);
 const baseUrl = process.env.BASE_URL || `http://localhost:${port}`;
 const usersFile = path.join(__dirname, '..', 'app', 'users.json');
 const evalFile = path.join(__dirname, '..', 'app', 'evaluations.json');
 const connFile = path.join(__dirname, '..', 'app', 'connections.json');
-const oauthCfg = parseOAuthConfig();
+const oauthCfg = parseOAuthConfig(getArg('--oauth'));
 const oauthStates = new Set();
 const gateCfgPath = path.join(__dirname, '..', 'app', 'gatekeeper_config.yaml');
 const gateStore = path.join(__dirname, '..', 'app', 'gatekeeper_devices.json');


### PR DESCRIPTION
## Summary
- add keyboard shortcut info to dynamic-help section
- document interface keyboard shortcuts in README
- support `--help` and argument parsing in `serve-interface.js`
- add `--help` flag to `op-functions.js`
- fix README and script after merge issues

## Testing
- `node --test`
- `node tools/check-translations.js`
