### PR TITLE
Implement live color sync across tabs

### DIFF
--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -90,6 +90,25 @@
     } catch {}
     applyStoredColors();
   });
+  window.addEventListener('storage', e => {
+    if (!e.key) return;
+    const colorKeys = [
+      'ethicom_colors',
+      'ethicom_bg_color',
+      'ethicom_module_color',
+      'ethicom_tanna_color',
+      'ethicom_text_color'
+    ];
+    if (colorKeys.includes(e.key)) {
+      try {
+        const tc = JSON.parse(localStorage.getItem('ethicom_text_color') || 'null');
+        if (tc) applyTextColor(tc);
+      } catch {}
+      applyStoredColors();
+    } else if (e.key === 'ethicom_theme' && typeof applyTheme === 'function') {
+      applyTheme(e.newValue || 'tanna-dark');
+    }
+  });
 })();
 
 function getReadmePath(lang) {


### PR DESCRIPTION
## Summary
- update `ethicom-utils.js` to listen for `storage` events
- apply stored colors and themes on change so open pages update immediately

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_683b61b5f17c8321b7e01c9a851176cf