### PR TITLE
Add convenience script for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 **Audience:** Developers, educators, and curious readers.
 
 1. Read `GET_STARTED.md` for the main files.
-2. Run `node tools/serve-interface.js` to start the local server.
+2. Run `node tools/serve-interface.js` to start the local server. For GitHub
+   Pages deployments you can simply execute `npm run serve-gh`.
 3. Open `http://localhost:8080/index.html`.
 
 ```
@@ -423,6 +424,7 @@ Serve the Ethicom interface locally with:
 ```bash
 node tools/serve-interface.js
 ```
+For GitHub Pages use `npm run serve-gh` to set up OAuth redirects.
 
 Then open `http://localhost:8080/ethicom.html` in your browser.
 Opening the HTML file directly (e.g. via `file://`) bypasses the local server and
@@ -430,7 +432,8 @@ causes the language list to remain empty. Always access the interface through
 the provided `localhost` address so that translation files load correctly.
 When deploying on another domain, set the environment variable `BASE_URL`
 to that public origin (e.g. `https://4789-alpha.github.io`) so that OAuth
-redirects work properly.
+redirects work properly. Start the server with `npm run serve-gh` to
+apply this setting automatically.
 Configure your GitHub OAuth application to use `${BASE_URL}/auth/github/callback`
 as the callback URL and put your credentials in `app/oauth_config.yaml`.
 
@@ -442,8 +445,7 @@ node tools/signup-cli.js <email> <password> [--nick=<alias>]
 The script prints the assigned ID, alias and TOTP secret.
 
 On GitHub Pages the `/auth/google` path only shows brief instructions.
-Start the local server with `BASE_URL` set to your public origin to enable
-the actual Google login flow.
+Run `npm run serve-gh` locally to enable the actual Google login flow.
 
 ### Optional Setup Helper
 [⇧](#contents)

--- a/auth/google/index.html
+++ b/auth/google/index.html
@@ -10,7 +10,7 @@
   <main class="card" style="margin:2em auto;max-width:600px;">
     <h2>Google OAuth unavailable</h2>
     <p>This GitHub Pages demo cannot start the Google login flow.</p>
-    <p>Run <code>node tools/serve-interface.js</code> locally with <code>BASE_URL=https://4789-alpha.github.io</code> to enable OAuth callbacks.</p>
+    <p>Run <code>npm run serve-gh</code> locally to enable OAuth callbacks.</p>
   </main>
 </body>
 </html>

--- a/interface/ratings.js
+++ b/interface/ratings.js
@@ -140,7 +140,7 @@ async function initRatings() {
   } catch (e) {
     library.innerHTML =
       'Fehler beim Laden der Bibliothek. ' +
-      'Bitte rufen Sie die Seite \u00fcber <code>node tools/serve-interface.js</code> ' +
+      'Bitte rufen Sie die Seite \u00fcber <code>npm run serve-gh</code> ' +
       `unter <a href="${baseUrl}/ethicom.html">${baseUrl}</a> auf.`;
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "canvas": "^2.11.2"
   },
   "scripts": {
-    "verify": "node tools/check-file-integrity.js"
+    "verify": "node tools/check-file-integrity.js",
+    "serve-gh": "BASE_URL=https://4789-alpha.github.io node tools/serve-interface.js"
   }
 }


### PR DESCRIPTION
## Summary
- add `serve-gh` npm script to start the server with the proper BASE_URL
- mention the new script in README and OAuth instruction page
- update interface hint to point to `npm run serve-gh`

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_684091ab96488321b01a901f67e648ce