### PR TITLE
Implement gatekeeper image creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,13 @@ Registrierungsdaten werden offline gehasht gespeichert. Keine Gewährleistung f�
 Adressen und Telefonnummern werden ebenfalls offline gehasht gespeichert.
 **4789**
 
+### Gatekeeper Image
+[⇧](#contents)
+
+Run `node tools/generate-gatekeeper-image.js <dir> <seconds>` to create a minimal folder
+with `gatekeeper.js`, `gatekeeper_config.yaml` and a temporary token.
+Copy that folder to another device and run `node gatekeeper.js <token>` for delegated control during that time.
+
 ### API Access Control
 [⇧](#contents)
 

--- a/test/gatekeeper-image.test.js
+++ b/test/gatekeeper-image.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
+
+const script = path.join(__dirname, '..', 'tools', 'generate-gatekeeper-image.js');
+
+function runScript(dir) {
+  return spawnSync('node', [script, dir, '60'], { encoding: 'utf8' });
+}
+
+test('creates gatekeeper image with token', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gimg-'));
+  const res = runScript(dir);
+  assert.strictEqual(res.status, 0);
+  const tokenFile = path.join(dir, 'temp_token.txt');
+  const gkFile = path.join(dir, 'gatekeeper.js');
+  const cfgFile = path.join(dir, 'gatekeeper_config.yaml');
+  assert.ok(fs.existsSync(tokenFile));
+  assert.ok(fs.existsSync(gkFile));
+  assert.ok(fs.existsSync(cfgFile));
+  const token = fs.readFileSync(tokenFile, 'utf8').trim();
+  assert.ok(/^[a-f0-9]{32}$/.test(token));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+

--- a/tools/generate-gatekeeper-image.js
+++ b/tools/generate-gatekeeper-image.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { issueTempToken, parseConfig } = require('./gatekeeper.js');
+
+const outDir = process.argv[2] ? path.resolve(process.argv[2]) : path.join(__dirname, '..', 'gatekeeper_image');
+const duration = parseInt(process.argv[3] || '3600', 10);
+
+const cfgPath = path.join(__dirname, '..', 'app', 'gatekeeper_config.yaml');
+const storePath = path.join(__dirname, '..', 'app', 'gatekeeper_devices.json');
+const logPath = path.join(__dirname, '..', 'app', 'gatekeeper_log.json');
+
+const cfg = parseConfig(cfgPath) || {};
+const idHash = cfg.private_identity
+  ? crypto.createHash('sha256').update(String(cfg.private_identity)).digest('hex')
+  : null;
+
+if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+
+const token = issueTempToken(
+  cfg.controller || 'gatekeeper.local',
+  storePath,
+  idHash,
+  duration,
+  logPath
+);
+
+fs.copyFileSync(path.join(__dirname, 'gatekeeper.js'), path.join(outDir, 'gatekeeper.js'));
+fs.copyFileSync(cfgPath, path.join(outDir, 'gatekeeper_config.yaml'));
+fs.writeFileSync(path.join(outDir, 'temp_token.txt'), token);
+
+console.log(`Gatekeeper image written to ${outDir}`);
+console.log(`Token: ${token}`);
+


### PR DESCRIPTION
## Summary
- add `generate-gatekeeper-image.js` to package gatekeeper files with a temp token
- document how to create a gatekeeper image
- test image generation

## Testing
- `node --test`
- `node tools/check-translations.js`
