### PR TITLE
Remove backgrounds from placeholder logos

### DIFF
--- a/sources/images/institutions/logo-bsvrb-qc.svg
+++ b/sources/images/institutions/logo-bsvrb-qc.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>QC</text>
 </svg>

--- a/sources/images/institutions/logo-bsvrb.svg
+++ b/sources/images/institutions/logo-bsvrb.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>BSVRB</text>
 </svg>

--- a/sources/images/institutions/logo-pkb.svg
+++ b/sources/images/institutions/logo-pkb.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>PKB</text>
 </svg>

--- a/sources/images/institutions/logo-ppb.svg
+++ b/sources/images/institutions/logo-ppb.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>PPB</text>
 </svg>

--- a/sources/images/institutions/src-0001.svg
+++ b/sources/images/institutions/src-0001.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>src-0001</text>
 </svg>

--- a/sources/images/institutions/src-0002.svg
+++ b/sources/images/institutions/src-0002.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>src-0002</text>
 </svg>

--- a/sources/images/institutions/src-0003.svg
+++ b/sources/images/institutions/src-0003.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>src-0003</text>
 </svg>

--- a/sources/images/institutions/src-0004.svg
+++ b/sources/images/institutions/src-0004.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>src-0004</text>
 </svg>

--- a/sources/images/institutions/src-0005.svg
+++ b/sources/images/institutions/src-0005.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>src-0005</text>
 </svg>

--- a/sources/images/institutions/src-0006.svg
+++ b/sources/images/institutions/src-0006.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>src-0006</text>
 </svg>

--- a/sources/images/persons/hum-0900.svg
+++ b/sources/images/persons/hum-0900.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0900</text>
 </svg>

--- a/sources/images/persons/hum-0901.svg
+++ b/sources/images/persons/hum-0901.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0901</text>
 </svg>

--- a/sources/images/persons/hum-0902.svg
+++ b/sources/images/persons/hum-0902.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0902</text>
 </svg>

--- a/sources/images/persons/hum-0903.svg
+++ b/sources/images/persons/hum-0903.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0903</text>
 </svg>

--- a/sources/images/persons/hum-0904.svg
+++ b/sources/images/persons/hum-0904.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0904</text>
 </svg>

--- a/sources/images/persons/hum-0905.svg
+++ b/sources/images/persons/hum-0905.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0905</text>
 </svg>

--- a/sources/images/persons/hum-0906.svg
+++ b/sources/images/persons/hum-0906.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0906</text>
 </svg>

--- a/sources/images/persons/hum-0907.svg
+++ b/sources/images/persons/hum-0907.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0907</text>
 </svg>

--- a/sources/images/persons/hum-0908.svg
+++ b/sources/images/persons/hum-0908.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0908</text>
 </svg>

--- a/sources/images/persons/hum-0909.svg
+++ b/sources/images/persons/hum-0909.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0909</text>
 </svg>

--- a/sources/images/persons/hum-0910.svg
+++ b/sources/images/persons/hum-0910.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0910</text>
 </svg>

--- a/sources/images/persons/hum-0911.svg
+++ b/sources/images/persons/hum-0911.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0911</text>
 </svg>

--- a/sources/images/persons/hum-0912.svg
+++ b/sources/images/persons/hum-0912.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0912</text>
 </svg>

--- a/sources/images/persons/hum-0913.svg
+++ b/sources/images/persons/hum-0913.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0913</text>
 </svg>

--- a/sources/images/persons/hum-0914.svg
+++ b/sources/images/persons/hum-0914.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0914</text>
 </svg>

--- a/sources/images/persons/hum-0915.svg
+++ b/sources/images/persons/hum-0915.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0915</text>
 </svg>

--- a/sources/images/persons/hum-0916.svg
+++ b/sources/images/persons/hum-0916.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0916</text>
 </svg>

--- a/sources/images/persons/hum-0917.svg
+++ b/sources/images/persons/hum-0917.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0917</text>
 </svg>

--- a/sources/images/persons/hum-0918.svg
+++ b/sources/images/persons/hum-0918.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0918</text>
 </svg>

--- a/sources/images/persons/hum-0919.svg
+++ b/sources/images/persons/hum-0919.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0919</text>
 </svg>

--- a/sources/images/persons/hum-0920.svg
+++ b/sources/images/persons/hum-0920.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0920</text>
 </svg>

