### PR TITLE
Fix text color override

### DIFF
--- a/interface/color-wizard.js
+++ b/interface/color-wizard.js
@@ -131,7 +131,10 @@ function openColorSettingsWizard(){
       localStorage.setItem(k, JSON.stringify(v));
       const css = `rgb(${v.r},${v.g},${v.b})`;
       if (k==='ethicom_tanna_color') cwApplyTanna(v);
-      else if (k==='ethicom_text_color') document.documentElement.style.setProperty('--text-color',css);
+      else if (k==='ethicom_text_color') {
+        document.documentElement.style.setProperty('--text-color',css);
+        if (document.body) document.body.style.setProperty('--text-color',css);
+      }
         else if (k==='ethicom_bg_color') {
           document.documentElement.style.setProperty('--bg-color',css);
           if (document.body) document.body.style.setProperty('--bg-color',css);
@@ -165,7 +168,9 @@ function openColorSettingsWizardCLI(){
     if(!m){alert('Invalid format. Use r,g,b');return;}
     const c={r:Math.min(255,+m[1]),g:Math.min(255,+m[2]),b:Math.min(255,+m[3])};
     localStorage.setItem(key,JSON.stringify(c));
-    document.documentElement.style.setProperty(cssVar,`rgb(${c.r},${c.g},${c.b})`);
+    const css=`rgb(${c.r},${c.g},${c.b})`;
+    document.documentElement.style.setProperty(cssVar,css);
+    if(cssVar==='--text-color' && document.body) document.body.style.setProperty('--text-color',css);
     if(apply) apply(c);
   }
 

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -13,6 +13,7 @@
     if (!obj) return;
     const css = `rgb(${obj.r},${obj.g},${obj.b})`;
     document.documentElement.style.setProperty('--text-color', css);
+    if (document.body) document.body.style.setProperty('--text-color', css);
   }
 
   function applyStoredColors() {

--- a/interface/theme-manager.js
+++ b/interface/theme-manager.js
@@ -176,7 +176,9 @@ function initSliderSet(rId,gId,bId,rvId,gvId,bvId,previewId,storeKey,setCSS){
     const css=`rgb(${c.r},${c.g},${c.b})`;
     if(typeof setCSS ==='string') {
       document.documentElement.style.setProperty(setCSS,css);
-      if (setCSS === '--bg-color' && document.body)
+      if (document.body && setCSS === '--text-color')
+        document.body.style.setProperty('--text-color', css);
+      else if (setCSS === '--bg-color' && document.body)
         document.body.style.setProperty('--bg-color', css);
     } else if(setCSS.apply) setCSS.apply(c,css);
   }
@@ -199,7 +201,9 @@ function updateSliderSet(rId,gId,bId,rvId,gvId,bvId,previewId,storeKey,setCSS){
   const css=`rgb(${c.r},${c.g},${c.b})`;
   if(typeof setCSS==='string') {
     document.documentElement.style.setProperty(setCSS,css);
-    if (setCSS === '--bg-color' && document.body)
+    if (document.body && setCSS === '--text-color')
+      document.body.style.setProperty('--text-color', css);
+    else if (setCSS === '--bg-color' && document.body)
       document.body.style.setProperty('--bg-color', css);
   } else if(setCSS.apply) setCSS.apply(c,css);
 }


### PR DESCRIPTION
## Summary
- ensure text color overrides are applied on body
- sync pop-in and wizard to set inline `--text-color` on body as well

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6840e673f6e483218b4340f27d2a3efb