### PR TITLE
Add BSVRB start page

### DIFF
--- a/bsvrb.html
+++ b/bsvrb.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>BSVRB – Start</title>
+  <link rel="stylesheet" href="interface/ethicom-style.css" />
+  <script src="utils/op-level.js"></script>
+  <script src="interface/theme-manager.js"></script>
+  <script src="interface/accessibility.js"></script>
+  <script src="interface/logo-background.js"></script>
+  <script src="interface/module-logo.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main_content">Skip to main content</a>
+  <div id="op_background"></div>
+  <header>
+    <h1>BSVRB</h1>
+    <p class="tagline">Biersportverein Region Bern</p>
+  </header>
+  <nav>
+    <a href="bsvrb.html" aria-current="page">Start</a>
+    <a href="interface/ethicom.html">Ethikom</a>
+    <a href="bewertung.html">Bewertung</a>
+    <a href="interface/login.html">Login</a>
+    <a href="interface/signup.html">Signup</a>
+    <a href="README.html" class="readme-link">README</a>
+  </nav>
+  <main id="main_content">
+    <section class="card">
+      <h2>Willkommen</h2>
+      <p>Herzlich willkommen beim Biersportverein Region Bern.</p>
+    </section>
+    <section class="card">
+      <h2>Statuten</h2>
+      <p>Die Statuten werden hier später eingefügt.</p>
+    </section>
+    <section class="card">
+      <h2>Projekte</h2>
+      <p>Links zu laufenden und geplanten Projekten folgen.</p>
+    </section>
+    <section class="card">
+      <h2>Disclaimers</h2>
+      <ul>
+        <li>Diese Struktur wird ohne Gewährleistung bereitgestellt. Fehler oder Auslassungen sind möglich.</li>
+        <li>Die Nutzung erfolgt auf eigene Verantwortung. Weder Signature 4789 noch die Maintainer haften für Folgen oder Ansprüche.</li>
+        <li>4789 ist ein Standard für Verantwortung, keine Person und kein Glaubenssystem.</li>
+        <li>Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung.</li>
+        <li>Tritt ein Widerspruch auf, gilt die Selbstreflexion nach <code>structure_9874.md</code>.</li>
+        <li>Humor ist zulässig, sofern Verantwortung und Klarheit gewahrt bleiben.</li>
+      </ul>
+    </section>
+  </main>
+  <div id="side_drop"></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a start page `bsvrb.html` for the Biersportverein Region Bern
- keep existing disclaimers from the 4789 framework

## Testing
- `node --test` *(fails: ERR_TEST_FAILURE)*
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_683db906b12c8321b3b0fc5588312644