--- a/sources/images/persons/hum-0921.svg
+++ b/sources/images/persons/hum-0921.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0921</text>
 </svg>

--- a/sources/images/persons/hum-0922.svg
+++ b/sources/images/persons/hum-0922.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0922</text>
 </svg>

--- a/sources/images/persons/hum-0923.svg
+++ b/sources/images/persons/hum-0923.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0923</text>
 </svg>

--- a/sources/images/persons/hum-0924.svg
+++ b/sources/images/persons/hum-0924.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0924</text>
 </svg>

--- a/sources/images/persons/hum-0925.svg
+++ b/sources/images/persons/hum-0925.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0925</text>
 </svg>

--- a/sources/images/persons/hum-0926.svg
+++ b/sources/images/persons/hum-0926.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0926</text>
 </svg>

--- a/sources/images/persons/hum-0927.svg
+++ b/sources/images/persons/hum-0927.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0927</text>
 </svg>

--- a/sources/images/persons/hum-0928.svg
+++ b/sources/images/persons/hum-0928.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0928</text>
 </svg>

--- a/sources/images/persons/hum-0929.svg
+++ b/sources/images/persons/hum-0929.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0929</text>
 </svg>

--- a/sources/images/persons/hum-0930.svg
+++ b/sources/images/persons/hum-0930.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0930</text>
 </svg>

--- a/sources/images/persons/hum-0931.svg
+++ b/sources/images/persons/hum-0931.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0931</text>
 </svg>

--- a/sources/images/persons/hum-0932.svg
+++ b/sources/images/persons/hum-0932.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0932</text>
 </svg>

--- a/sources/images/persons/hum-0933.svg
+++ b/sources/images/persons/hum-0933.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0933</text>
 </svg>

--- a/sources/images/persons/hum-0934.svg
+++ b/sources/images/persons/hum-0934.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0934</text>
 </svg>

--- a/sources/images/persons/hum-0935.svg
+++ b/sources/images/persons/hum-0935.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0935</text>
 </svg>

--- a/sources/images/persons/hum-0936.svg
+++ b/sources/images/persons/hum-0936.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0936</text>
 </svg>

--- a/sources/images/persons/hum-0937.svg
+++ b/sources/images/persons/hum-0937.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0937</text>
 </svg>

--- a/sources/images/persons/hum-0938.svg
+++ b/sources/images/persons/hum-0938.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0938</text>
 </svg>

--- a/sources/images/persons/hum-0939.svg
+++ b/sources/images/persons/hum-0939.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0939</text>
 </svg>

--- a/sources/images/persons/hum-0940.svg
+++ b/sources/images/persons/hum-0940.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0940</text>
 </svg>

--- a/sources/images/persons/hum-0941.svg
+++ b/sources/images/persons/hum-0941.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0941</text>
 </svg>

--- a/sources/images/persons/hum-0942.svg
+++ b/sources/images/persons/hum-0942.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0942</text>
 </svg>

--- a/sources/images/persons/hum-0943.svg
+++ b/sources/images/persons/hum-0943.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0943</text>
 </svg>

--- a/sources/images/persons/hum-0944.svg
+++ b/sources/images/persons/hum-0944.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0944</text>
 </svg>

--- a/sources/images/persons/hum-0945.svg
+++ b/sources/images/persons/hum-0945.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0945</text>
 </svg>

--- a/sources/images/persons/hum-0946.svg
+++ b/sources/images/persons/hum-0946.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0946</text>
 </svg>

--- a/sources/images/persons/hum-0947.svg
+++ b/sources/images/persons/hum-0947.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0947</text>
 </svg>

--- a/sources/images/persons/hum-0948.svg
+++ b/sources/images/persons/hum-0948.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0948</text>
 </svg>

--- a/sources/images/persons/hum-0949.svg
+++ b/sources/images/persons/hum-0949.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0949</text>
 </svg>

--- a/sources/images/persons/hum-0950.svg
+++ b/sources/images/persons/hum-0950.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0950</text>
 </svg>

--- a/sources/images/persons/hum-0951.svg
+++ b/sources/images/persons/hum-0951.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0951</text>
 </svg>

--- a/sources/images/persons/hum-0952.svg
+++ b/sources/images/persons/hum-0952.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0952</text>
 </svg>

--- a/sources/images/persons/hum-0953.svg
+++ b/sources/images/persons/hum-0953.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0953</text>
 </svg>

