### PR TITLE
Fix GitHub OAuth redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,8 @@ the provided `localhost` address so that translation files load correctly.
 When deploying on another domain, set the environment variable `BASE_URL`
 to that public origin (e.g. `https://4789-alpha.github.io`) so that OAuth
 redirects work properly.
+Configure your GitHub OAuth application to use `${BASE_URL}/auth/github/callback`
+as the callback URL and put your credentials in `app/oauth_config.yaml`.
 
 ### Optional Setup Helper
 [⇧](#contents)

--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -193,7 +193,8 @@ function handleGithubStart(req, res) {
   }
   const state = crypto.randomBytes(8).toString('hex');
   oauthStates.add(state);
-  const url = `https://github.com/login/oauth/authorize?client_id=${oauthCfg.github.client_id}&state=${state}`;
+  const redirect = encodeURIComponent(`${baseUrl}/auth/github/callback`);
+  const url = `https://github.com/login/oauth/authorize?client_id=${oauthCfg.github.client_id}&state=${state}&redirect_uri=${redirect}`;
   res.writeHead(302, { Location: url });
   res.end();
 }


### PR DESCRIPTION
## Summary
- send explicit redirect_uri during GitHub OAuth start
- document GitHub OAuth setup in the README

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_683b67261aac83219bbf0fa6226af475