### PR TITLE
Add department logo placeholders

### DIFF
--- a/bsvrb-fischerabteilung.html
+++ b/bsvrb-fischerabteilung.html
@@ -14,7 +14,7 @@
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>
   <div id="op_background"></div>
-  <header>
+  <header data-logo="sources/images/institutions/logo-ppb.svg">
     <h1>Ökologische Fischerabteilung BSVRB</h1>
     <p class="tagline">Vorbereitung zur Gründung – Pro Piscis Bernensis</p>
     <nav>

--- a/bsvrb-kulturabteilung.html
+++ b/bsvrb-kulturabteilung.html
@@ -14,7 +14,7 @@
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>
   <div id="op_background"></div>
-  <header>
+  <header data-logo="sources/images/institutions/logo-pkb.svg">
     <h1>Kunst- und Kulturabteilung BSVRB</h1>
     <p class="tagline">Vorbereitung zur Gründung – Pro Cultura Bernensis</p>
     <nav>

--- a/bsvrb-quality.html
+++ b/bsvrb-quality.html
@@ -14,7 +14,7 @@
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>
   <div id="op_background"></div>
-  <header>
+  <header data-logo="sources/images/institutions/logo-bsvrb-qc.svg">
     <h1>BSVRB – Qualitätskontrolle</h1>
     <p class="tagline">Verantwortungssystem</p>
     <nav>

--- a/bsvrb-start.html
+++ b/bsvrb-start.html
@@ -15,7 +15,7 @@
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>
   <div id="op_background"></div>
-  <header>
+  <header data-logo="sources/images/institutions/logo-bsvrb.svg">
     <h1>BSVRB</h1>
     <p class="tagline">Bündnis für sinnvolle Verantwortung in regionalen Belangen</p>
     <nav>

--- a/bsvrb.html
+++ b/bsvrb.html
@@ -14,7 +14,7 @@
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>
   <div id="op_background"></div>
-  <header>
+  <header data-logo="sources/images/institutions/logo-bsvrb.svg">
     <h1>BSVRB</h1>
     <p class="tagline">Biersportverein Region Bern</p>
   </header>

--- a/interface/module-logo.js
+++ b/interface/module-logo.js
@@ -14,11 +14,14 @@ function getLogoPath(opLevel) {
 function insertModuleLogo() {
   const header = document.querySelector('header');
   if (!header) return;
+  const custom = header.getAttribute('data-logo');
   const level = typeof getStoredOpLevel === 'function'
     ? (getStoredOpLevel() || 'OP-0')
     : 'OP-0';
-  const src = getLogoPath(level);
-  const fallback = src.includes('../') ? '../op-logo/tanna_op0.png' : 'op-logo/tanna_op0.png';
+  const src = custom || getLogoPath(level);
+  const fallback = custom
+    ? src
+    : src.includes('../') ? '../op-logo/tanna_op0.png' : 'op-logo/tanna_op0.png';
   const h1 = header.querySelector('h1');
   const size = h1 ? getComputedStyle(h1).fontSize : '1em';
   header.classList.add('with-logo');

--- a/sources/images/institutions/logo-bsvrb-qc.svg
+++ b/sources/images/institutions/logo-bsvrb-qc.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
+  <rect width='120' height='60' fill='#ddd'/>
+  <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>QC</text>
+</svg>

--- a/sources/images/institutions/logo-bsvrb.svg
+++ b/sources/images/institutions/logo-bsvrb.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
+  <rect width='120' height='60' fill='#ddd'/>
+  <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>BSVRB</text>
+</svg>

--- a/sources/images/institutions/logo-pkb.svg
+++ b/sources/images/institutions/logo-pkb.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
+  <rect width='120' height='60' fill='#ddd'/>
+  <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>PKB</text>
+</svg>

--- a/sources/images/institutions/logo-ppb.svg
+++ b/sources/images/institutions/logo-ppb.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
+  <rect width='120' height='60' fill='#ddd'/>
+  <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>PPB</text>
+</svg>


### PR DESCRIPTION
## Summary
- support custom header logos via `data-logo`
- add placeholder images for BSVRB and its departments
- link the placeholders in department pages

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_683e343cd8ec83219268a593d74cc7f1