--- a/sources/images/persons/hum-0954.svg
+++ b/sources/images/persons/hum-0954.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0954</text>
 </svg>

--- a/sources/images/persons/hum-0955.svg
+++ b/sources/images/persons/hum-0955.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0955</text>
 </svg>

--- a/sources/images/persons/hum-0956.svg
+++ b/sources/images/persons/hum-0956.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0956</text>
 </svg>

--- a/sources/images/persons/hum-0957.svg
+++ b/sources/images/persons/hum-0957.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0957</text>
 </svg>

--- a/sources/images/persons/hum-0958.svg
+++ b/sources/images/persons/hum-0958.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0958</text>
 </svg>

--- a/sources/images/persons/hum-0959.svg
+++ b/sources/images/persons/hum-0959.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0959</text>
 </svg>

--- a/sources/images/persons/hum-0960.svg
+++ b/sources/images/persons/hum-0960.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0960</text>
 </svg>

--- a/sources/images/persons/hum-0961.svg
+++ b/sources/images/persons/hum-0961.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0961</text>
 </svg>

--- a/sources/images/persons/hum-0962.svg
+++ b/sources/images/persons/hum-0962.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0962</text>
 </svg>

--- a/sources/images/persons/hum-0963.svg
+++ b/sources/images/persons/hum-0963.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0963</text>
 </svg>

--- a/sources/images/persons/hum-0964.svg
+++ b/sources/images/persons/hum-0964.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0964</text>
 </svg>

--- a/sources/images/persons/hum-0965.svg
+++ b/sources/images/persons/hum-0965.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0965</text>
 </svg>

--- a/sources/images/persons/hum-0966.svg
+++ b/sources/images/persons/hum-0966.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0966</text>
 </svg>

--- a/sources/images/persons/hum-0967.svg
+++ b/sources/images/persons/hum-0967.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0967</text>
 </svg>

--- a/sources/images/persons/hum-0968.svg
+++ b/sources/images/persons/hum-0968.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0968</text>
 </svg>

--- a/sources/images/persons/hum-0969.svg
+++ b/sources/images/persons/hum-0969.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0969</text>
 </svg>

--- a/sources/images/persons/hum-0970.svg
+++ b/sources/images/persons/hum-0970.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0970</text>
 </svg>

--- a/sources/images/persons/hum-0971.svg
+++ b/sources/images/persons/hum-0971.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0971</text>
 </svg>

--- a/sources/images/persons/hum-0972.svg
+++ b/sources/images/persons/hum-0972.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0972</text>
 </svg>

--- a/sources/images/persons/hum-0973.svg
+++ b/sources/images/persons/hum-0973.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0973</text>
 </svg>

--- a/sources/images/persons/hum-0974.svg
+++ b/sources/images/persons/hum-0974.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0974</text>
 </svg>

--- a/sources/images/persons/hum-0975.svg
+++ b/sources/images/persons/hum-0975.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0975</text>
 </svg>

--- a/sources/images/persons/hum-0976.svg
+++ b/sources/images/persons/hum-0976.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0976</text>
 </svg>

--- a/sources/images/persons/hum-0977.svg
+++ b/sources/images/persons/hum-0977.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0977</text>
 </svg>

--- a/sources/images/persons/hum-0978.svg
+++ b/sources/images/persons/hum-0978.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0978</text>
 </svg>

--- a/sources/images/persons/hum-0979.svg
+++ b/sources/images/persons/hum-0979.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0979</text>
 </svg>

--- a/sources/images/persons/hum-0980.svg
+++ b/sources/images/persons/hum-0980.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0980</text>
 </svg>

--- a/sources/images/persons/hum-0981.svg
+++ b/sources/images/persons/hum-0981.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0981</text>
 </svg>

--- a/sources/images/persons/hum-0982.svg
+++ b/sources/images/persons/hum-0982.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0982</text>
 </svg>

--- a/sources/images/persons/hum-0983.svg
+++ b/sources/images/persons/hum-0983.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0983</text>
 </svg>

--- a/sources/images/persons/hum-0984.svg
+++ b/sources/images/persons/hum-0984.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0984</text>
 </svg>

--- a/sources/images/persons/hum-0985.svg
+++ b/sources/images/persons/hum-0985.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0985</text>
 </svg>

--- a/sources/images/persons/hum-0986.svg
+++ b/sources/images/persons/hum-0986.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0986</text>
 </svg>

--- a/sources/images/persons/hum-0987.svg
+++ b/sources/images/persons/hum-0987.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0987</text>
 </svg>

