### PR TITLE
Implement auto-collapse in settings

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -252,6 +252,10 @@ details.card > *:not(summary) {
   align-content: start;
 }
 
+.settings-grid > details[open] {
+  grid-column: 1 / -1;
+}
+
 .module {
   background-color: var(--module-color);
   color: var(--text-color);

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -354,6 +354,15 @@
             });
         });
       }
+
+      const all = document.querySelectorAll('.settings-grid details');
+      all.forEach(det => {
+        det.addEventListener('toggle', () => {
+          if (det.open) {
+            all.forEach(other => { if (other !== det) other.open = false; });
+          }
+        });
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- update settings grid styles so expanded details span all columns
- ensure only one details section can stay open at a time in settings

## Testing
- `node --test`
- `node tools/check-translations.js`
