### PR TITLE
Ensure color choices persist

### DIFF
--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -74,6 +74,13 @@
     } catch {}
     applyStoredColors();
   });
+  document.addEventListener('themeChanged', () => {
+    try {
+      const tc = JSON.parse(localStorage.getItem('ethicom_text_color') || 'null');
+      if (tc) applyTextColor(tc);
+    } catch {}
+    applyStoredColors();
+  });
 })();
 
 function getReadmePath(lang) {


### PR DESCRIPTION
## Summary
- trigger color application whenever the theme changes so that stored settings stay active

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_683a4a22201083218079f3d55dff09e2