### PR TITLE
Add API connectivity check script

### DIFF
--- a/tools/check_api.py
+++ b/tools/check_api.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Check connectivity to the local or remote 4789 LLM API."""
+import json
+from api_example import load_llm_config, call_llm
+
+
+def main():
+    import sys
+    prompt = ' '.join(sys.argv[1:]) or 'Ping'
+    try:
+        result = call_llm(prompt, load_llm_config())
+        print(json.dumps(result, indent=2))
+        print('API reachable.')
+    except Exception as exc:
+        print('API request failed:', exc)
+        exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/use_cases/api_example_python.md
+++ b/use_cases/api_example_python.md
@@ -10,3 +10,11 @@ python3 tools/api_example.py "Your prompt here"
 ```
 
 Ensure the configured API server is reachable. Offline environments may skip network calls.
+
+For a quick connectivity check you can run:
+
+```bash
+python3 tools/check_api.py
+```
+
+This script loads the same configuration and reports whether the LLM API responds.


### PR DESCRIPTION
## Summary
- add `tools/check_api.py` script to test LLM endpoint
- document connectivity check in `use_cases/api_example_python.md`

## Testing
- `node --test` *(fails: ERR_TEST_FAILURE)*
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_683f64e2182c83218b6c17191458c68c