### PR TITLE
Implement automatic low-contrast outlines

### DIFF
--- a/README.html
+++ b/README.html
@@ -8,6 +8,7 @@
   <script src="interface/color-utils.js"></script>
   <script src="interface/theme-manager.js"></script>
   <script src="interface/accessibility.js"></script>
+  <script src="interface/auto-outline.js"></script>
   <script src="interface/logo-background.js"></script>
   <script src="interface/module-logo.js"></script>
   <script src="interface/render-markdown.js"></script>

--- a/bewertung.html
+++ b/bewertung.html
@@ -9,6 +9,7 @@
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/color-utils.js"></script>
   <script src="interface/accessibility.js"></script>
+  <script src="interface/auto-outline.js"></script>
   <script src="interface/language-selector.js"></script>
   <script src="interface/theme-manager.js"></script>
   <script src="interface/color-auth.js"></script>

--- a/bsvrb-fischerabteilung.html
+++ b/bsvrb-fischerabteilung.html
@@ -8,6 +8,7 @@
   <script src="interface/color-utils.js"></script>
   <script src="interface/theme-manager.js"></script>
   <script src="interface/accessibility.js"></script>
+  <script src="interface/auto-outline.js"></script>
   <script src="interface/logo-background.js"></script>
   <script src="interface/module-logo.js"></script>
   <script src="interface/user-registers.js"></script>

--- a/bsvrb-kulturabteilung.html
+++ b/bsvrb-kulturabteilung.html
@@ -8,6 +8,7 @@
   <script src="interface/color-utils.js"></script>
   <script src="interface/theme-manager.js"></script>
   <script src="interface/accessibility.js"></script>
+  <script src="interface/auto-outline.js"></script>
   <script src="interface/logo-background.js"></script>
   <script src="interface/module-logo.js"></script>
   <script src="interface/user-registers.js"></script>

--- a/bsvrb-quality.html
+++ b/bsvrb-quality.html
@@ -8,6 +8,7 @@
   <script src="interface/color-utils.js"></script>
   <script src="interface/theme-manager.js"></script>
   <script src="interface/accessibility.js"></script>
+  <script src="interface/auto-outline.js"></script>
   <script src="interface/logo-background.js"></script>
   <script src="interface/module-logo.js"></script>
   <script src="interface/user-registers.js"></script>

--- a/bsvrb-start.html
+++ b/bsvrb-start.html
@@ -8,6 +8,7 @@
   <script src="utils/op-level.js"></script>
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/accessibility.js"></script>
+  <script src="interface/auto-outline.js"></script>
   <script src="interface/theme-manager.js"></script>
   <script src="interface/logo-background.js"></script>
   <script src="interface/module-logo.js"></script>

--- a/bsvrb.html
+++ b/bsvrb.html
@@ -8,6 +8,7 @@
   <script src="utils/op-level.js"></script>
   <script src="interface/theme-manager.js"></script>
   <script src="interface/accessibility.js"></script>
+  <script src="interface/auto-outline.js"></script>
   <script src="interface/logo-background.js"></script>
   <script src="interface/module-logo.js"></script>
   <script src="interface/user-registers.js"></script>

--- a/home.html
+++ b/home.html
@@ -8,6 +8,7 @@
   <script src="utils/op-level.js"></script>
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/accessibility.js"></script>
+  <script src="interface/auto-outline.js"></script>
   <script src="interface/color-auth.js"></script>
   <script src="interface/color-utils.js"></script>
   <script src="interface/language-selector.js"></script>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <script src="utils/op-level.js"></script>
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/accessibility.js"></script>
+  <script src="interface/auto-outline.js"></script>
   <script src="interface/color-utils.js"></script>
   <script src="interface/color-auth.js"></script>
   <script src="interface/language-selector.js"></script>

--- a/interface/apple-hig.html
+++ b/interface/apple-hig.html
@@ -8,6 +8,7 @@
   <script src="color-utils.js"></script>
   <script src="theme-manager.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="slow-mode.js"></script>
   <script src="logo-background.js"></script>
   <script src="module-logo.js"></script>

