### PR TITLE
Add vibration on rating

### DIFF
--- a/interface/bewertung.js
+++ b/interface/bewertung.js
@@ -5,6 +5,16 @@ let ratingInfo = {};
 let detailsMap = {};
 let candidateList = [];
 
+function vibrateHeartbeat() {
+  if (
+    window.touchSettings &&
+    window.touchSettings.state.haptics &&
+    navigator.vibrate
+  ) {
+    navigator.vibrate([60, 40, 60]);
+  }
+}
+
 async function loadRatingTexts() {
   try {
     const txt = await fetch('i18n/ui-text.json').then(r => r.json());
@@ -212,6 +222,7 @@ function submitBewertung() {
   const lvl = parseInt(evalData.op_level.replace('OP-', '').split('.')[0], 10) || 0;
   if (lvl > ratingInfo[human_id].max) ratingInfo[human_id].max = lvl;
   alert(ratingTexts.rating_saved || 'Rating saved.');
+  vibrateHeartbeat();
 }
 
 if (typeof module !== 'undefined') {

--- a/interface_OLD/modules/op-0-human-interface.js
+++ b/interface_OLD/modules/op-0-human-interface.js
@@ -1,3 +1,13 @@
+function vibrateHeartbeat() {
+  if (
+    window.touchSettings &&
+    window.touchSettings.state.haptics &&
+    navigator.vibrate
+  ) {
+    navigator.vibrate([60, 40, 60]);
+  }
+}
+
 function initOP0HumanInterface() {
   const container = document.getElementById("op_interface");
   if (!container) return;
@@ -93,4 +103,5 @@ function submitOP0HumanEval() {
   } else if (typeof recordEvidence === "function") {
     recordEvidence(JSON.stringify(evalData), "user");
   }
+  vibrateHeartbeat();
 }

--- a/interface_OLD/modules/op-0-interface.js
+++ b/interface_OLD/modules/op-0-interface.js
@@ -1,5 +1,15 @@
 // op-0-interface.js – OP-0: Anonyme Bewertung (keine Signatur, minimale Verantwortung)
 
+function vibrateHeartbeat() {
+  if (
+    window.touchSettings &&
+    window.touchSettings.state.haptics &&
+    navigator.vibrate
+  ) {
+    navigator.vibrate([60, 40, 60]);
+  }
+}
+
 async function initOP0Interface() {
   const container = document.getElementById("op_interface");
   if (!container) return;
@@ -67,4 +77,5 @@ function submitOP0Vote(id) {
     };
     recordEvidence(JSON.stringify(evalData), 'user');
   }
+  vibrateHeartbeat();
 }


### PR DESCRIPTION
## Summary
- trigger haptic vibration when saving a rating
- apply same feedback for OP‑0 rating interfaces

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_683a4d34c5c88321a3f449ae1b752d37