### PR TITLE
Remove Codex environment notice

### DIFF
--- a/bsvrb-start.html
+++ b/bsvrb-start.html
@@ -84,15 +84,6 @@
         <li>Nutzung nur reflektiert und mit Konsequenz.</li>
       </ul>
     </section>
-    <section class="card">
-      <h2>Hinweis zur Codex-Umgebung</h2>
-      <p>
-        Das Terminal im Codex‑Container ist minimal ausgestattet.
-        Interaktive Editoren wie <code>nano</code> oder <code>vim</code> stehen nicht zur Verfügung. Nach dem Start besteht keine
-        Netzwerkanbindung, daher lassen sich keine Pakete über <code>apt</code> nachträglich installieren.
-        Codeänderungen erfolgen über Befehle wie <code>cat</code> und <code>echo</code> oder über den integrierten Codex-Editor.
-      </p>
-    </section>
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {

--- a/home.html
+++ b/home.html
@@ -57,14 +57,6 @@
       </ul>
     </section>
     <section class="card">
-      <h2>Hinweis zur Codex-Umgebung</h2>
-      <p>
-        Das Terminal im Codex‑Container ist minimal ausgestattet.
-        Interaktive Editoren wie <code>nano</code> oder <code>vim</code> stehen nicht zur Verfügung. Nach dem Start besteht keine
-        Netzwerkanbindung, daher lassen sich keine Pakete über <code>apt</code> nachträglich installieren. Codeänderungen erfolgen über Befehle wie <code>cat</code> und <code>echo</code> oder über den integrierten Codex-Editor.
-      </p>
-    </section>
-    <section class="card">
       <h2>Direkt loslegen</h2>
       <p>Starte die Bewertung über <a href="interface/ethicom.html">Ethicom</a>. Eine Vorschau für OP‑0 ist ohne Anmeldung möglich.</p>
     </section>

--- a/index.html
+++ b/index.html
@@ -93,15 +93,6 @@
         <li>Nutzung nur reflektiert und mit Konsequenz.</li>
       </ul>
     </section>
-    <section class="card">
-      <h2>Hinweis zur Codex-Umgebung</h2>
-      <p>
-        Das Terminal im Codex‑Container ist minimal ausgestattet.
-        Interaktive Editoren wie <code>nano</code> oder <code>vim</code> stehen nicht zur Verfügung. Nach dem Start besteht keine
-        Netzwerkanbindung, daher lassen sich keine Pakete über <code>apt</code> nachträglich installieren.
-        Codeänderungen erfolgen über Befehle wie <code>cat</code> und <code>echo</code> oder über den integrierten Codex-Editor.
-      </p>
-    </section>
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {

--- a/start.html
+++ b/start.html
@@ -54,14 +54,6 @@
         <li>Humor ist zulässig, sofern Verantwortung und Klarheit gewahrt bleiben.</li>
       </ul>
     </section>
-    <section class="card">
-      <h2>Hinweis zur Codex-Umgebung</h2>
-      <p>
-        Das Terminal im Codex‑Container ist minimal ausgestattet.
-        Interaktive Editoren wie <code>nano</code> oder <code>vim</code> stehen nicht zur Verfügung. Nach dem Start besteht keine
-        Netzwerkanbindung, daher lassen sich keine Pakete über <code>apt</code> nachträglich installieren. Codeänderungen erfolgen über Befehle wie <code>cat</code> und <code>echo</code> oder über den integrierten Codex-Editor.
-      </p>
-    </section>
   </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- strip the "Hinweis zur Codex-Umgebung" sections from the HTML pages

## Testing
- `node --test` *(fails: ERR_TEST_FAILURE)*
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_683e34c8ab608321a2c5968075afea51