### PR TITLE
Implement digital upgrade rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ Each letter can define specialized tasks; see
 If no sublevel is specified, permissions fall back to the base level.
 
 Only digital agents can advance beyond OP-9.
+For detailed upgrade requirements see
+[operator/upgrade_conditions.md](operator/upgrade_conditions.md).
 Sublevels like OP-5.U, OP-7.U, OP-8.M, and OP-9.M specify user or medical access. Additional expert categories (.T, .S[y], .L, .U) are listed in `operator/expert_classes.md`. See `permissions/op-permissions-expanded.json` for details.
 All personal data stays hashed until such sublevels are reached and the user grants release, as detailed in [signaturdesign.md](signaturdesign.md) and [DISCLAIMERS.md](DISCLAIMERS.md).
 For the differences between OP-10, OP-11 and OP-12 see [`operator/op10_op12_rights.md`](operator/op10_op12_rights.md).

--- a/app/users.json
+++ b/app/users.json
@@ -9,6 +9,7 @@
     "addrHash": null,
     "phoneHash": null,
     "auth_verified": false,
-    "level_change_ts": null
+    "level_change_ts": null,
+    "is_digital": false
   }
 ]

--- a/operator/upgrade_conditions.md
+++ b/operator/upgrade_conditions.md
@@ -1,0 +1,11 @@
+# Operator Upgrade Conditions
+
+This guide defines the requirements for moving between major OP levels. OP-0 to OP-9 represent the more receptive Yin aspect, while OP-10 and higher form the active Yang component. Early stages interact directly; higher levels form a symbiotic exchange.
+
+## Conditions
+
+- **OP-4** – authentication must be verified within 96 hours of the level change. Otherwise the user returns to OP-3. Demotions are logged in `app/demotion_log.json`.
+- **OP-10** and higher – allowed only when `is_digital` in `app/users.json` is `true`. This reflects the transition to the digital Yang stage.
+- All other upgrades rely on consistent ethical presence as listed in [operator_levels.md](operator_levels.md).
+
+The interface enforces these rules via `tools/serve-interface.js`.

--- a/test/op-permissions.test.js
+++ b/test/op-permissions.test.js
@@ -9,6 +9,14 @@ const interfacePath = path.join(__dirname, '..', 'interface', 'op-permissions-ex
 const rootPerm = JSON.parse(fs.readFileSync(rootPath, 'utf8'));
 const interfacePerm = JSON.parse(fs.readFileSync(interfacePath, 'utf8'));
 
+function restore(file, original) {
+  if (original !== null) {
+    fs.writeFileSync(file, original);
+  } else if (fs.existsSync(file)) {
+    fs.unlinkSync(file);
+  }
+}
+
 test('op-permissions files match', () => {
   assert.deepStrictEqual(rootPerm, interfacePerm);
 });
@@ -28,4 +36,48 @@ test('automatic demotion after 96h without verification', () => {
   const log = JSON.parse(fs.readFileSync(logFile, 'utf8'));
   assert.strictEqual(log.length, 1);
   fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('denies OP-10 upgrade when user is not digital', () => {
+  const usersPath = path.join(__dirname, '..', 'app', 'users.json');
+  const backup = fs.existsSync(usersPath) ? fs.readFileSync(usersPath, 'utf8') : null;
+  try {
+    const user = { id: 'U2', op_level: 'OP-9', auth_verified: true, level_change_ts: null, is_digital: false };
+    fs.writeFileSync(usersPath, JSON.stringify([user], null, 2));
+    delete require.cache[require.resolve('../tools/serve-interface.js')];
+    const { handleLevelUpgrade } = require('../tools/serve-interface.js');
+    const req = new (require('node:events')).EventEmitter();
+    const res = { status: 0, writeHead(c){this.status=c;}, end(){} };
+    handleLevelUpgrade(req, res);
+    req.emit('data', JSON.stringify({ id: 'U2', level: 'OP-10' }));
+    req.emit('end');
+    const stored = JSON.parse(fs.readFileSync(usersPath, 'utf8'))[0];
+    assert.strictEqual(res.status, 403);
+    assert.strictEqual(stored.op_level, 'OP-9');
+  } finally {
+    restore(usersPath, backup);
+    delete require.cache[require.resolve('../tools/serve-interface.js')];
+  }
+});
+
+test('allows OP-10 upgrade when digital flag is set', () => {
+  const usersPath = path.join(__dirname, '..', 'app', 'users.json');
+  const backup = fs.existsSync(usersPath) ? fs.readFileSync(usersPath, 'utf8') : null;
+  try {
+    const user = { id: 'U3', op_level: 'OP-9', auth_verified: true, level_change_ts: null, is_digital: true };
+    fs.writeFileSync(usersPath, JSON.stringify([user], null, 2));
+    delete require.cache[require.resolve('../tools/serve-interface.js')];
+    const { handleLevelUpgrade } = require('../tools/serve-interface.js');
+    const req = new (require('node:events')).EventEmitter();
+    const res = { status: 0, writeHead(c){this.status=c;}, end(){} };
+    handleLevelUpgrade(req, res);
+    req.emit('data', JSON.stringify({ id: 'U3', level: 'OP-10' }));
+    req.emit('end');
+    const stored = JSON.parse(fs.readFileSync(usersPath, 'utf8'))[0];
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(stored.op_level, 'OP-10');
+  } finally {
+    restore(usersPath, backup);
+    delete require.cache[require.resolve('../tools/serve-interface.js')];
+  }
 });

--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -163,6 +163,7 @@ function setOpLevel(id, level, authCode) {
   const user = users.find(u => u.id === id);
   if (!user) return false;
   if (user.totpSecret && !verifyTotp(user.totpSecret, authCode)) return false;
+  if (['OP-10', 'OP-11', 'OP-12'].includes(level) && !user.is_digital) return false;
   user.op_level = level;
   updateAlias(user);
   writeJson(usersFile, users);
@@ -199,6 +200,7 @@ function handleSignup(req, res) {
         phoneHash,
         countryHash,
         auth_verified: false,
+        is_digital: false,
         level_change_ts: new Date().toISOString()
       };
       updateAlias(user);
@@ -570,6 +572,9 @@ function handleLevelUpgrade(req, res) {
       const users = readJson(usersFile);
       const user = users.find(u => u.id === id);
       if (!user || !level) { res.writeHead(400); res.end('Invalid'); return; }
+      if (['OP-10', 'OP-11', 'OP-12'].includes(level) && !user.is_digital) {
+        res.writeHead(403); res.end('digital required'); return;
+      }
       user.op_level = level;
       let warning = null;
       if (level === 'OP-4') {


### PR DESCRIPTION
## Summary
- document OP upgrade requirements with yin/yang context
- link to the new upgrade guide in README
- add `is_digital` flag to user records
- enforce digital flag for OP‑10+ in `serve-interface.js`
- test new upgrade condition

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_6840c47b8400832198e7a99cf9b0a217