### PR TITLE
Refactor color helpers into shared module

### DIFF
--- a/README.html
+++ b/README.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>README – Ethics Structure 4789</title>
   <link rel="stylesheet" href="interface/ethicom-style.css" />
+  <script src="interface/color-utils.js"></script>
   <script src="interface/theme-manager.js"></script>
   <script src="interface/accessibility.js"></script>
   <script src="interface/logo-background.js"></script>

--- a/bewertung.html
+++ b/bewertung.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="interface/ethicom-style.css" />
   <script src="utils/op-level.js"></script>
   <script src="interface/ethicom-utils.js"></script>
+  <script src="interface/color-utils.js"></script>
   <script src="interface/accessibility.js"></script>
   <script src="interface/language-selector.js"></script>
   <script src="interface/theme-manager.js"></script>

--- a/home.html
+++ b/home.html
@@ -9,6 +9,7 @@
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/accessibility.js"></script>
   <script src="interface/color-auth.js"></script>
+  <script src="interface/color-utils.js"></script>
   <script src="interface/language-selector.js"></script>
   <script src="interface/dynamic-info.js"></script>
   <script src="interface/op-overview.js"></script>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <script src="utils/op-level.js"></script>
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/accessibility.js"></script>
+  <script src="interface/color-utils.js"></script>
   <script src="interface/color-auth.js"></script>
   <script src="interface/language-selector.js"></script>
   <script src="interface/dynamic-info.js"></script>

--- a/interface/apple-hig.html
+++ b/interface/apple-hig.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Apple Human Interface Guidelines</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="color-utils.js"></script>
   <script src="theme-manager.js"></script>
   <script src="accessibility.js"></script>
   <script src="slow-mode.js"></script>

--- a/interface/color-utils.js
+++ b/interface/color-utils.js
@@ -1,0 +1,32 @@
+function parseColor(v){
+  v = (v || '').trim();
+  if(v.startsWith('#')){
+    if(v.length === 4) v = '#' + v[1] + v[1] + v[2] + v[2] + v[3] + v[3];
+    const n = parseInt(v.slice(1),16);
+    return {r:(n>>16)&255,g:(n>>8)&255,b:n&255};
+  }
+  const m = v.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  return m ? {r:+m[1],g:+m[2],b:+m[3]} : {r:0,g:0,b:0};
+}
+
+function applyTannaColor(c){
+  localStorage.setItem('ethicom_tanna_color', JSON.stringify(c));
+  if(document.body.classList.contains('theme-tanna') ||
+     document.body.classList.contains('theme-tanna-dark')){
+    const css = `rgb(${c.r},${c.g},${c.b})`;
+    document.documentElement.style.setProperty('--primary-color', css);
+    document.documentElement.style.setProperty('--accent-color', css);
+    const h = `rgba(${Math.round(c.r*0.2)},${Math.round(c.g*0.2)},${Math.round(c.b*0.2)},0.9)`;
+    const n = `rgba(${Math.round(c.r*0.3)},${Math.round(c.g*0.3)},${Math.round(c.b*0.3)},0.9)`;
+    document.documentElement.style.setProperty('--header-bg', h);
+    document.documentElement.style.setProperty('--nav-bg', n);
+  }
+}
+
+if(typeof window !== 'undefined'){
+  window.parseColor = parseColor;
+  window.applyTannaColor = applyTannaColor;
+}
+if(typeof module !== 'undefined' && module.exports){
+  module.exports = { parseColor, applyTannaColor };
+}

--- a/interface/color-wizard.js
+++ b/interface/color-wizard.js
@@ -1,27 +1,8 @@
 // Stepwise color settings wizard
 
