### PR TITLE
Add simple navigator explorer

### DIFF
--- a/i18n/ui-text.json
+++ b/i18n/ui-text.json
@@ -103,6 +103,7 @@
     "connect_approve": "Approve",
     "connect_request_sent": "Request sent.",
     "connect_error": "Request failed.",
+    "nav_navigator": "Navigator",
     "nav_story": "Story"
   },
   "de": {
@@ -208,6 +209,7 @@
     "connect_approve": "Bestätigen",
     "connect_request_sent": "Anfrage gesendet.",
     "connect_error": "Anfrage fehlgeschlagen.",
+    "nav_navigator": "Navigator",
     "nav_story": "Geschichte"
   },
   "fr": {

--- a/interface/navigator.html
+++ b/interface/navigator.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Navigator</title>
+  <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="../utils/op-level.js"></script>
+  <script src="ethicom-utils.js"></script>
+  <script src="accessibility.js"></script>
+  <script src="theme-manager.js"></script>
+  <script src="logo-background.js"></script>
+  <script src="side-drop.js"></script>
+  <script src="op-side-nav.js"></script>
+  <script src="module-logo.js"></script>
+  <script type="module" src="navigator.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main_content">Skip to main content</a>
+  <div id="op_background"></div>
+  <header>
+    <h1>Navigator</h1>
+    <nav aria-label="Main navigation">
+      <a href="../home.html">Home</a>
+      <a href="../bewertung.html">Bewertung</a>
+      <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="login.html">Login</a>
+      <a href="../wings/ratings.html">Ratings</a>
+      <a href="signup.html">Signup</a>
+      <a href="genealogie.html">Genealogie</a>
+      <a href="navigator.html" aria-current="page">Navigator</a>
+      <a href="../README.html" class="readme-link">README</a>
+    </nav>
+  </header>
+  <main id="main_content">
+    <section class="card">
+      <h2>File Explorer</h2>
+      <ul id="file_list"></ul>
+    </section>
+  </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      applyTheme('tanna-dark');
+      initSideDrop('op-navigation.html');
+      const menu = document.getElementById('side_menu');
+      if (menu) menu.addEventListener('click', e => { e.preventDefault(); toggleSideDrop(); });
+    });
+  </script>
+  <div id="side_drop"></div>
+</body>
+</html>

--- a/interface/navigator.js
+++ b/interface/navigator.js
@@ -1,0 +1,38 @@
+function sanitize(path) {
+  return path.replace(/\.{2,}/g, '').replace(/\\/g, '/');
+}
+
+async function loadExplorer(path = '') {
+  const res = await fetch(`/api/explorer?path=${encodeURIComponent(path)}`);
+  if (!res.ok) return;
+  const entries = await res.json();
+  const list = document.getElementById('file_list');
+  list.innerHTML = '';
+  const up = path.split('/').filter(Boolean);
+  if (up.length) {
+    const parent = up.slice(0, -1).join('/');
+    const li = document.createElement('li');
+    li.innerHTML = `<button data-path="${parent}">..</button>`;
+    list.appendChild(li);
+  }
+  entries.forEach(e => {
+    const li = document.createElement('li');
+    if (e.dir) {
+      li.innerHTML = `<button data-path="${sanitize(path ? path + '/' + e.name : e.name)}">${e.name}/</button>`;
+    } else {
+      li.textContent = e.name;
+    }
+    list.appendChild(li);
+  });
+  list.querySelectorAll('button').forEach(btn => {
+    btn.addEventListener('click', () => loadExplorer(btn.dataset.path));
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadExplorer();
+});
+
+if (typeof window !== 'undefined') {
+  window.loadExplorer = loadExplorer;
+}

--- a/interface/op0-navigation.js
+++ b/interface/op0-navigation.js
@@ -31,6 +31,7 @@
       `<a href="${base}interface/norman.html">Norman</a>`+
       `<a href="${base}interface/material.html">Material</a>`+
       `<a href="${base}interface/apple-hig.html">Apple\u00a0HIG</a>`+
+      `<a href="${base}interface/navigator.html">Navigator</a>`+
       `<a href="${base}README.html">README</a>`+
       '</nav>';
     document.body.insertAdjacentHTML('afterbegin', navHtml);


### PR DESCRIPTION
## Summary
- add Navigator link to OP-0 navigation
- implement a basic file explorer page
- support explorer API route in the server
- provide English and German translations for Navigator

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_683a3c8252a883218726ccc6cf7edbfb