### PR TITLE
Fix settings logic and highlight color wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ README.md -> GET_STARTED.md -> index.html
 **Color verification of the chosen primary color starts once a user holds an OP-1 signature.**
 **From that level, the color choice is stored privately inside the user's signature and never shown publicly.**
 **Custom color schemes can be exported via `exportColorSettings()` and imported via `importColorSettings(json)` in the browser console.**
+**The settings page includes a Color Wizard and Text Wizard for step-by-step or command-line color selection.**
 **Providing a nickname during signup creates an alias formatted as `nickname@OP-x`, which updates when the OP level changes.**
 
 Users may add a nickname during signup. The server combines it with the OP level to form an alias like `<nick>@OP-1`. This alias updates whenever the OP level changes.

--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -148,6 +148,7 @@ function checkPendingDemotions(userPath, logPath) {
     }
   }
   if (changed) writeJson(userPath || usersFile, users);
+}
 function updateAlias(user) {
   if (user && user.nickname) {
     user.alias = `${user.nickname}@${user.op_level}`;


### PR DESCRIPTION
## Summary
- close missing function brace in `serve-interface.js`
- document the new Color Wizard and Text Wizard tools in README

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_683e38fee8908321a320825d8f940f49