### PR TITLE
Add Google auth info page

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,10 @@ When deploying on another domain, set the environment variable `BASE_URL`
 to that public origin (e.g. `https://4789-alpha.github.io`) so that OAuth
 redirects work properly.
 
+On GitHub Pages the `/auth/google` path only shows brief instructions.
+Start the local server with `BASE_URL` set to your public origin to enable
+the actual Google login flow.
+
 ### Optional Setup Helper
 [⇧](#contents)
 

--- a/auth/google/index.html
+++ b/auth/google/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Google Login Info</title>
+  <link rel="stylesheet" href="../../interface/ethicom-style.css" />
+</head>
+<body>
+  <main class="card" style="margin:2em auto;max-width:600px;">
+    <h2>Google OAuth unavailable</h2>
+    <p>This GitHub Pages demo cannot start the Google login flow.</p>
+    <p>Run <code>node tools/serve-interface.js</code> locally with <code>BASE_URL=https://4789-alpha.github.io</code> to enable OAuth callbacks.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a static info page at `/auth/google` for GitHub Pages
- document that Google login requires running the local server

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_683b66f265908321b8ab94858f07a738