### PR TITLE
Fix color settings persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ README.md -> GET_STARTED.md -> index.html
 | [wings/index.html](wings/index.html) | Mobile interface "Wings" |
 | [wings/ratings.html](wings/ratings.html) | Library of all ratings with search |
 | `interface_OLD/` | Historical demo of the first interface generation |
-**Settings are stored per device using browser localStorage and are not synced globally.**
+**Settings are stored per device using browser localStorage and are not synced globally. Color adjustments made in the settings page apply automatically on every page.**
 **Ratings from OP-1 onward are stored globally with the assigned signature ID. The email used during signup is hashed and never exposed.**
 **Optional GitHub login authenticates via GitHub's OAuth flow. The returned username is hashed and stored offline.**
 **Optional Google login authenticates via Google's OAuth flow. The returned email address is hashed and stored offline.**

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -17,6 +17,15 @@
 
   function applyStoredColors() {
     try {
+      const custom = JSON.parse(localStorage.getItem('ethicom_colors') || '{}');
+      if (custom && typeof custom === 'object') {
+        Object.entries(custom).forEach(([name, val]) => {
+          document.documentElement.style.setProperty(name, String(val));
+        });
+      }
+    } catch {}
+
+    try {
       const bg = JSON.parse(localStorage.getItem('ethicom_bg_color') || 'null');
       if (bg) {
         document.documentElement.style.setProperty(


### PR DESCRIPTION
## Summary
- load custom color variables from localStorage on every page
- clarify that saved colors apply on each page

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_683ad71120888321bac50bfe9f93edba