### PR TITLE
Add background damping setting

### DIFF
--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -2,7 +2,9 @@ function initLogoBackground() {
   const container = document.getElementById('op_background');
   if (!container) return;
 
-  const RESTITUTION = 0.9;
+  let RESTITUTION = 1;
+  const storedRest = parseFloat(localStorage.getItem('ethicom_bg_restitution'));
+  if (!Number.isNaN(storedRest)) RESTITUTION = storedRest;
 
   function rgbToHue(r, g, b) {
     r /= 255; g /= 255; b /= 255;

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -94,6 +94,11 @@
           <input type="range" id="bg_symbol_size" min="50" max="200" step="10" value="100" />
             <small class="note">Reload to apply.</small>
         </div>
+        <div id="bg_damping_wrap">
+          <label for="bg_damping">Tanna damping: <span id="bg_damping_val">1</span></label>
+          <input type="range" id="bg_damping" min="0" max="1" step="0.05" value="1" />
+            <small class="note">Reload to apply.</small>
+        </div>
       </div>
     </details>
     <details class="card">
@@ -297,6 +302,19 @@
           sizeSlider.addEventListener('input', e => sizeVal.textContent = e.target.value);
           sizeSlider.addEventListener('change', e => {
             localStorage.setItem('ethicom_bg_symbol_size', e.target.value);
+            alert('Reload the page to apply.');
+          });
+        }
+
+      const dampSlider = document.getElementById('bg_damping');
+      const dampVal = document.getElementById('bg_damping_val');
+        if (dampSlider && dampVal) {
+          const storedDamp = parseFloat(localStorage.getItem('ethicom_bg_restitution') || '1');
+          dampSlider.value = storedDamp;
+          dampVal.textContent = storedDamp;
+          dampSlider.addEventListener('input', e => dampVal.textContent = e.target.value);
+          dampSlider.addEventListener('change', e => {
+            localStorage.setItem('ethicom_bg_restitution', e.target.value);
             alert('Reload the page to apply.');
           });
         }


### PR DESCRIPTION
## Summary
- let users configure tanna damping factor
- read stored damping value in logo background

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_683a3d1ba32c83218eeb283820a774ce