### PR TITLE
Fix theme persistence

### DIFF
--- a/README.html
+++ b/README.html
@@ -73,7 +73,6 @@
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      applyTheme('tanna');
       initLogoBackground();
       fetch('README.md')
         .then(r => r.text())

--- a/bewertung.html
+++ b/bewertung.html
@@ -42,7 +42,6 @@
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      applyTheme('tanna-dark');
       initBewertung();
       initSideDrop('interface/op-navigation.html');
       const menu = document.getElementById('side_menu');

--- a/interface/apple-hig.html
+++ b/interface/apple-hig.html
@@ -39,10 +39,5 @@
       </ol>
     </section>
   </main>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      applyTheme('tanna-dark');
-    });
-  </script>
 </body>
 </html>

--- a/interface/donate.html
+++ b/interface/donate.html
@@ -50,7 +50,6 @@
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      applyTheme('tanna');
       if (typeof initDonation === 'function') initDonation();
       initSideDrop('op-navigation.html');
       const menu=document.getElementById('side_menu');

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -66,7 +66,6 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       getLanguage();
-      applyTheme('tanna-dark');
       if (typeof renderOpOverview === 'function') renderOpOverview();
       initSideDrop('op-navigation.html');
       const menu = document.getElementById('side_menu');

--- a/interface/fish-interface/fischEditor.html
+++ b/interface/fish-interface/fischEditor.html
@@ -56,7 +56,6 @@
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      applyTheme('tanna');
       initSideDrop('../op-navigation.html');
       const menu=document.getElementById('side_menu');
       if(menu) menu.addEventListener('click',e=>{e.preventDefault();toggleSideDrop();});

--- a/interface/fish-interface/fischeBern.html
+++ b/interface/fish-interface/fischeBern.html
@@ -47,7 +47,6 @@
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      applyTheme('tanna');
       initSideDrop('../op-navigation.html');
       const menu=document.getElementById('side_menu');
       if(menu) menu.addEventListener('click',e=>{e.preventDefault();toggleSideDrop();});

--- a/interface/fish.html
+++ b/interface/fish.html
@@ -43,10 +43,5 @@
       </p>
     </section>
   </main>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      applyTheme('tanna-dark');
-    });
-  </script>
 </body>
 </html>

--- a/interface/genealogie.html
+++ b/interface/genealogie.html
@@ -40,7 +40,6 @@
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      applyTheme('tanna-dark');
       if (typeof initGenealogie === 'function') initGenealogie();
       initSideDrop('op-navigation.html');
       const menu=document.getElementById('side_menu');

--- a/interface/hermes.html
+++ b/interface/hermes.html
@@ -57,7 +57,6 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       getLanguage();
-      applyTheme('tanna-dark');
       renderBadge(getStoredOpLevel() || 'OP-0', getStoredOpLevel() || 'OP-0');
       if (typeof initHermes === 'function') initHermes();
       initSideDrop('op-navigation.html');

--- a/interface/material.html
+++ b/interface/material.html
@@ -37,10 +37,5 @@
       </ol>
     </section>
   </main>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      applyTheme('tanna-dark');
-    });
-  </script>
 </body>
 </html>

--- a/interface/navigator.html
+++ b/interface/navigator.html
@@ -40,7 +40,6 @@
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      applyTheme('tanna-dark');
       initSideDrop('op-navigation.html');
       const menu = document.getElementById('side_menu');
       if (menu) menu.addEventListener('click', e => { e.preventDefault(); toggleSideDrop(); });

--- a/interface/nielsen.html
+++ b/interface/nielsen.html
@@ -44,10 +44,5 @@
       </ol>
     </section>
   </main>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      applyTheme('tanna-dark');
-    });
-  </script>
 </body>
 </html>

--- a/interface/norman.html
+++ b/interface/norman.html
@@ -40,10 +40,5 @@
       </ol>
     </section>
   </main>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      applyTheme('tanna-dark');
-    });
-  </script>
 </body>
 </html>

--- a/interface/shneiderman.html
+++ b/interface/shneiderman.html
@@ -42,10 +42,5 @@
       </ol>
     </section>
   </main>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      applyTheme('tanna-dark');
-    });
-  </script>
 </body>
 </html>

--- a/interface/start.html
+++ b/interface/start.html
@@ -57,10 +57,5 @@
       </ul>
     </section>
   </main>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      applyTheme('tanna-dark');
-    });
-  </script>
 </body>
 </html>

--- a/start.html
+++ b/start.html
@@ -54,10 +54,5 @@
       </ul>
     </section>
   </main>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      applyTheme('tanna-dark');
-    });
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove inline `applyTheme()` calls that overrode local theme choice
- delete now-empty DOMContentLoaded handlers

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_683a4778c3448321a0af5ed7d3f38177