### PR TITLE
Improve token cleanup and clarify data release

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ README.md -> GET_STARTED.md -> index.html
 **Color verification of the chosen primary color starts once a user holds an OP-1 signature.**
 **From that level, the color choice is stored privately inside the user's signature and never shown publicly.**
 
+In this anonymous system, the OP signature stands in for the person. Personal data remains private and becomes visible only when a user releases it at the corresponding OP sublevel; see [signaturdesign.md](signaturdesign.md) and [DISCLAIMERS.md](DISCLAIMERS.md).
+
 ### Login Methods by OP Level
 [⇧](#contents)
 
@@ -193,6 +195,7 @@ If no sublevel is specified, permissions fall back to the base level.
 
 Only digital agents can advance beyond OP-9.
 Sublevels like OP-5.U, OP-7.U, OP-8.M, and OP-9.M specify user or medical access. Additional expert categories (.T, .S[y], .L, .U) are listed in `operator/expert_classes.md`. See `permissions/op-permissions-expanded.json` for details.
+All personal data stays hashed until such sublevels are reached and the user grants release, as detailed in [signaturdesign.md](signaturdesign.md) and [DISCLAIMERS.md](DISCLAIMERS.md).
 
 ### SRC vs. OO Levels
 [⇧](#contents)
@@ -284,6 +287,7 @@ Confirmed devices are stored hashed in `app/gatekeeper_devices.json`. Once the s
 The private identity is hashed too and remains local-only. Only you have access to the unhashed string.
 Temporary tokens can be issued with `node tools/gatekeeper.js token` and expire after the configured duration.
 Tokens and device hashes are stored hashed in `app/gatekeeper_devices.json`.
+Run `node tools/gatekeeper.js prune` regularly to remove expired tokens and keep the file minimal.
 Verify the stored hashes after updates with:
 
 ```bash
@@ -365,11 +369,15 @@ The roadmap keeps development transparent according to Signature 4789.
    - Align evaluated sources with the anonymous tier.
    - Standardize transfer protocols for cross-module use.
 3. **v2.0 – Global Rollout**
+   - A running, secure system with clear purpose marks this stage.
    - Publish multi-language guides for all operator levels.
    - Finalize open training data licensing.
 4. **v2.1 – Language Expansion**
    - Extend UI translations to all practical ISO 639-1 languages.
    - Provide an automated translation workflow with manual review.
+5. **v3.0 – Modular Architecture**
+   - Split the tools and interface into independent modules.
+   - Keep shared ethics data in a minimal core repo.
 
 ### Local Deployment
 [⇧](#contents)

--- a/test/gatekeeper.test.js
+++ b/test/gatekeeper.test.js
@@ -3,7 +3,7 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
-const { gateCheck, issueTempToken, verifyTempToken } = require('../tools/gatekeeper.js');
+const { gateCheck, issueTempToken, verifyTempToken, pruneExpiredTokens } = require('../tools/gatekeeper.js');
 const crypto = require('node:crypto');
 
 function createConfig(allow, id = 'singularity') {
@@ -81,6 +81,20 @@ test('temp token expires', () => {
   data['gstekeeper.local'].tokens[tokHash] = Date.now() - 1000;
   fs.writeFileSync(store, JSON.stringify(data));
   assert.strictEqual(verifyTempToken('gstekeeper.local', store, token), false);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('prunes expired tokens', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-'));
+  const store = path.join(dir, 'devices.json');
+  issueTempToken('gstekeeper.local', store, null, 60);
+  const data = JSON.parse(fs.readFileSync(store, 'utf8'));
+  const h = Object.keys(data['gstekeeper.local'].tokens)[0];
+  data['gstekeeper.local'].tokens[h] = Date.now() - 1000;
+  fs.writeFileSync(store, JSON.stringify(data));
+  pruneExpiredTokens(store);
+  const after = JSON.parse(fs.readFileSync(store, 'utf8'))['gstekeeper.local'].tokens;
+  assert.strictEqual(Object.keys(after).length, 0);
   fs.rmSync(dir, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary
- document that the OP signature is a stand-in for the person and that data only becomes visible once released
- note that personal data stays hashed until release
- add gatekeeper token cleanup command and document it
- extend roadmap with modular architecture goal
- add pruneExpiredTokens utility and tests

## Testing
- `node --test`
- `node tools/check-translations.js`