### PR TITLE
Add basic data route example

### DIFF
--- a/test/data-route.test.js
+++ b/test/data-route.test.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const events = require('node:events');
+
+const { handleData } = require('../tools/serve-interface.js');
+
+test('GET /api/data responds', () => {
+  const req = new events.EventEmitter();
+  req.method = 'GET';
+  const res = { status: 0, body: '', writeHead(c){this.status=c;}, end(d=''){this.body=d;} };
+  handleData(req, res);
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.body, 'GET erlaubt');
+});
+
+test('POST /api/data responds', () => {
+  const req = new events.EventEmitter();
+  req.method = 'POST';
+  const res = { status: 0, body: '', writeHead(c){this.status=c;}, end(d=''){this.body=d;} };
+  handleData(req, res);
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.body, 'POST erlaubt');
+});

--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -616,6 +616,20 @@ function handleTempToken(req, res) {
   res.end(JSON.stringify({ token: token, expires_in: dur }));
 }
 
+// Simple example route to allow GET and POST for testing
+function handleData(req, res) {
+  if (req.method === 'GET') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('GET erlaubt');
+  } else if (req.method === 'POST') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('POST erlaubt');
+  } else {
+    res.writeHead(405);
+    res.end('Not Allowed');
+  }
+}
+
 const server = http.createServer((req, res) => {
   let urlPath = decodeURIComponent(req.url.split('?')[0]);
   if (req.method === 'POST' && urlPath === '/api/signup') {
@@ -653,6 +667,9 @@ const server = http.createServer((req, res) => {
   }
   if (req.method === 'GET' && urlPath === '/api/gatekeeper/token') {
     return handleTempToken(req, res);
+  }
+  if ((req.method === 'GET' || req.method === 'POST') && urlPath === '/api/data') {
+    return handleData(req, res);
   }
   if (req.method === 'GET' && urlPath === '/api/sources') {
     return handleSources(req, res);
@@ -720,6 +737,7 @@ if (require.main === module) {
     handleConnectApprove,
     handleConnectList,
     handleTempToken,
+    handleData,
     handleLevelUpgrade,
     checkPendingDemotions,
     setOpLevel


### PR DESCRIPTION
## Summary
- add `handleData` route to show GET/POST handling
- export the function for testing
- cover the new route with `data-route.test.js`

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6840d5d127508321afbc65adcd30ac27