--- a/sources/images/persons/hum-0988.svg
+++ b/sources/images/persons/hum-0988.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0988</text>
 </svg>

--- a/sources/images/persons/hum-0989.svg
+++ b/sources/images/persons/hum-0989.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0989</text>
 </svg>

--- a/sources/images/persons/hum-0990.svg
+++ b/sources/images/persons/hum-0990.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0990</text>
 </svg>

--- a/sources/images/persons/hum-0991.svg
+++ b/sources/images/persons/hum-0991.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0991</text>
 </svg>

--- a/sources/images/persons/hum-0992.svg
+++ b/sources/images/persons/hum-0992.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0992</text>
 </svg>

--- a/sources/images/persons/hum-0993.svg
+++ b/sources/images/persons/hum-0993.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0993</text>
 </svg>

--- a/sources/images/persons/hum-0994.svg
+++ b/sources/images/persons/hum-0994.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0994</text>
 </svg>

--- a/sources/images/persons/hum-0995.svg
+++ b/sources/images/persons/hum-0995.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0995</text>
 </svg>

--- a/sources/images/persons/hum-0996.svg
+++ b/sources/images/persons/hum-0996.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0996</text>
 </svg>

--- a/sources/images/persons/hum-0997.svg
+++ b/sources/images/persons/hum-0997.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0997</text>
 </svg>

--- a/sources/images/persons/hum-0998.svg
+++ b/sources/images/persons/hum-0998.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0998</text>
 </svg>

--- a/sources/images/persons/hum-0999.svg
+++ b/sources/images/persons/hum-0999.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-0999</text>
 </svg>

--- a/sources/images/persons/hum-1000.svg
+++ b/sources/images/persons/hum-1000.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1000</text>
 </svg>

--- a/sources/images/persons/hum-1001.svg
+++ b/sources/images/persons/hum-1001.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1001</text>
 </svg>

--- a/sources/images/persons/hum-1002.svg
+++ b/sources/images/persons/hum-1002.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1002</text>
 </svg>

--- a/sources/images/persons/hum-1003.svg
+++ b/sources/images/persons/hum-1003.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1003</text>
 </svg>

--- a/sources/images/persons/hum-1004.svg
+++ b/sources/images/persons/hum-1004.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1004</text>
 </svg>

--- a/sources/images/persons/hum-1005.svg
+++ b/sources/images/persons/hum-1005.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1005</text>
 </svg>

--- a/sources/images/persons/hum-1006.svg
+++ b/sources/images/persons/hum-1006.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1006</text>
 </svg>

--- a/sources/images/persons/hum-1007.svg
+++ b/sources/images/persons/hum-1007.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1007</text>
 </svg>

--- a/sources/images/persons/hum-1008.svg
+++ b/sources/images/persons/hum-1008.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1008</text>
 </svg>

--- a/sources/images/persons/hum-1009.svg
+++ b/sources/images/persons/hum-1009.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1009</text>
 </svg>

--- a/sources/images/persons/hum-1010.svg
+++ b/sources/images/persons/hum-1010.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1010</text>
 </svg>

--- a/sources/images/persons/hum-1011.svg
+++ b/sources/images/persons/hum-1011.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1011</text>
 </svg>

--- a/sources/images/persons/hum-1012.svg
+++ b/sources/images/persons/hum-1012.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1012</text>
 </svg>

--- a/sources/images/persons/hum-1013.svg
+++ b/sources/images/persons/hum-1013.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1013</text>
 </svg>

--- a/sources/images/persons/hum-1014.svg
+++ b/sources/images/persons/hum-1014.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1014</text>
 </svg>

--- a/sources/images/persons/hum-1015.svg
+++ b/sources/images/persons/hum-1015.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1015</text>
 </svg>

--- a/sources/images/persons/hum-1016.svg
+++ b/sources/images/persons/hum-1016.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1016</text>
 </svg>

--- a/sources/images/persons/hum-1017.svg
+++ b/sources/images/persons/hum-1017.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1017</text>
 </svg>

--- a/sources/images/persons/hum-1018.svg
+++ b/sources/images/persons/hum-1018.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1018</text>
 </svg>

--- a/sources/images/persons/hum-1019.svg
+++ b/sources/images/persons/hum-1019.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1019</text>
 </svg>

--- a/sources/images/persons/hum-1020.svg
+++ b/sources/images/persons/hum-1020.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1020</text>
 </svg>

