### PR TITLE
Fix checkbox layout in settings

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -270,7 +270,7 @@ details.card > *:not(summary) {
 .swipe-card.swipe-up { transform: translateY(-80px); }
 .swipe-card.swipe-down { transform: translateY(80px); }
 
-input,
+input:not([type=checkbox]):not([type=radio]),
 select,
 textarea {
   width: 100%;
@@ -281,6 +281,14 @@ textarea {
   border-radius: 4px;
   background: #fff;
   color: #000;
+}
+
+input[type=checkbox],
+input[type=radio] {
+  width: auto;
+  margin-right: 0.5em;
+  padding: 0;
+  vertical-align: middle;
 }
 
 input[type=range] {


### PR DESCRIPTION
## Summary
- prevent checkboxes from expanding to full width
- style checkboxes and radio buttons for consistent alignment

## Testing
- `node --test` *(fails: 6 failing tests)*
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_683e2e8a45548321ada56a2fdbe1f496