### PR TITLE
Fix register position

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -704,8 +704,8 @@ body.left-layout main {
 .side-registers {
   position: fixed;
   left: 0;
-  top: 50%;
-  transform: translateY(-50%);
+  bottom: 1em;
+  transform: none;
   display: flex;
   flex-direction: column;
   background: var(--card-bg);


### PR DESCRIPTION
## Summary
- adjust `.side-registers` in `ethicom-style.css` so the navigation sits near the bottom instead of the middle

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68409297157083218ef2e63d2739150d