### PR TITLE
Add offline signup page

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ README.md -> GET_STARTED.md -> index.html
 | [org-bewertung.html](org-bewertung.html) | Preview for organisation ratings |
 | [interface/settings.html](interface/settings.html) | Language, theme, Tanna logo, and low motion settings |
 | [interface/signup.html](interface/signup.html) | Registration form |
+| [interface/offline-signup.html](interface/offline-signup.html) | Offline local signup |
 | [interface/tanna-template.html](interface/tanna-template.html) | Base template |
 | [interface/tanna-template-dark.html](interface/tanna-template-dark.html) | Template in dark theme |
 | [interface/tanna-template-light.html](interface/tanna-template-light.html) | Template in light theme |

--- a/interface/offline-signup.html
+++ b/interface/offline-signup.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Offline Signup</title>
+  <link rel="stylesheet" href="ethicom-style.css" />
+  <script src="ethicom-utils.js"></script>
+  <script src="offline-signup.js"></script>
+  <script src="theme-manager.js"></script>
+  <script src="logo-background.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main_content">Skip to main content</a>
+  <div id="op_background"></div>
+  <header>
+    <h1>Offline Signup</h1>
+  </header>
+  <main id="main_content">
+    <p>This page stores a local profile when no server is available.</p>
+    <label for="email_input">Email:</label>
+    <input type="email" id="email_input" placeholder="name@provider.com" />
+
+    <label for="pw_input">Password:</label>
+    <input type="password" id="pw_input" placeholder="At least 8 characters" />
+
+    <button onclick="storeOfflineProfile()">Store Locally</button>
+    <pre id="status" style="white-space:pre-wrap;margin-top:1em;"></pre>
+    <section class="card" style="margin-top:2em;">
+      <h2>Disclaimers</h2>
+      <ul>
+        <li>This structure is provided without warranty.</li>
+        <li>Use it responsibly and at your own risk.</li>
+        <li>Registration data is hashed and stored locally.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/interface/offline-signup.js
+++ b/interface/offline-signup.js
@@ -1,0 +1,29 @@
+async function storeOfflineProfile() {
+  const emailEl = document.getElementById('email_input');
+  const pwEl = document.getElementById('pw_input');
+  const statusEl = document.getElementById('status');
+  const email = emailEl.value.trim();
+  const pw = pwEl.value;
+  statusEl.textContent = '';
+
+  if (!/^[^@]+@[^@]+\.[^@]+$/.test(email)) {
+    statusEl.textContent = 'Invalid email format.';
+    return;
+  }
+  if (pw.length < 8) {
+    statusEl.textContent = 'Password must be at least 8 characters.';
+    return;
+  }
+
+  const salt = Math.random().toString(36).slice(2, 10);
+  const emailHash = await sha256(email);
+  const pwHash = await sha256(pw + salt);
+  const created = new Date().toISOString();
+  const obj = { emailHash, pwHash, salt, created };
+  localStorage.setItem('ethicom_offline_user', JSON.stringify(obj));
+  statusEl.textContent = 'Profile stored locally.';
+}
+
+if (typeof window !== 'undefined') {
+  window.storeOfflineProfile = storeOfflineProfile;
+}


### PR DESCRIPTION
## Summary
- add offline signup HTML page for local credential storage
- include offline signup JS for hashed storage
- document offline signup in README

## Testing
- `node --test` *(fails: SyntaxError: Unexpected end of input)*
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_683cddadd89083219ea1f3ef1aadd6a9