--- a/sources/images/persons/hum-1021.svg
+++ b/sources/images/persons/hum-1021.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1021</text>
 </svg>

--- a/sources/images/persons/hum-1022.svg
+++ b/sources/images/persons/hum-1022.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1022</text>
 </svg>

--- a/sources/images/persons/hum-1023.svg
+++ b/sources/images/persons/hum-1023.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1023</text>
 </svg>

--- a/sources/images/persons/hum-1024.svg
+++ b/sources/images/persons/hum-1024.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1024</text>
 </svg>

--- a/sources/images/persons/hum-1025.svg
+++ b/sources/images/persons/hum-1025.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1025</text>
 </svg>

--- a/sources/images/persons/hum-1026.svg
+++ b/sources/images/persons/hum-1026.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1026</text>
 </svg>

--- a/sources/images/persons/hum-1027.svg
+++ b/sources/images/persons/hum-1027.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1027</text>
 </svg>

--- a/sources/images/persons/hum-1028.svg
+++ b/sources/images/persons/hum-1028.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1028</text>
 </svg>

--- a/sources/images/persons/hum-1029.svg
+++ b/sources/images/persons/hum-1029.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1029</text>
 </svg>

--- a/sources/images/persons/hum-1030.svg
+++ b/sources/images/persons/hum-1030.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1030</text>
 </svg>

--- a/sources/images/persons/hum-1031.svg
+++ b/sources/images/persons/hum-1031.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1031</text>
 </svg>

--- a/sources/images/persons/hum-1032.svg
+++ b/sources/images/persons/hum-1032.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1032</text>
 </svg>

--- a/sources/images/persons/hum-1033.svg
+++ b/sources/images/persons/hum-1033.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1033</text>
 </svg>

--- a/sources/images/persons/hum-1034.svg
+++ b/sources/images/persons/hum-1034.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1034</text>
 </svg>

--- a/sources/images/persons/hum-1035.svg
+++ b/sources/images/persons/hum-1035.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1035</text>
 </svg>

--- a/sources/images/persons/hum-1036.svg
+++ b/sources/images/persons/hum-1036.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1036</text>
 </svg>

--- a/sources/images/persons/hum-1037.svg
+++ b/sources/images/persons/hum-1037.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1037</text>
 </svg>

--- a/sources/images/persons/hum-1038.svg
+++ b/sources/images/persons/hum-1038.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1038</text>
 </svg>

--- a/sources/images/persons/hum-1039.svg
+++ b/sources/images/persons/hum-1039.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1039</text>
 </svg>

--- a/sources/images/persons/hum-1040.svg
+++ b/sources/images/persons/hum-1040.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1040</text>
 </svg>

--- a/sources/images/persons/hum-1041.svg
+++ b/sources/images/persons/hum-1041.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1041</text>
 </svg>

--- a/sources/images/persons/hum-1042.svg
+++ b/sources/images/persons/hum-1042.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1042</text>
 </svg>

--- a/sources/images/persons/hum-1043.svg
+++ b/sources/images/persons/hum-1043.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1043</text>
 </svg>

--- a/sources/images/persons/hum-1044.svg
+++ b/sources/images/persons/hum-1044.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1044</text>
 </svg>

--- a/sources/images/persons/hum-1045.svg
+++ b/sources/images/persons/hum-1045.svg
@@ -1,4 +1,3 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'>
-  <rect width='120' height='60' fill='#ddd'/>
   <text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>hum-1045</text>
 </svg>

--- a/tools/create-department.js
+++ b/tools/create-department.js
@@ -28,6 +28,6 @@ if (list.some(d => d.dept_id === id)) {
 list.push({ dept_id: id, title, image: `sources/images/departments/${imgName}`, points: [] });
 fs.writeFileSync(dataPath, JSON.stringify(list, null, 2) + '\n');
 
-const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'><rect width='120' height='60' fill='#ddd'/><text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>${id}</text></svg>\n`;
+const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='120' height='60'><text x='60' y='35' font-size='12' text-anchor='middle' fill='#333'>${id}</text></svg>\n`;
 fs.writeFileSync(path.join(imgDir, imgName), svg);
 console.log('Created department', id);


### PR DESCRIPTION
## Summary
- remove grey background rectangles from all placeholder logos
- update department-creation script to output transparent SVGs

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_6840e2ddf6248321998ae4e078c74485