### PR TITLE
Fix README links in interface_OLD

### DIFF
--- a/interface_OLD/about.html
+++ b/interface_OLD/about.html
@@ -38,7 +38,7 @@
     <a href="tools.html" data-ui="nav_tools">Tools</a>
     <a href="settings.html" data-ui="nav_settings" class="icon-only">⚙</a>
     <a href="../wings/index.html">Wings</a>
-    <a href="../README.md" target="_blank" class="readme-link">README</a>
+    <a href="../README.html" target="_blank" class="readme-link">README</a>
     <a href="#" id="side_menu" class="icon-only">☰</a>
   </nav>
   <main id="main_content">

--- a/interface_OLD/chat.html
+++ b/interface_OLD/chat.html
@@ -35,7 +35,7 @@
     <a href="tools.html" data-ui="nav_tools">Tools</a>
     <a href="chat.html">Chat</a>
     <a href="../wings/index.html">Wings</a>
-    <a href="../README.md" target="_blank" class="readme-link">README</a>
+    <a href="../README.html" target="_blank" class="readme-link">README</a>
     <a href="#" id="side_menu" class="icon-only">☰</a>
   </nav>
   <main id="main_content">

--- a/interface_OLD/erstkontakt.html
+++ b/interface_OLD/erstkontakt.html
@@ -43,7 +43,7 @@
     <a href="tools.html" data-ui="nav_tools">Tools</a>
     <a href="settings.html" data-ui="nav_settings" class="icon-only">⚙</a>
     <a href="../wings/index.html">Wings</a>
-    <a href="../README.md" target="_blank" class="readme-link">README</a>
+    <a href="../README.html" target="_blank" class="readme-link">README</a>
     <a href="#" id="side_menu" class="icon-only">☰</a>
   </nav>
   <main id="main_content">

--- a/interface_OLD/ethicom-utils.js
+++ b/interface_OLD/ethicom-utils.js
@@ -4,8 +4,8 @@
 function getReadmePath(lang) {
   const prefix = window.location.pathname.includes('/interface/') ? '..' : '.';
   return lang === 'en'
-    ? `${prefix}/README.md`
-    : `${prefix}/i18n/README.${lang}.md`;
+    ? `${prefix}/README.html`
+    : `${prefix}/i18n/README.${lang}.html`;
 }
 
 function renderBadge(currentRank, maxRank) {

--- a/interface_OLD/ethicom.html
+++ b/interface_OLD/ethicom.html
@@ -46,7 +46,7 @@
     <a href="tools.html" data-ui="nav_tools">Tools</a>
     <a href="settings.html" data-ui="nav_settings" class="icon-only">⚙</a>
     <a href="../wings/index.html">Wings</a>
-    <a href="../README.md" target="_blank" data-ui="nav_readme" class="readme-link">README</a>
+    <a href="../README.html" target="_blank" data-ui="nav_readme" class="readme-link">README</a>
   </nav>
   <main id="main_content">
     <h2 id="title">Ethik-Kompass</h2>

--- a/interface_OLD/language-selector.js
+++ b/interface_OLD/language-selector.js
@@ -34,8 +34,8 @@ function getUiTextPath() {
 function updateReadmeLinks(lang) {
   const prefix = window.location.pathname.includes('/interface/') ? '..' : '.';
   const base = lang === 'en'
-    ? `${prefix}/README.md`
-    : `${prefix}/i18n/README.${lang}.md`;
+    ? `${prefix}/README.html`
+    : `${prefix}/i18n/README.${lang}.html`;
   document.querySelectorAll('a.readme-link').forEach(a => {
     const anchor = a.getAttribute('href').split('#')[1];
     a.href = anchor ? `${base}#${anchor}` : base;

--- a/interface_OLD/page-flow-demo.html
+++ b/interface_OLD/page-flow-demo.html
@@ -51,7 +51,7 @@
     <a href="tools.html" data-ui="nav_tools">Tools</a>
     <a href="settings.html" data-ui="nav_settings" class="icon-only">⚙</a>
     <a href="../wings/index.html">Wings</a>
-    <a href="../README.md" target="_blank" data-ui="nav_readme" class="readme-link">README</a>
+    <a href="../README.html" target="_blank" data-ui="nav_readme" class="readme-link">README</a>
     <a href="#" id="side_menu" class="icon-only">☰</a>
   </nav>
   <main id="main_content">

--- a/interface_OLD/ratings.html
+++ b/interface_OLD/ratings.html
@@ -35,7 +35,7 @@
     <a href="tools.html" data-ui="nav_tools">Tools</a>
     <a href="settings.html" data-ui="nav_settings" class="icon-only">⚙</a>
     <a href="../wings/index.html">Wings</a>
-    <a href="../README.md" target="_blank" class="readme-link">README</a>
+    <a href="../README.html" target="_blank" class="readme-link">README</a>
     <a href="#" id="side_menu" class="icon-only">☰</a>
   </nav>
   <main id="main_content">

--- a/interface_OLD/settings.html
+++ b/interface_OLD/settings.html
@@ -38,7 +38,7 @@
     <a href="tools.html" data-ui="nav_tools">Tools</a>
     <a href="settings.html" data-ui="nav_settings" class="icon-only">⚙</a>
     <a href="../wings/index.html">Wings</a>
-    <a href="../README.md" target="_blank" data-ui="nav_readme" class="readme-link">README</a>
+    <a href="../README.html" target="_blank" data-ui="nav_readme" class="readme-link">README</a>
     <a href="#" id="side_menu" class="icon-only">☰</a>
   </nav>
   <main id="main_content">

--- a/interface_OLD/signup.html
+++ b/interface_OLD/signup.html
@@ -36,7 +36,7 @@
     <a href="tools.html" data-ui="nav_tools">Tools</a>
     <a href="settings.html" data-ui="nav_settings" class="icon-only">⚙</a>
     <a href="../wings/index.html">Wings</a>
-    <a href="../README.md" target="_blank" class="readme-link">README</a>
+    <a href="../README.html" target="_blank" class="readme-link">README</a>
     <a href="#" id="side_menu" class="icon-only">☰</a>
   </nav>
   <main id="main_content">

--- a/interface_OLD/tools.html
+++ b/interface_OLD/tools.html
@@ -36,7 +36,7 @@
     <a href="tools.html" data-ui="nav_tools">Tools</a>
     <a href="settings.html" data-ui="nav_settings" class="icon-only">⚙</a>
     <a href="../wings/index.html">Wings</a>
-    <a href="../README.md" target="_blank" data-ui="nav_readme" class="readme-link">README</a>
+    <a href="../README.html" target="_blank" data-ui="nav_readme" class="readme-link">README</a>
     <a href="#" id="side_menu" class="icon-only">☰</a>
   </nav>
   <main id="main_content">


### PR DESCRIPTION
## Summary
- point README links at `README.html`
- update utilities to use `.html` README path

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_684018b7f08c83219c7a7dc34ace84e6