--- a/interface/auto-outline.js
+++ b/interface/auto-outline.js
@@ -1,0 +1,55 @@
+// auto-outline.js - automatically add text outlines when contrast is low
+
+(function(){
+  const OUTLINE_COLORS = ['#000000', '#ffffff', '#39ff14'];
+
+  function parseColor(v){
+    v = (v || '').trim();
+    if(v.startsWith('#')){
+      if(v.length === 4) v = '#' + v[1] + v[1] + v[2] + v[2] + v[3] + v[3];
+      const n = parseInt(v.slice(1),16);
+      return {r:(n>>16)&255,g:(n>>8)&255,b:n&255};
+    }
+    const m = v.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+    return m ? {r:+m[1],g:+m[2],b:+m[3]} : null;
+  }
+
+  function lum(v){
+    v /= 255;
+    return v <= 0.03928 ? v/12.92 : Math.pow((v+0.055)/1.055, 2.4);
+  }
+
+  function contrast(c1, c2){
+    const l1 = 0.2126*lum(c1.r) + 0.7152*lum(c1.g) + 0.0722*lum(c1.b);
+    const l2 = 0.2126*lum(c2.r) + 0.7152*lum(c2.g) + 0.0722*lum(c2.b);
+    return (Math.max(l1,l2)+0.05)/(Math.min(l1,l2)+0.05);
+  }
+
+  function bestOutline(textColor){
+    const tc = parseColor(textColor);
+    if(!tc) return '#000';
+    let best = OUTLINE_COLORS[0];
+    let bestRatio = 0;
+    OUTLINE_COLORS.forEach(c => {
+      const ratio = contrast(tc, parseColor(c));
+      if(ratio > bestRatio){ bestRatio = ratio; best = c; }
+    });
+    return best;
+  }
+
+  function applyAutoOutline(){
+    document.querySelectorAll('body *').forEach(el => {
+      const style = getComputedStyle(el);
+      const color = parseColor(style.color);
+      const bg = parseColor(style.backgroundColor);
+      if(!color || !bg) return;
+      if(contrast(color, bg) < 2){
+        const oc = bestOutline(style.color);
+        el.style.textShadow = `0 0 2px ${oc}`;
+      }
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', applyAutoOutline);
+  document.addEventListener('themeChanged', applyAutoOutline);
+})();

--- a/interface/connect.html
+++ b/interface/connect.html
@@ -9,6 +9,7 @@
   <script src="ethicom-utils.js"></script>
   <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="slow-mode.js"></script>
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>

--- a/interface/donate.html
+++ b/interface/donate.html
@@ -9,6 +9,7 @@
   <script src="ethicom-utils.js"></script>
   <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="slow-mode.js"></script>
   <script src="donate.js"></script>
   <script src="theme-manager.js"></script>

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -9,6 +9,7 @@
   <script src="ethicom-utils.js"></script>
   <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="slow-mode.js"></script>
   <script src="language-selector.js"></script>
   <script src="dynamic-info.js"></script>

--- a/interface/fish-interface/fischEditor.html
+++ b/interface/fish-interface/fischEditor.html
@@ -9,6 +9,7 @@
   <script src="../ethicom-utils.js"></script>
   <script src="../color-utils.js"></script>
   <script src="../accessibility.js"></script>
+  <script src="../auto-outline.js"></script>
   <script src="../theme-manager.js"></script>
   <script src="../logo-background.js"></script>
   <script src="../side-drop.js"></script>

--- a/interface/fish-interface/fischeBern.html
+++ b/interface/fish-interface/fischeBern.html
@@ -9,6 +9,7 @@
   <script src="../ethicom-utils.js"></script>
   <script src="../color-utils.js"></script>
   <script src="../accessibility.js"></script>
+  <script src="../auto-outline.js"></script>
   <script src="../theme-manager.js"></script>
   <script src="../logo-background.js"></script>
   <script src="../side-drop.js"></script>

--- a/interface/fish-interface/fischeSchweiz.html
+++ b/interface/fish-interface/fischeSchweiz.html
@@ -9,6 +9,7 @@
   <script src="../ethicom-utils.js"></script>
   <script src="../color-utils.js"></script>
   <script src="../accessibility.js"></script>
+  <script src="../auto-outline.js"></script>
   <script src="../theme-manager.js"></script>
   <script src="../logo-background.js"></script>
   <script src="../side-drop.js"></script>

--- a/interface/fish-interface/gewaesserBern.html
+++ b/interface/fish-interface/gewaesserBern.html
@@ -9,6 +9,7 @@
   <script src="../ethicom-utils.js"></script>
   <script src="../color-utils.js"></script>
   <script src="../accessibility.js"></script>
+  <script src="../auto-outline.js"></script>
   <script src="../theme-manager.js"></script>
   <script src="../logo-background.js"></script>
   <script src="../side-drop.js"></script>

--- a/interface/fish.html
+++ b/interface/fish.html
@@ -9,6 +9,7 @@
   <script src="ethicom-utils.js"></script>
   <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="slow-mode.js"></script>
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>

--- a/interface/hermes.html
+++ b/interface/hermes.html
@@ -9,6 +9,7 @@
   <script src="ethicom-utils.js"></script>
   <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="slow-mode.js"></script>
   <script src="language-selector.js"></script>
   <script src="dynamic-info.js"></script>

--- a/interface/login.html
+++ b/interface/login.html
@@ -10,6 +10,7 @@
   <script src="ethicom-utils.js"></script>
   <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="slow-mode.js"></script>
   <script src="login.js"></script>
   <script src="biometric-login.js"></script>

--- a/interface/material.html
+++ b/interface/material.html
@@ -8,6 +8,7 @@
   <script src="color-utils.js"></script>
   <script src="theme-manager.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="slow-mode.js"></script>
   <script src="logo-background.js"></script>
   <script src="module-logo.js"></script>

--- a/interface/navigator.html
+++ b/interface/navigator.html
@@ -9,6 +9,7 @@
   <script src="ethicom-utils.js"></script>
   <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>
   <script src="side-drop.js"></script>

--- a/interface/nielsen.html
+++ b/interface/nielsen.html
@@ -8,6 +8,7 @@
   <script src="color-utils.js"></script>
   <script src="theme-manager.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="slow-mode.js"></script>
   <script src="logo-background.js"></script>
   <script src="module-logo.js"></script>

--- a/interface/norman.html
+++ b/interface/norman.html
@@ -8,6 +8,7 @@
   <script src="color-utils.js"></script>
   <script src="theme-manager.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="slow-mode.js"></script>
   <script src="logo-background.js"></script>
   <script src="module-logo.js"></script>

--- a/interface/op-story.html
+++ b/interface/op-story.html
@@ -9,6 +9,7 @@
   <script src="ethicom-utils.js"></script>
   <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="theme-manager.js"></script>
   <script src="logo-background.js"></script>
   <script src="dynamic-info.js"></script>

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -12,6 +12,7 @@
   <script src="theme-manager.js"></script>
   <script src="color-wizard.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="slow-mode.js"></script>
   <script src="touch-features.js"></script>
   <script src="attention-seeker.js"></script>

--- a/interface/shneiderman.html
+++ b/interface/shneiderman.html
@@ -8,6 +8,7 @@
   <script src="color-utils.js"></script>
   <script src="theme-manager.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="slow-mode.js"></script>
   <script src="logo-background.js"></script>
   <script src="module-logo.js"></script>

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -10,6 +10,7 @@
   <script src="ethicom-utils.js"></script>
   <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="slow-mode.js"></script>
   <script src="signup.js"></script>
   <script src="color-auth.js"></script>

--- a/interface/start.html
+++ b/interface/start.html
@@ -9,6 +9,7 @@
   <script src="ethicom-utils.js"></script>
   <script src="color-utils.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="slow-mode.js"></script>
   <style>
     .op-list { list-style: none; padding: 0; }

--- a/interface/tanna-animation.html
+++ b/interface/tanna-animation.html
@@ -8,6 +8,7 @@
   <script src="color-utils.js"></script>
   <script src="theme-manager.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="logo-background.js"></script>
   <script src="module-logo.js"></script>
   <script src="tanna-animation.js"></script>

--- a/interface_OLD/ethicom.html
+++ b/interface_OLD/ethicom.html
@@ -13,6 +13,7 @@
   <script src="language-selector.js"></script>
   <script src="translation-manager.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="dynamic-help.js"></script>
   <script src="dynamic-info.js"></script>
   <script src="theme-manager.js"></script>

--- a/interface_OLD/settings.html
+++ b/interface_OLD/settings.html
@@ -11,6 +11,7 @@
   <script src="dev-mode.js"></script>
   <script src="op0-testmode.js"></script>
   <script src="accessibility.js"></script>
+  <script src="auto-outline.js"></script>
   <script src="color-auth.js"></script>
   <script src="attention-seeker.js"></script>
   <script src="touch-features.js"></script>

--- a/org-bewertung.html
+++ b/org-bewertung.html
@@ -8,6 +8,7 @@
   <script src="utils/op-level.js"></script>
   <script src="interface/theme-manager.js"></script>
   <script src="interface/accessibility.js"></script>
+  <script src="interface/auto-outline.js"></script>
   <script src="interface/logo-background.js"></script>
   <script src="interface/op0-navigation.js"></script>
   <script src="interface/side-drop.js"></script>

--- a/personenbewertung.html
+++ b/personenbewertung.html
@@ -8,6 +8,7 @@
   <script src="utils/op-level.js"></script>
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/accessibility.js"></script>
+  <script src="interface/auto-outline.js"></script>
   <script src="interface/language-selector.js"></script>
   <script src="interface/theme-manager.js"></script>
   <script src="interface/color-auth.js"></script>

--- a/start.html
+++ b/start.html
@@ -9,6 +9,7 @@
   <script src="interface/ethicom-utils.js"></script>
   <script src="interface/color-utils.js"></script>
   <script src="interface/accessibility.js"></script>
+  <script src="interface/auto-outline.js"></script>
   <style>
     .op-list { list-style: none; padding: 0; }
     .op-list li { margin-bottom: 0.6em; }

--- a/template.html
+++ b/template.html
@@ -8,6 +8,7 @@
   <script src="interface/color-utils.js"></script>
   <script src="interface/theme-manager.js"></script>
   <script src="interface/accessibility.js"></script>
+  <script src="interface/auto-outline.js"></script>
   <script src="interface/logo-background.js"></script>
   <script src="interface/module-logo.js"></script>
   <script src="interface/user-registers.js"></script>

--- a/wings/index.html
+++ b/wings/index.html
@@ -9,6 +9,7 @@
   <script src="../utils/op-level.js"></script>
   <script src="../interface/ethicom-utils.js"></script>
   <script src="../interface/accessibility.js"></script>
+<script src="../interface/auto-outline.js"></script>
   <script src="../interface/interface-loader.js"></script>
   <script src="../interface/language-selector.js"></script>
   <script src="../interface/translation-manager.js"></script>

--- a/wings/ratings.html
+++ b/wings/ratings.html
@@ -10,6 +10,7 @@
   <script src="../interface/ethicom-utils.js"></script>
   <script src="../interface/color-utils.js"></script>
   <script src="../interface/accessibility.js"></script>
+<script src="../interface/auto-outline.js"></script>
   <script src="../interface/language-selector.js"></script>
   <script src="../interface/translation-manager.js"></script>
   <script src="../interface/signature-strength.js"></script>


### PR DESCRIPTION
## Summary
- add `auto-outline.js` to generate outlines when text contrast is low
- include the new script on all HTML pages so it runs on load

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_6840e760f43c8321a8fd813c7a3cebff