### PR TITLE
Add command-line signup tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,13 @@ redirects work properly.
 Configure your GitHub OAuth application to use `${BASE_URL}/auth/github/callback`
 as the callback URL and put your credentials in `app/oauth_config.yaml`.
 
+To register a user from the terminal run:
+
+```bash
+node tools/signup-cli.js <email> <password> [--nick=<alias>]
+```
+The script prints the assigned ID, alias and TOTP secret.
+
 On GitHub Pages the `/auth/google` path only shows brief instructions.
 Start the local server with `BASE_URL` set to your public origin to enable
 the actual Google login flow.

--- a/tools/signup-cli.js
+++ b/tools/signup-cli.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+const events = require('events');
+const { handleSignup } = require('./serve-interface.js');
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2 || args.includes('--help') || args.includes('-h')) {
+    console.log('Usage: node tools/signup-cli.js <email> <password> [--nick=<n>] [--addr=<a>] [--country=<c>] [--phone=<p>]');
+    process.exit(0);
+  }
+  const [email, password, ...rest] = args;
+  const opts = {};
+  for (const arg of rest) {
+    const [k, v] = arg.replace(/^--/, '').split('=');
+    if (k === 'nick') opts.nickname = v;
+    else if (k === 'addr') opts.address = v;
+    else if (k === 'country') opts.country = v;
+    else if (k === 'phone') opts.phone = v;
+  }
+  const req = new events.EventEmitter();
+  const res = { status: 0, body: '', writeHead(code) { this.status = code; }, end(d) { if (d) this.body += d; } };
+  handleSignup(req, res);
+  req.emit('data', JSON.stringify({ email, password, ...opts }));
+  req.emit('end');
+  if (res.status === 200) {
+    const data = JSON.parse(res.body);
+    console.log('ID:', data.id);
+    if (data.alias) console.log('Alias:', data.alias);
+    console.log('TOTP secret:', data.secret);
+  } else {
+    console.error('Signup failed:', res.body || res.status);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { main };


### PR DESCRIPTION
## Summary
- add a small `signup-cli.js` script that calls the existing `handleSignup` logic
- note the new script in the README

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68408fed77d883218764d2c36ab662fe