### PR TITLE
Add color settings export/import

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ README.md -> GET_STARTED.md -> index.html
 **Optional Google login authenticates via Google's OAuth flow. The returned email address is hashed and stored offline.**
 **Color verification of the chosen primary color starts once a user holds an OP-1 signature.**
 **From that level, the color choice is stored privately inside the user's signature and never shown publicly.**
+**Custom color schemes can be exported via `exportColorSettings()` and imported via `importColorSettings(json)` in the browser console.**
 **Providing a nickname during signup creates an alias formatted as `nickname@OP-x`, which updates when the OP level changes.**
 
 Users may add a nickname during signup. The server combines it with the OP level to form an alias like `<nick>@OP-1`. This alias updates whenever the OP level changes.

--- a/interface/theme-manager.js
+++ b/interface/theme-manager.js
@@ -348,3 +348,24 @@ function saveCurrentAsCustom(){
 }
 
 window.addEventListener('beforeunload',saveCurrentAsCustom);
+
+function exportColorSettings(){
+  const keys=['ethicom_theme','ethicom_custom_theme','ethicom_text_color','ethicom_bg_color','ethicom_tanna_color','ethicom_module_color'];
+  const out={};
+  keys.forEach(k=>{const v=localStorage.getItem(k); if(v) out[k]=v;});
+  return JSON.stringify(out);
+}
+
+function importColorSettings(str){
+  if(!str) return;
+  try{
+    const obj=JSON.parse(str);
+    Object.entries(obj).forEach(([k,v])=>localStorage.setItem(k,v));
+    if(obj.ethicom_theme) applyTheme(obj.ethicom_theme);
+    resetSlidersFromTheme();
+    if(typeof applyStoredColors==='function') applyStoredColors();
+  }catch{}
+}
+
+window.exportColorSettings=exportColorSettings;
+window.importColorSettings=importColorSettings;


### PR DESCRIPTION
## Summary
- enable exporting and importing of color settings in `theme-manager.js`
- document new functions in README

## Testing
- `node --test` *(fails: Unexpected identifier 'user')*
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_683cd83954408321a02370dcd31dc251