### PR TITLE
Update gatekeeper note

### DIFF
--- a/signaturdesign.md
+++ b/signaturdesign.md
@@ -35,7 +35,7 @@ Dieses Alias wird nur intern gespeichert und passt sich an, sobald sich die Oper
 
 ## Interne Speicherung und Gatekeeper
 
-Alle Bewertungen werden intern abgelegt und sind nicht öffentlich abrufbar. Mit einem Gatekeeper lassen sich die Signaturangaben lokal archivieren. Dieser Vorgang ist ab **OP-1** möglich. Gespeichert werden lediglich die reduzierten Bewertungsaspekte *Qualität* und *Ethik*.
+Alle Bewertungen werden intern abgelegt und sind nicht öffentlich abrufbar. Mit einem Gatekeeper lassen sich die Signaturangaben lokal archivieren. Dieser Vorgang ist ab **OP-0** möglich. Gespeichert werden lediglich die reduzierten Bewertungsaspekte *Qualität* und *Ethik*.
 
 ## Revision ohne Duplikate
 


### PR DESCRIPTION
## Summary
- state that gatekeeper archiving can start at OP-0 in the signature design doc

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6840d091c8a48321950f6b12dcbf9d84