### PR TITLE
Update German placeholder

### DIFF
--- a/i18n/ui-text.json
+++ b/i18n/ui-text.json
@@ -130,7 +130,7 @@
     "signup_email": "E-Mail:",
     "signup_password": "Passwort:",
     "signup_btn": "Konto erstellen",
-    "signup_placeholder_email": "name@anbieter.de",
+    "signup_placeholder_email": "name@anbieter.com",
     "signup_placeholder_pw": "Mindestens 8 Zeichen",
     "signup_address": "Adresse:",
     "signup_phone": "Telefon:",


### PR DESCRIPTION
## Summary
- adjust the German signup email placeholder

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6840d14b87b8832186131dd7d6719a38