### PR TITLE
Fix table cell injection in fish interface

### DIFF
--- a/interface/fish-interface/fischEditor.js
+++ b/interface/fish-interface/fischEditor.js
@@ -20,7 +20,19 @@ async function initFischEditor() {
     tbody.innerHTML = '';
     list.forEach(f => {
       const row = document.createElement('tr');
-      row.innerHTML = `<td>${f.name}</td><td>${f.scientific_name}</td><td>${f.type}</td><td>${f.habitat}</td><td>${f.max_cm}</td><td>${f.spawn}</td>`;
+      const cells = [
+        f.name,
+        f.scientific_name,
+        f.type,
+        f.habitat,
+        f.max_cm,
+        f.spawn
+      ];
+      cells.forEach(value => {
+        const cell = document.createElement('td');
+        cell.textContent = value;
+        row.appendChild(cell);
+      });
       tbody.appendChild(row);
     });
   }

--- a/interface/fish-interface/fischeBern.js
+++ b/interface/fish-interface/fischeBern.js
@@ -6,8 +6,27 @@ async function initFischeBern() {
     const tbody = document.createElement('tbody');
     list.forEach(f => {
       const row = document.createElement('tr');
-      const img = f.image ? `<img class="fish-image" src="../../${f.image}" alt="${f.name}">` : '';
-      row.innerHTML = `<td>${f.name}</td><td>${img}</td><td>${f.scientific_name}</td><td>${f.type}</td><td>${f.habitat}</td><td>${f.max_cm}</td><td>${f.spawn}</td>`;
+
+      const nameCell = document.createElement('td');
+      nameCell.textContent = f.name;
+      row.appendChild(nameCell);
+
+      const imgCell = document.createElement('td');
+      if (f.image) {
+        const imgElem = document.createElement('img');
+        imgElem.className = 'fish-image';
+        imgElem.src = `../../${f.image}`;
+        imgElem.alt = f.name;
+        imgCell.appendChild(imgElem);
+      }
+      row.appendChild(imgCell);
+
+      [f.scientific_name, f.type, f.habitat, f.max_cm, f.spawn].forEach(value => {
+        const cell = document.createElement('td');
+        cell.textContent = value;
+        row.appendChild(cell);
+      });
+
       tbody.appendChild(row);
     });
     table.appendChild(tbody);


### PR DESCRIPTION
## Summary
- sanitize fish list rendering using DOM APIs
- avoid HTML injection when displaying Bern fish data

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_683a35c0cee08321965c450b7e6402e1