### PR TITLE
Fix gatekeeper.local references

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,10 +272,10 @@ README is used.
 
 Local control can be toggled via `tools/gatekeeper.js`. The script reads
 `app/gatekeeper_config.yaml` and only allows actions when `allow_control` is set
-to `true` for the controller `gstekeeper.local`. The optional
+to `true` for the controller `gatekeeper.local`. The optional
 `private_identity` value is hashed and stored with the device hash in
 `app/gatekeeper_devices.json`. This keeps remote commands gated and
-limited to the local environment. `gstekeeper.local` holds back every personal
+limited to the local environment. `gatekeeper.local` holds back every personal
 ID and may share only signed, anonymous data as a sign of trust.
 The gatekeeper runs on any platform that can execute Node.js. Copy the repository or the
 `tools` and `app` folders to a USB drive and run `node tools/gatekeeper.js` on Windows,

--- a/app/gatekeeper_config.yaml
+++ b/app/gatekeeper_config.yaml
@@ -1,5 +1,5 @@
 gatekeeper:
-  controller: "gstekeeper.local"
+  controller: "gatekeeper.local"
   allow_control: false
   local_only: true
   private_identity: "singularity"

--- a/test/data-hashing.test.js
+++ b/test/data-hashing.test.js
@@ -108,11 +108,11 @@ test('gatekeeper stores device hashes and no biometric file exists as stated in 
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-'));
   const cfgFile = path.join(dir, 'cfg.yaml');
   const storeFile = path.join(dir, 'devices.json');
-  fs.writeFileSync(cfgFile, 'gatekeeper:\n  controller: "gstekeeper.local"\n  allow_control: true\n  local_only: true\n  private_identity: "id42"');
-  const token = issueTempToken('gstekeeper.local', storeFile, null, 60);
+  fs.writeFileSync(cfgFile, 'gatekeeper:\n  controller: "gatekeeper.local"\n  allow_control: true\n  local_only: true\n  private_identity: "id42"');
+  const token = issueTempToken('gatekeeper.local', storeFile, null, 60);
   assert.ok(fs.existsSync(storeFile));
   assert.ok(gateCheck(cfgFile, storeFile, token));
-  const data = JSON.parse(fs.readFileSync(storeFile, 'utf8'))['gstekeeper.local'];
+  const data = JSON.parse(fs.readFileSync(storeFile, 'utf8'))['gatekeeper.local'];
   const devHash = data.devices[0];
   const tokHash = Object.keys(data.tokens)[0];
   assert.strictEqual(devHash.length, 64);

--- a/test/gatekeeper.test.js
+++ b/test/gatekeeper.test.js
@@ -7,7 +7,7 @@ const { gateCheck, issueTempToken, verifyTempToken, pruneExpiredTokens } = requi
 const crypto = require('node:crypto');
 
 function createConfig(allow, id = 'singularity') {
-  return `gatekeeper:\n  controller: "gstekeeper.local"\n  allow_control: ${allow}\n  local_only: true\n  private_identity: "${id}"`;
+  return `gatekeeper:\n  controller: "gatekeeper.local"\n  allow_control: ${allow}\n  local_only: true\n  private_identity: "${id}"`;
 }
 
 test('denies control when allow_control is false', () => {
@@ -67,33 +67,33 @@ test('denies control with mismatched identity', () => {
 test('creates and validates temp token', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-'));
   const store = path.join(dir, 'devices.json');
-  const token = issueTempToken('gstekeeper.local', store, null, 60);
-  assert.ok(verifyTempToken('gstekeeper.local', store, token));
+  const token = issueTempToken('gatekeeper.local', store, null, 60);
+  assert.ok(verifyTempToken('gatekeeper.local', store, token));
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
 test('temp token expires', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-'));
   const store = path.join(dir, 'devices.json');
-  const token = issueTempToken('gstekeeper.local', store, null, 60);
+  const token = issueTempToken('gatekeeper.local', store, null, 60);
   const data = JSON.parse(fs.readFileSync(store, 'utf8'));
-  const tokHash = Object.keys(data['gstekeeper.local'].tokens)[0];
-  data['gstekeeper.local'].tokens[tokHash] = Date.now() - 1000;
+  const tokHash = Object.keys(data['gatekeeper.local'].tokens)[0];
+  data['gatekeeper.local'].tokens[tokHash] = Date.now() - 1000;
   fs.writeFileSync(store, JSON.stringify(data));
-  assert.strictEqual(verifyTempToken('gstekeeper.local', store, token), false);
+  assert.strictEqual(verifyTempToken('gatekeeper.local', store, token), false);
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
 test('prunes expired tokens', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-'));
   const store = path.join(dir, 'devices.json');
-  issueTempToken('gstekeeper.local', store, null, 60);
+  issueTempToken('gatekeeper.local', store, null, 60);
   const data = JSON.parse(fs.readFileSync(store, 'utf8'));
-  const h = Object.keys(data['gstekeeper.local'].tokens)[0];
-  data['gstekeeper.local'].tokens[h] = Date.now() - 1000;
+  const h = Object.keys(data['gatekeeper.local'].tokens)[0];
+  data['gatekeeper.local'].tokens[h] = Date.now() - 1000;
   fs.writeFileSync(store, JSON.stringify(data));
   pruneExpiredTokens(store);
-  const after = JSON.parse(fs.readFileSync(store, 'utf8'))['gstekeeper.local'].tokens;
+  const after = JSON.parse(fs.readFileSync(store, 'utf8'))['gatekeeper.local'].tokens;
   assert.strictEqual(Object.keys(after).length, 0);
   fs.rmSync(dir, { recursive: true, force: true });
 });
@@ -102,11 +102,11 @@ test('stores hashed address and phone', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-'));
   const file = path.join(dir, 'config.yaml');
   const store = path.join(dir, 'devices.json');
-  const cfg = `gatekeeper:\n  controller: "gstekeeper.local"\n  allow_control: true\n  local_only: true\n  private_identity: "id"\n  address: "Street 1"\n  phone: "+123"`;
+  const cfg = `gatekeeper:\n  controller: "gatekeeper.local"\n  allow_control: true\n  local_only: true\n  private_identity: "id"\n  address: "Street 1"\n  phone: "+123"`;
   fs.writeFileSync(file, cfg);
   assert.strictEqual(gateCheck(file, store), true);
   const data = JSON.parse(fs.readFileSync(store, 'utf8'));
-  const entry = data['gstekeeper.local'];
+  const entry = data['gatekeeper.local'];
   const addrHash = crypto.createHash('sha256').update('Street 1').digest('hex');
   const phoneHash = crypto.createHash('sha256').update('+123').digest('hex');
   assert.strictEqual(entry.address, addrHash);
@@ -118,10 +118,10 @@ test('denies control with mismatched address', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-'));
   const file = path.join(dir, 'config.yaml');
   const store = path.join(dir, 'devices.json');
-  const cfgA = `gatekeeper:\n  controller: "gstekeeper.local"\n  allow_control: true\n  local_only: true\n  private_identity: "id"\n  address: "A"`;
+  const cfgA = `gatekeeper:\n  controller: "gatekeeper.local"\n  allow_control: true\n  local_only: true\n  private_identity: "id"\n  address: "A"`;
   fs.writeFileSync(file, cfgA);
   assert.strictEqual(gateCheck(file, store), true);
-  const cfgB = `gatekeeper:\n  controller: "gstekeeper.local"\n  allow_control: true\n  local_only: true\n  private_identity: "id"\n  address: "B"`;
+  const cfgB = `gatekeeper:\n  controller: "gatekeeper.local"\n  allow_control: true\n  local_only: true\n  private_identity: "id"\n  address: "B"`;
   fs.writeFileSync(file, cfgB);
   assert.strictEqual(gateCheck(file, store), false);
   fs.rmSync(dir, { recursive: true, force: true });
@@ -131,7 +131,7 @@ test('logs token issuance', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-'));
   const store = path.join(dir, 'devices.json');
   const logFile = path.join(dir, 'log.json');
-  issueTempToken('gstekeeper.local', store, null, 10, logFile);
+  issueTempToken('gatekeeper.local', store, null, 10, logFile);
   const data = JSON.parse(fs.readFileSync(logFile, 'utf8'));
   assert.strictEqual(data.length, 1);
   assert.strictEqual(data[0].action, 'issue_token');

--- a/tools/gatekeeper.js
+++ b/tools/gatekeeper.js
@@ -146,7 +146,6 @@ function verifyTempToken(controller, storePath, token, logPath) {
   return ok;
 }
 
-function gateCheck(configPath, devicesPath, tempToken, logPath) {
 function pruneExpiredTokens(storePath, now = Date.now()) {
   const devices = readDevices(storePath);
   let changed = false;
@@ -163,14 +162,14 @@ function pruneExpiredTokens(storePath, now = Date.now()) {
   return changed;
 }
 
-function gateCheck(configPath, devicesPath, tempToken) {
+function gateCheck(configPath, devicesPath, tempToken, logPath) {
   const cfg = parseConfig(configPath);
   if (!cfg) {
     console.log('Gatekeeper: configuration missing.');
     return false;
   }
   const deviceFile = devicesPath || path.join(__dirname, '..', 'app', 'gatekeeper_devices.json');
-  const controllerOK = cfg.controller === 'gstekeeper.local';
+  const controllerOK = cfg.controller === 'gatekeeper.local';
   const idHash = identityHash(cfg.private_identity);
   const addrHash = identityHash(cfg.address);
   const phoneHash = identityHash(cfg.phone);
@@ -213,14 +212,14 @@ if (require.main === module) {
   const idHash = identityHash(cfg.private_identity);
   if (cmd === 'token') {
     const dur = parseInt(cfg.temp_token_duration || '86400', 10);
-    const tok = issueTempToken(cfg.controller || 'gstekeeper.local', storePath, idHash, dur, logPath);
+    const tok = issueTempToken(cfg.controller || 'gatekeeper.local', storePath, idHash, dur, logPath);
     console.log(tok);
   } else if (cmd === 'prune') {
     pruneExpiredTokens(storePath);
     console.log('Expired tokens pruned.');
   } else {
     if (gateCheck(cfgPath, storePath, cmd, logPath)) {
-      console.log('Gatekeeper: gstekeeper.local control allowed (local only).');
+      console.log('Gatekeeper: gatekeeper.local control allowed (local only).');
       process.exit(0);
     } else {
       console.log('Gatekeeper: control denied.');

--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -490,7 +490,7 @@ function handleTempToken(req, res) {
   const dur = parseInt(cfg.temp_token_duration || '86400', 10);
   const idHash = cfg.private_identity ? crypto.createHash('sha256').update(String(cfg.private_identity)).digest('hex') : null;
   const token = issueTempToken(
-    cfg.controller || 'gstekeeper.local',
+    cfg.controller || 'gatekeeper.local',
     gateStore,
     idHash,
     dur,


### PR DESCRIPTION
## Summary
- fix spelling of `gatekeeper.local` in README and config
- update tests and code to use new controller name
- remove stray function declaration in `tools/gatekeeper.js`

## Testing
- `node --test`
- `node tools/check-translations.js`
