### PR TITLE
Add alias field to user signup and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ README.md -> GET_STARTED.md -> index.html
 **Optional Google login authenticates via Google's OAuth flow. The returned email address is hashed and stored offline.**
 **Color verification of the chosen primary color starts once a user holds an OP-1 signature.**
 **From that level, the color choice is stored privately inside the user's signature and never shown publicly.**
+**Providing a nickname during signup creates an alias formatted as `nickname@OP-x`, which updates when the OP level changes.**
 
 In this anonymous system, the OP signature stands in for the person. Personal data remains private and becomes visible only when a user releases it at the corresponding OP sublevel; see [signaturdesign.md](signaturdesign.md) and [DISCLAIMERS.md](DISCLAIMERS.md).
 

--- a/signaturdesign.md
+++ b/signaturdesign.md
@@ -28,6 +28,9 @@ Jede zusätzliche Ebene (x, y, z, …) entspricht einer weiteren Array-Schicht b
 Ab **OP-1** kann eine Signatur einen kurzen Nickname enthalten. Diese Option erleichtert die Zuordnung einzelner Bewertungen. OP-0 bleibt weiterhin anonym.
 Bei der Registrierung wird eine zufällige, 12‑stellige Signatur (z.B. `SIG-XXXXXXXXXXXX`) erzeugt. Die E‑Mail-Adresse wird gehasht auf dem Server gespeichert und bleibt verborgen. Nur die Signatur-ID erscheint später in den globalen Bewertungsdateien.
 
+Wenn ein Nickname angegeben wird, entsteht daraus automatisch ein Alias in der Form `nickname@OP-Stufe` (etwa `alex@OP-1`). 
+Dieses Alias wird nur intern gespeichert und passt sich an, sobald sich die Operatorstufe ändert.
+
 ## Interne Speicherung und Gatekeeper
 
 Alle Bewertungen werden intern abgelegt und sind nicht öffentlich abrufbar. Ab **OP-7** archiviert ein Gatekeeper die Signaturangaben. Gespeichert werden lediglich die reduzierten Bewertungsaspekte *Qualität* und *Ethik*.


### PR DESCRIPTION
## Summary
- generate alias on signup when a nickname is provided
- store alias in user records and export a new setOpLevel helper
- document alias behaviour in signaturdesign and README
- test alias generation on signup and alias updates when levels change

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_683cd20fecc083219e38ca2c7798bdcd