### PR TITLE
Add shared user state parser

### DIFF
--- a/tools/api-access.js
+++ b/tools/api-access.js
@@ -1,23 +1,4 @@
-const fs = require('fs');
-const path = require('path');
-
-function parseUserState(filePath) {
-  const p = filePath || path.join(__dirname, '..', 'app', 'user_state.yaml');
-  if (!fs.existsSync(p)) return null;
-  const data = fs.readFileSync(p, 'utf8').split(/\r?\n/);
-  let opLevel = null;
-  let ethicsConfirmed = null;
-  let ethicsTest = null;
-  data.forEach(line => {
-    const op = line.match(/^\s*op_level:\s*(.*)$/);
-    if (op) opLevel = op[1].replace(/['"]/g, '');
-    const ec = line.match(/^\s*ethics_confirmed:\s*(.*)$/);
-    if (ec) ethicsConfirmed = ec[1].replace(/['"]/g, '') === 'true';
-    const et = line.match(/^\s*ethics_test_passed:\s*(.*)$/);
-    if (et) ethicsTest = et[1].replace(/['"]/g, '') === 'true';
-  });
-  return { op_level: opLevel, ethics_confirmed: ethicsConfirmed, ethics_test_passed: ethicsTest };
-}
+const { parseUserState } = require('./user-state.js');
 
 function opLevelToNumber(level) {
   if (!level) return 0;
@@ -30,7 +11,9 @@ function apiAccessAllowed(minLevel = 'OP-3', userStatePath) {
   if (!state) return false;
   const userLevel = opLevelToNumber(state.op_level);
   const required = opLevelToNumber(minLevel);
-  const ethicsOk = state.ethics_confirmed === true || state.ethics_test_passed === true;
+  const ethicsOk =
+    state.ethics_confirmed === true ||
+    state.ethics_test_passed === true;
   return userLevel >= required && ethicsOk;
 }
 

--- a/tools/op-rights-demo.js
+++ b/tools/op-rights-demo.js
@@ -1,17 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-
-function parseUserState(filePath) {
-  const p = filePath || path.join(__dirname, '..', 'app', 'user_state.yaml');
-  if (!fs.existsSync(p)) return null;
-  const data = fs.readFileSync(p, 'utf8').split(/\r?\n/);
-  let op = null;
-  data.forEach(line => {
-    const m = line.match(/^\s*op_level:\s*(.*)$/);
-    if (m) op = m[1].replace(/['"]/g, '');
-  });
-  return op;
-}
+const { parseUserState } = require('./user-state.js');
 
 function loadPermissions(filePath) {
   const p = filePath || path.join(__dirname, '..', 'permissions', 'op-permissions-expanded.json');
@@ -33,7 +22,8 @@ function showRights(level) {
 
 if (require.main === module) {
   const argLevel = process.argv[2];
-  const level = argLevel || parseUserState() || 'OP-0';
+  const state = parseUserState();
+  const level = argLevel || (state ? state.op_level : null) || 'OP-0';
   showRights(level);
 }
 

--- a/tools/user-state.js
+++ b/tools/user-state.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+function parseUserState(filePath) {
+  const p = filePath || path.join(__dirname, '..', 'app', 'user_state.yaml');
+  if (!fs.existsSync(p)) return null;
+  const data = fs.readFileSync(p, 'utf8').split(/\r?\n/);
+  let opLevel = null;
+  let ethicsConfirmed = null;
+  let ethicsTest = null;
+  data.forEach(line => {
+    const op = line.match(/^\s*op_level:\s*(.*)$/);
+    if (op) opLevel = op[1].replace(/['"]/g, '');
+    const ec = line.match(/^\s*ethics_confirmed:\s*(.*)$/);
+    if (ec) ethicsConfirmed = ec[1].replace(/['"]/g, '') === 'true';
+    const et = line.match(/^\s*ethics_test_passed:\s*(.*)$/);
+    if (et) ethicsTest = et[1].replace(/['"]/g, '') === 'true';
+  });
+  return { op_level: opLevel, ethics_confirmed: ethicsConfirmed, ethics_test_passed: ethicsTest };
+}
+
+module.exports = { parseUserState };


### PR DESCRIPTION
## Summary
- extract user state parsing to `tools/user-state.js`
- update `api-access.js` and `op-rights-demo.js` to use the shared parser
- fix minor line break issue in `api-access.js`

## Testing
- `node --test`
- `node tools/check-translations.js`
