### PR TITLE
Add background symbol size slider

### DIFF
--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -93,7 +93,11 @@ function initLogoBackground() {
   // Density of floating symbols can be customized via settings
   const storedPct = parseInt(localStorage.getItem('ethicom_bg_fill') || '40', 10);
   const fillRatio = Number.isFinite(storedPct) ? storedPct / 100 : 0.4;
-  const avgSize = levels.reduce((sum, lvl) => sum + 30 + lvl * 10 + 5, 0) / levels.length;
+  const storedSize = parseInt(localStorage.getItem('ethicom_bg_symbol_size') || '100', 10);
+  const sizeScale = Number.isFinite(storedSize) ? storedSize / 100 : 1;
+  const avgSize =
+    levels.reduce((sum, lvl) => sum + (30 + lvl * 10 + 5) * sizeScale, 0) /
+    levels.length;
   const avgArea = avgSize * avgSize;
   const maxSymbols = Math.floor(canvas.width * canvas.height / avgArea);
   const total = Math.max(20, Math.floor(maxSymbols * fillRatio));
@@ -104,7 +108,7 @@ function initLogoBackground() {
     const mass = lvl + 1;
     const count = lvl >= 8 ? lvl - 6 : 1;
     const hue = lvl >= 8 ? (lvl - 7) * 30 : 0;
-    const size = 30 + lvl * 10 + Math.random() * 10;
+    const size = (30 + lvl * 10 + Math.random() * 10) * sizeScale;
     const radius = size / 2;
     const subSize = size / count;
     const x = Math.random() * (canvas.width - size) + radius;

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -80,6 +80,11 @@
           <input type="range" id="bg_symbol_hue" min="0" max="360" step="1" value="0" />
             <small class="note">Reload to apply.</small>
         </div>
+        <div id="bg_symbol_size_wrap">
+          <label for="bg_symbol_size">Tanna size: <span id="bg_symbol_size_val">100</span>%</label>
+          <input type="range" id="bg_symbol_size" min="50" max="200" step="10" value="100" />
+            <small class="note">Reload to apply.</small>
+        </div>
       </div>
     </details>
     <details class="card">
@@ -269,6 +274,19 @@
         hueSlider.addEventListener('input', e => hueVal.textContent = e.target.value);
         hueSlider.addEventListener('change', e => {
           localStorage.setItem('ethicom_bg_symbol_hue', e.target.value);
+          alert('Reload the page to apply.');
+        });
+      }
+
+      const sizeSlider = document.getElementById('bg_symbol_size');
+      const sizeVal = document.getElementById('bg_symbol_size_val');
+      if (sizeSlider && sizeVal) {
+        const storedSize = parseInt(localStorage.getItem('ethicom_bg_symbol_size') || '100', 10);
+        sizeSlider.value = storedSize;
+        sizeVal.textContent = storedSize;
+        sizeSlider.addEventListener('input', e => sizeVal.textContent = e.target.value);
+        sizeSlider.addEventListener('change', e => {
+          localStorage.setItem('ethicom_bg_symbol_size', e.target.value);
           alert('Reload the page to apply.');
         });
       }


### PR DESCRIPTION
## Summary
- support background symbol size setting in logo animation
- add slider for Tanna symbol size in settings

## Testing
- `node --test` *(fails: SyntaxError in tools/gatekeeper.js)*
- `node tools/check-translations.js`