### PR TITLE
Add header color customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ README.md -> GET_STARTED.md -> index.html
 **From that level, the color choice is stored privately inside the user's signature and never shown publicly.**
 **Custom color schemes can be exported via `exportColorSettings()` and imported via `importColorSettings(json)` in the browser console.**
 **The settings page includes a Color Wizard and Text Wizard for step-by-step or command-line color selection.**
+**Header background color can be adjusted in the Color Wizard under "Header". Input fields follow the Module color and Text color settings.**
 **Providing a nickname during signup creates an alias formatted as `nickname@OP-x`, which updates when the OP level changes.**
 
 Users may add a nickname during signup. The server combines it with the OP level to form an alias like `<nick>@OP-1`. This alias updates whenever the OP level changes.

--- a/interface/color-wizard.js
+++ b/interface/color-wizard.js
@@ -107,6 +107,7 @@ function openColorSettingsWizard(){
   steps.push(cwBuildColorStep('Background','ethicom_bg_color','--bg-color','cw_bg'));
   steps.push(cwBuildColorStep('Tanna Symbol','ethicom_tanna_color',{var:'--primary-color'},'cw_tanna',cwApplyTannaCSS));
   steps.push(cwBuildColorStep('Module Color','ethicom_module_color','--module-color','cw_module'));
+  steps.push(cwBuildColorStep('Header','ethicom_header_color','--header-bg','cw_header',(c,css)=>document.documentElement.style.setProperty('--nav-bg',css)));
 
   const confirmStep = document.createElement('div');
   confirmStep.innerHTML = '<p>Save these colors?</p>';
@@ -137,6 +138,10 @@ function openColorSettingsWizard(){
           if (document.body) document.body.style.setProperty('--bg-color',css);
         }
       else if (k==='ethicom_module_color') document.documentElement.style.setProperty('--module-color',css);
+      else if (k==='ethicom_header_color') {
+        document.documentElement.style.setProperty('--header-bg',css);
+        document.documentElement.style.setProperty('--nav-bg',css);
+      }
     });
     overlay.remove();
   });
@@ -173,6 +178,7 @@ function openColorSettingsWizardCLI(){
   ask('ethicom_bg_color','--bg-color','Background');
   ask('ethicom_tanna_color','--primary-color','Tanna Symbol',cwApplyTanna);
   ask('ethicom_module_color','--module-color','Module');
+  ask('ethicom_header_color','--header-bg','Header',c=>document.documentElement.style.setProperty('--nav-bg',`rgb(${c.r},${c.g},${c.b})`));
   alert('Colors updated');
 }
 

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -47,6 +47,17 @@
     } catch {}
 
     try {
+      const header = JSON.parse(
+        localStorage.getItem('ethicom_header_color') || 'null'
+      );
+      if (header) {
+        const css = `rgb(${header.r},${header.g},${header.b})`;
+        document.documentElement.style.setProperty('--header-bg', css);
+        document.documentElement.style.setProperty('--nav-bg', css);
+      }
+    } catch {}
+
+    try {
       const tanna = JSON.parse(
         localStorage.getItem('ethicom_tanna_color') || 'null'
       );
@@ -96,7 +107,8 @@
       'ethicom_bg_color',
       'ethicom_module_color',
       'ethicom_tanna_color',
-      'ethicom_text_color'
+      'ethicom_text_color',
+      'ethicom_header_color'
     ];
     if (colorKeys.includes(e.key)) {
       try {

--- a/interface/theme-manager.js
+++ b/interface/theme-manager.js
@@ -106,7 +106,8 @@ function createCustomTheme() {
     '--bg-color': 'Background',
     '--text-color': 'Text',
     '--primary-color': 'Primary',
-    '--accent-color': 'Accent'
+    '--accent-color': 'Accent',
+    '--header-bg': 'Header'
   };
   const groups = [];
   const stored = JSON.parse(localStorage.getItem('ethicom_custom_theme') || '{}');
@@ -209,6 +210,7 @@ function resetSlidersFromTheme(){
   updateSliderSet('bg_r','bg_g','bg_b','bg_r_val','bg_g_val','bg_b_val','bg_preview','ethicom_bg_color','--bg-color');
   updateSliderSet('tanna_r_p','tanna_g_p','tanna_b_p','tanna_r_p_val','tanna_g_p_val','tanna_b_p_val','tanna_preview_p','ethicom_tanna_color',{var:'--primary-color',apply:applyTannaCSS});
   updateSliderSet('module_r','module_g','module_b','module_r_val','module_g_val','module_b_val','module_preview','ethicom_module_color','--module-color');
+  updateSliderSet('header_r','header_g','header_b','header_r_val','header_g_val','header_b_val','header_preview','ethicom_header_color','--header-bg');
 }
 
 function openColorSettingsPopin(){
@@ -262,12 +264,19 @@ function openColorSettingsPopin(){
   <span id="tanna_preview_p" class="color-preview"></span><br/>
   <span id="tanna_contrast_p" style="color:red;display:none;">Low contrast with logos</span>
  </div></details>
-<details class="card"><summary>Module Color</summary>
+ <details class="card"><summary>Module Color</summary>
  <div id="module_color_pop">
   <label>R: <input type="range" id="module_r" min="0" max="255"> <span id="module_r_val"></span></label><br/>
   <label>G: <input type="range" id="module_g" min="0" max="255"> <span id="module_g_val"></span></label><br/>
   <label>B: <input type="range" id="module_b" min="0" max="255"> <span id="module_b_val"></span></label>
   <span id="module_preview" class="color-preview"></span>
+ </div></details>
+<details class="card"><summary>Header</summary>
+ <div id="header_color_pop">
+  <label>R: <input type="range" id="header_r" min="0" max="255"> <span id="header_r_val"></span></label><br/>
+  <label>G: <input type="range" id="header_g" min="0" max="255"> <span id="header_g_val"></span></label><br/>
+  <label>B: <input type="range" id="header_b" min="0" max="255"> <span id="header_b_val"></span></label>
+  <span id="header_preview" class="color-preview"></span>
  </div></details>`;
 
   overlay.appendChild(box);
@@ -330,6 +339,7 @@ function openColorSettingsPopin(){
   initSliderSet('tanna_r_p','tanna_g_p','tanna_b_p','tanna_r_p_val','tanna_g_p_val','tanna_b_p_val','tanna_preview_p','ethicom_tanna_color',{var:'--primary-color',apply:applyTannaCSS});
 
   initSliderSet('module_r','module_g','module_b','module_r_val','module_g_val','module_b_val','module_preview','ethicom_module_color','--module-color');
+  initSliderSet('header_r','header_g','header_b','header_r_val','header_g_val','header_b_val','header_preview','ethicom_header_color','--header-bg');
 }
 
 window.applyTheme = applyTheme;


### PR DESCRIPTION
## Summary
- allow header/background colors to be configured
- store header color in localStorage and apply it on load
- include header color step in Color Wizard and pop‑in settings
- document header color option

## Testing
- `npx --yes node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6840e6ccba948321bbea62cdbd42110e