### PR TITLE
Add gatekeeper GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ Verify the stored hashes after updates with:
 ```bash
 node tools/verify-gatekeeper.js
 ```
+For a simple web interface run `node tools/gatekeeper-gui.js` and open the printed
+URL (default `http://localhost:8675/gatekeeper.html`).
 Registrierungsdaten werden offline gehasht gespeichert. Keine Gewährleistung für absolute Anonymität.
 Adressen und Telefonnummern werden ebenfalls offline gehasht gespeichert.
 **4789**

--- a/interface/gatekeeper.html
+++ b/interface/gatekeeper.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Gatekeeper</title>
+  <link rel="stylesheet" href="ethicom-style.css" />
+</head>
+<body>
+  <header><h1>Gatekeeper</h1></header>
+  <main>
+    <button id="check_btn" class="accent-button">Check Gate</button>
+    <p id="check_result" class="note"></p>
+    <button id="tok_btn" class="accent-button">Generate Token</button>
+    <p id="tok_out" class="note"></p>
+    <button id="prune_btn" class="accent-button">Prune Tokens</button>
+    <p id="prune_out" class="note"></p>
+  </main>
+  <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const checkBtn = document.getElementById('check_btn');
+    const resP = document.getElementById('check_result');
+    const tokBtn = document.getElementById('tok_btn');
+    const tokOut = document.getElementById('tok_out');
+    const pruneBtn = document.getElementById('prune_btn');
+    const pruneOut = document.getElementById('prune_out');
+
+    checkBtn.addEventListener('click', () => {
+      fetch('/check').then(r => r.json()).then(d => {
+        resP.textContent = d.allowed ? 'Allowed' : 'Denied';
+      });
+    });
+
+    tokBtn.addEventListener('click', () => {
+      fetch('/token', {method:'POST'}).then(r => r.json()).then(d => {
+        tokOut.textContent = d.token + ' (expires in ' + d.expires_in + 's)';
+      });
+    });
+
+    pruneBtn.addEventListener('click', () => {
+      fetch('/prune', {method:'POST'}).then(r => r.text()).then(t => {
+        pruneOut.textContent = t;
+      });
+    });
+  });
+  </script>
+</body>
+</html>

--- a/tools/gatekeeper-gui.js
+++ b/tools/gatekeeper-gui.js
@@ -1,0 +1,70 @@
+const http = require('http');
+const path = require('path');
+const fs = require('fs');
+const crypto = require('crypto');
+const {
+  gateCheck,
+  issueTempToken,
+  pruneExpiredTokens,
+  parseConfig
+} = require('./gatekeeper.js');
+
+const port = process.env.GATEKEEPER_GUI_PORT || 8675;
+const cfgPath = path.join(__dirname, '..', 'app', 'gatekeeper_config.yaml');
+const storePath = path.join(__dirname, '..', 'app', 'gatekeeper_devices.json');
+const logPath = path.join(__dirname, '..', 'app', 'gatekeeper_log.json');
+const htmlPath = path.join(__dirname, '..', 'interface', 'gatekeeper.html');
+
+function serveFile(p, res) {
+  fs.createReadStream(p).on('error', () => {
+    res.statusCode = 404;
+    res.end('Not found');
+  }).pipe(res);
+}
+
+const server = http.createServer((req, res) => {
+  const urlPath = decodeURIComponent(req.url.split('?')[0]);
+  if (req.method === 'POST' && urlPath === '/token') {
+    const cfg = parseConfig(cfgPath) || {};
+    const dur = parseInt(cfg.temp_token_duration || '86400', 10);
+    const idHash = cfg.private_identity
+      ? crypto.createHash('sha256').update(String(cfg.private_identity)).digest('hex')
+      : null;
+    const tok = issueTempToken(
+      cfg.controller || 'gatekeeper.local',
+      storePath,
+      idHash,
+      dur,
+      logPath
+    );
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ token: tok, expires_in: dur }));
+    return;
+  }
+  if (req.method === 'POST' && urlPath === '/prune') {
+    pruneExpiredTokens(storePath);
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('pruned');
+    return;
+  }
+  if (req.method === 'GET' && urlPath === '/check') {
+    const ok = gateCheck(cfgPath, storePath, undefined, logPath);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ allowed: ok }));
+    return;
+  }
+  if (urlPath === '/' || urlPath === '/gatekeeper.html') {
+    serveFile(htmlPath, res);
+  } else {
+    res.statusCode = 404;
+    res.end('Not found');
+  }
+});
+
+if (require.main === module) {
+  server.listen(port, () => {
+    console.log(`Gatekeeper GUI at http://localhost:${port}/gatekeeper.html`);
+  });
+} else {
+  module.exports = server;
+}


### PR DESCRIPTION
## Summary
- provide `gatekeeper-gui.js` to launch a tiny web UI for the gatekeeper
- add `gatekeeper.html` with buttons for check, token and pruning
- document the new GUI option in README

## Testing
- `node --test`
- `node tools/check-translations.js`
