### PR TITLE
Add automated server setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ README.md -> GET_STARTED.md -> index.html
 - [Source Manager](#source-manager)
 - [Roadmap](#roadmap)
 - [Local Deployment](#local-deployment)
+- [Automated Server Setup](#automated-server-setup)
 - [Automated Gatekeeper Setup](#automated-gatekeeper-setup)
 - [Running Tests](#running-tests)
 - [Contributing](#contributing)
@@ -467,6 +468,13 @@ Run `python3 install.py` and follow the prompts to update `app/app_settings.yaml
 The script lets you configure the default interface language, offline mode and
 the port used by `tools/serve-interface.js`. All values are stored locally so
 the helper works without network access.
+
+### Automated Server Setup
+[⇧](#contents)
+
+Run `tools/auto-server-setup.sh` to install Node.js 18 if needed and launch the
+local server. The script shows key lines from `DISCLAIMERS.md` before starting
+`tools/serve-interface.js`.
 
 ### Automated Gatekeeper Setup
 [⇧](#contents)

--- a/tools/auto-server-setup.sh
+++ b/tools/auto-server-setup.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Automatic local server setup for the 4789 interface.
+set -e
+
+echo "Diese Struktur wird ohne Gew\u00e4hrleistung bereitgestellt. Fehler oder Auslassungen sind m\u00f6glich."
+echo "Die Nutzung erfolgt auf eigene Verantwortung. Weder Signature 4789 noch die Maintainer haften f\u00fcr Folgen oder Anspr\u00fcche."
+echo "4789 ist ein Standard f\u00fcr Verantwortung, keine Person und kein Glaubenssystem."
+echo "Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung."
+printf "Fortfahren? (yes/no) "
+read answer
+[ "$answer" = "yes" ] || { echo "Abbruch."; exit 1; }
+
+need_node() {
+  echo "Node.js 18+ wird ben\u00f6tigt."
+  if [ "$(uname)" = "Darwin" ]; then
+    if command -v brew >/dev/null 2>&1; then
+      echo "Installing Node.js via Homebrew..."
+      brew install node@18
+      brew link --force --overwrite node@18
+    else
+      echo "Homebrew fehlt. Bitte Node.js manuell installieren."
+      exit 1
+    fi
+  elif [ -f /etc/debian_version ]; then
+    echo "Installing Node.js via apt..."
+    curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+    sudo apt-get install -y nodejs
+  else
+    echo "Automatic Node.js installation nicht unterst\u00fctzt."
+    exit 1
+  fi
+}
+
+if command -v node >/dev/null 2>&1; then
+  ver=$(node -v | cut -c2- | cut -d. -f1)
+  if [ "$ver" -lt 18 ]; then
+    need_node
+  fi
+else
+  need_node
+fi
+
+echo "Installing npm dependencies..."
+npm install
+
+echo "Starting local server at http://localhost:8080 ..."
+node tools/serve-interface.js


### PR DESCRIPTION
## Summary
- provide `tools/auto-server-setup.sh` to install Node and start the local server
- document the helper in the README and update the table of contents

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6840d34d83b883218a689ee9a3b02bd3