-function cwParseCol(v){
-  v = (v || '').trim();
-  if (v.startsWith('#')) {
-    if (v.length === 4) v = '#' + v[1] + v[1] + v[2] + v[2] + v[3] + v[3];
-    const n = parseInt(v.slice(1), 16);
-    return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
-  }
-  const m = v.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
-  return m ? { r: +m[1], g: +m[2], b: +m[3] } : { r: 0, g: 0, b: 0 };
-}
 
 function cwApplyTanna(c){
-  if (document.body.classList.contains('theme-tanna') ||
-      document.body.classList.contains('theme-tanna-dark')) {
-    const css = `rgb(${c.r},${c.g},${c.b})`;
-    document.documentElement.style.setProperty('--primary-color', css);
-    document.documentElement.style.setProperty('--accent-color', css);
-    const h = `rgba(${Math.round(c.r*0.2)},${Math.round(c.g*0.2)},${Math.round(c.b*0.2)},0.9)`;
-    const n = `rgba(${Math.round(c.r*0.3)},${Math.round(c.g*0.3)},${Math.round(c.b*0.3)},0.9)`;
-    document.documentElement.style.setProperty('--header-bg', h);
-    document.documentElement.style.setProperty('--nav-bg', n);
-  }
+  applyTannaColor(c);
 }
 
 function cwApplyTannaCSS(c, css){
@@ -35,7 +16,7 @@ function cwApplyTannaCSS(c, css){
 }
 
 function cwBuildColorStep(title, storeKey, cssVar, prefix, applyFn){
-  const def = cwParseCol(getComputedStyle(document.documentElement).getPropertyValue(cssVar.var||cssVar));
+  const def = parseColor(getComputedStyle(document.documentElement).getPropertyValue(cssVar.var||cssVar));
   let cur;
   try { cur = JSON.parse(localStorage.getItem(storeKey) || 'null'); } catch {}
   if (!cur) cur = def;
@@ -169,7 +150,7 @@ function openColorSettingsWizardCLI(){
     if(typeof applyTheme==='function') applyTheme(theme);
   }
 
-  function parse(v){return cwParseCol(v);} // reuse parser
+  function parse(v){return parseColor(v);} // reuse parser
   function ask(key,cssVar,label,apply){
     let def=parse(getComputedStyle(document.documentElement).getPropertyValue(cssVar));
     try{const s=JSON.parse(localStorage.getItem(key)||'null');if(s) def=s;}catch{}

--- a/interface/connect.html
+++ b/interface/connect.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
+  <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="slow-mode.js"></script>
   <script src="theme-manager.js"></script>

--- a/interface/donate.html
+++ b/interface/donate.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
+  <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="slow-mode.js"></script>
   <script src="donate.js"></script>

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
+  <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="slow-mode.js"></script>
   <script src="language-selector.js"></script>

--- a/interface/fish-interface/fischEditor.html
+++ b/interface/fish-interface/fischEditor.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="../ethicom-style.css" />
   <script src="../../utils/op-level.js"></script>
   <script src="../ethicom-utils.js"></script>
+  <script src="../color-utils.js"></script>
   <script src="../accessibility.js"></script>
   <script src="../theme-manager.js"></script>
   <script src="../logo-background.js"></script>

--- a/interface/fish-interface/fischeBern.html
+++ b/interface/fish-interface/fischeBern.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="../ethicom-style.css" />
   <script src="../../utils/op-level.js"></script>
   <script src="../ethicom-utils.js"></script>
+  <script src="../color-utils.js"></script>
   <script src="../accessibility.js"></script>
   <script src="../theme-manager.js"></script>
   <script src="../logo-background.js"></script>

--- a/interface/fish-interface/fischeSchweiz.html
+++ b/interface/fish-interface/fischeSchweiz.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="../ethicom-style.css" />
   <script src="../../utils/op-level.js"></script>
   <script src="../ethicom-utils.js"></script>
+  <script src="../color-utils.js"></script>
   <script src="../accessibility.js"></script>
   <script src="../theme-manager.js"></script>
   <script src="../logo-background.js"></script>

--- a/interface/fish-interface/gewaesserBern.html
+++ b/interface/fish-interface/gewaesserBern.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="../ethicom-style.css" />
   <script src="../../utils/op-level.js"></script>
   <script src="../ethicom-utils.js"></script>
+  <script src="../color-utils.js"></script>
   <script src="../accessibility.js"></script>
   <script src="../theme-manager.js"></script>
   <script src="../logo-background.js"></script>

--- a/interface/fish.html
+++ b/interface/fish.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
+  <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="slow-mode.js"></script>
   <script src="theme-manager.js"></script>

--- a/interface/genealogie.html
+++ b/interface/genealogie.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
+  <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="slow-mode.js"></script>
   <script src="genealogie.js"></script>

--- a/interface/hermes.html
+++ b/interface/hermes.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
+  <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="slow-mode.js"></script>
   <script src="language-selector.js"></script>

--- a/interface/login.html
+++ b/interface/login.html
@@ -8,6 +8,7 @@
   <script src="language-selector.js"></script>
   <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
+  <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="slow-mode.js"></script>
   <script src="login.js"></script>

--- a/interface/material.html
+++ b/interface/material.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Material Design Prinzipien</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="color-utils.js"></script>
   <script src="theme-manager.js"></script>
   <script src="accessibility.js"></script>
   <script src="slow-mode.js"></script>

--- a/interface/navigator.html
+++ b/interface/navigator.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
+  <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>

--- a/interface/nielsen.html
+++ b/interface/nielsen.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Nielsens Heuristiken</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="color-utils.js"></script>
   <script src="theme-manager.js"></script>
   <script src="accessibility.js"></script>
   <script src="slow-mode.js"></script>

--- a/interface/norman.html
+++ b/interface/norman.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Normans Prinzipien</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="color-utils.js"></script>
   <script src="theme-manager.js"></script>
   <script src="accessibility.js"></script>
   <script src="slow-mode.js"></script>

--- a/interface/op-story.html
+++ b/interface/op-story.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
+  <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
+  <script src="color-utils.js"></script>
   <script src="language-selector.js"></script>
   <script src="theme-manager.js"></script>
   <script src="color-wizard.js"></script>
@@ -146,16 +147,6 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       initLanguageDropdown('lang_select');
-      function parseCol(v){
-        v=(v||'').trim();
-        if(v.startsWith('#')){
-          if(v.length===4) v='#'+v[1]+v[1]+v[2]+v[2]+v[3]+v[3];
-          const n=parseInt(v.slice(1),16);
-          return {r:(n>>16)&255,g:(n>>8)&255,b:n&255};
-        }
-        const m=v.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
-        return m?{r:+m[1],g:+m[2],b:+m[3]}:{r:0,g:0,b:0};
-      }
       function initColorSliders(){
         const wrap=document.getElementById('color_scheme');
         if(!wrap) return;
@@ -169,7 +160,7 @@
         const stored=JSON.parse(localStorage.getItem('ethicom_colors')||'{}');
         wrap.innerHTML='';
         for(const [name,label] of Object.entries(vars)){
-          const base=parseCol(stored[name]||getComputedStyle(document.documentElement).getPropertyValue(name));
+          const base=parseColor(stored[name]||getComputedStyle(document.documentElement).getPropertyValue(name));
           const b=document.createElement('div');
           const sample=textVars.has(name)?'Text':'';
           b.innerHTML=`<strong>${label}</strong><br>
@@ -233,17 +224,7 @@
         trv.textContent=c.r;
         tgv.textContent=c.g;
         tbv.textContent=c.b;
-        localStorage.setItem('ethicom_tanna_color',JSON.stringify(c));
-        if(document.body.classList.contains('theme-tanna') ||
-           document.body.classList.contains('theme-tanna-dark')){
-          const css=`rgb(${c.r},${c.g},${c.b})`;
-          document.documentElement.style.setProperty('--primary-color',css);
-          document.documentElement.style.setProperty('--accent-color',css);
-          const h=`rgba(${Math.round(c.r*0.2)},${Math.round(c.g*0.2)},${Math.round(c.b*0.2)},0.9)`;
-          const n=`rgba(${Math.round(c.r*0.3)},${Math.round(c.g*0.3)},${Math.round(c.b*0.3)},0.9)`;
-          document.documentElement.style.setProperty('--header-bg',h);
-          document.documentElement.style.setProperty('--nav-bg',n);
-        }
+        applyTannaColor(c);
         if(tp) tp.style.backgroundColor=`rgb(${c.r},${c.g},${c.b})`;
         warn.style.display=contrast(c)<2?'inline':'none';
       }

--- a/interface/shneiderman.html
+++ b/interface/shneiderman.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Shneidermans Regeln</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="color-utils.js"></script>
   <script src="theme-manager.js"></script>
   <script src="accessibility.js"></script>
   <script src="slow-mode.js"></script>

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -8,6 +8,7 @@
   <script src="language-selector.js"></script>
   <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
+  <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="slow-mode.js"></script>
   <script src="signup.js"></script>

--- a/interface/start.html
+++ b/interface/start.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>
   <script src="ethicom-utils.js"></script>
+  <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
   <script src="slow-mode.js"></script>
   <style>

--- a/interface/tanna-animation.html
+++ b/interface/tanna-animation.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Tanna Animation</title>
   <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="color-utils.js"></script>
   <script src="theme-manager.js"></script>
   <script src="accessibility.js"></script>
   <script src="logo-background.js"></script>

--- a/interface/theme-manager.js
+++ b/interface/theme-manager.js
@@ -75,16 +75,6 @@ function initThemeSelection() {
   }
 }
 
-function parseCol(v){
-  v=(v||'').trim();
-  if(v.startsWith('#')){
-    if(v.length===4) v='#'+v[1]+v[1]+v[2]+v[2]+v[3]+v[3];
-    const n=parseInt(v.slice(1),16);
-    return {r:(n>>16)&255,g:(n>>8)&255,b:n&255};
-  }
-  const m=v.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
-  return m?{r:+m[1],g:+m[2],b:+m[3]}:{r:0,g:0,b:0};
-}
 
 function createCustomTheme() {
   const overlay = document.createElement('div');
@@ -111,7 +101,7 @@ function createCustomTheme() {
   const groups = [];
   const stored = JSON.parse(localStorage.getItem('ethicom_custom_theme') || '{}');
   for(const [name,label] of Object.entries(vars)){
-    const base = parseCol(stored[name] || getComputedStyle(document.documentElement).getPropertyValue(name));
+    const base = parseColor(stored[name] || getComputedStyle(document.documentElement).getPropertyValue(name));
     const wrap = document.createElement('div');
     wrap.innerHTML = `<strong>${label}</strong><br>
       <label>R: <input type="range" min="0" max="255" value="${base.r}"> <span>${base.r}</span></label><br>
@@ -163,7 +153,7 @@ function initSliderSet(rId,gId,bId,rvId,gvId,bvId,previewId,storeKey,setCSS){
   const rv=document.getElementById(rvId),gv=document.getElementById(gvId),bv=document.getElementById(bvId);
   const prev=document.getElementById(previewId);
   if(!r||!g||!b) return;
-  const def=parseCol(getComputedStyle(document.documentElement).getPropertyValue(setCSS.var||setCSS));
+  const def=parseColor(getComputedStyle(document.documentElement).getPropertyValue(setCSS.var||setCSS));
   let cur;
   try{cur=JSON.parse(localStorage.getItem(storeKey)||'null');}catch{}
   if(!cur) cur=def;
@@ -186,7 +176,7 @@ function updateSliderSet(rId,gId,bId,rvId,gvId,bvId,previewId,storeKey,setCSS){
   const rv=document.getElementById(rvId),gv=document.getElementById(gvId),bv=document.getElementById(bvId);
   const prev=document.getElementById(previewId);
   if(!r||!g||!b) return;
-  const c=parseCol(getComputedStyle(document.documentElement).getPropertyValue(setCSS.var||setCSS));
+  const c=parseColor(getComputedStyle(document.documentElement).getPropertyValue(setCSS.var||setCSS));
   r.value=c.r;g.value=c.g;b.value=c.b;
   if(rv) rv.textContent=c.r;
   if(gv) gv.textContent=c.g;
@@ -307,16 +297,7 @@ function openColorSettingsPopin(){
   initSliderSet('bg_r','bg_g','bg_b','bg_r_val','bg_g_val','bg_b_val','bg_preview','ethicom_bg_color','--bg-color');
 
   function applyTanna(c){
-    localStorage.setItem('ethicom_tanna_color',JSON.stringify(c));
-    if(document.body.classList.contains('theme-tanna')||document.body.classList.contains('theme-tanna-dark')){
-      const css=`rgb(${c.r},${c.g},${c.b})`;
-      document.documentElement.style.setProperty('--primary-color',css);
-      document.documentElement.style.setProperty('--accent-color',css);
-      const h=`rgba(${Math.round(c.r*0.2)},${Math.round(c.g*0.2)},${Math.round(c.b*0.2)},0.9)`;
-      const n=`rgba(${Math.round(c.r*0.3)},${Math.round(c.g*0.3)},${Math.round(c.b*0.3)},0.9)`;
-      document.documentElement.style.setProperty('--header-bg',h);
-      document.documentElement.style.setProperty('--nav-bg',n);
-    }
+    applyTannaColor(c);
   }
 
   function applyTannaCSS(c,css){

--- a/start.html
+++ b/start.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="interface/ethicom-style.css" />
   <script src="utils/op-level.js"></script>
   <script src="interface/ethicom-utils.js"></script>
+  <script src="interface/color-utils.js"></script>
   <script src="interface/accessibility.js"></script>
   <style>
     .op-list { list-style: none; padding: 0; }

--- a/template.html
+++ b/template.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Seitenvorlage</title>
   <link rel="stylesheet" href="interface/ethicom-style.css" />
+  <script src="interface/color-utils.js"></script>
   <script src="interface/theme-manager.js"></script>
   <script src="interface/accessibility.js"></script>
   <script src="interface/logo-background.js"></script>

--- a/wings/index.html
+++ b/wings/index.html
@@ -12,6 +12,7 @@
   <script src="../interface/interface-loader.js"></script>
   <script src="../interface/language-selector.js"></script>
   <script src="../interface/translation-manager.js"></script>
+  <script src="../interface/color-utils.js"></script>
   <script src="../interface/theme-manager.js"></script>
   <script src="../interface/dynamic-help.js"></script>
   <script src="../interface/dynamic-info.js"></script>

--- a/wings/ratings.html
+++ b/wings/ratings.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="wings-style.css" />
   <script src="../utils/op-level.js"></script>
   <script src="../interface/ethicom-utils.js"></script>
+  <script src="../interface/color-utils.js"></script>
   <script src="../interface/accessibility.js"></script>
   <script src="../interface/language-selector.js"></script>
   <script src="../interface/translation-manager.js"></script>


### PR DESCRIPTION
## Summary
- centralize color parsing and theme updates in `color-utils.js`
- update interface scripts to use the shared helpers
- include `color-utils.js` on pages that apply themes

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_683b620425308321911762c72c1c1fde