### PR TITLE
Set dark theme as default color scheme

### DIFF
--- a/interface/color-wizard.js
+++ b/interface/color-wizard.js
@@ -79,7 +79,7 @@ function openColorSettingsWizard(){
 
   cancelBtn.addEventListener('click', () => overlay.remove());
 
-  const tempTheme = localStorage.getItem('ethicom_theme') || 'tanna-dark';
+  const tempTheme = localStorage.getItem('ethicom_theme') || 'dark';
   tempColors = {};
 
   const steps = [];
@@ -87,6 +87,7 @@ function openColorSettingsWizard(){
   const step0 = document.createElement('div');
   step0.innerHTML = `<label for="cw_theme_select">Color Scheme:</label>
     <select id="cw_theme_select">
+      <option value="dark">Dark</option>
       <option value="tanna-dark">Dark Tanna</option>
       <option value="tanna">Tanna</option>
       <option value="transparent">Transparent</option>
@@ -156,8 +157,8 @@ function openColorSettingsWizard(){
 window.openColorSettingsWizard = openColorSettingsWizard;
 
 function openColorSettingsWizardCLI(){
-  const themes=['tanna-dark','tanna','transparent','ocean','desert','custom'];
-  let theme=prompt('Color Scheme ('+themes.join(', ')+'):',localStorage.getItem('ethicom_theme')||'tanna-dark');
+  const themes=['dark','tanna-dark','tanna','transparent','ocean','desert','custom'];
+  let theme=prompt('Color Scheme ('+themes.join(', ')+'):',localStorage.getItem('ethicom_theme')||'dark');
   if(theme&&themes.includes(theme)){
     localStorage.setItem('ethicom_theme',theme);
     if(typeof applyTheme==='function') applyTheme(theme);

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -118,7 +118,7 @@
       } catch {}
       applyStoredColors();
     } else if (e.key === 'ethicom_theme' && typeof applyTheme === 'function') {
-      applyTheme(e.newValue || 'tanna-dark');
+      applyTheme(e.newValue || 'dark');
     }
   });
 })();

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -52,6 +52,7 @@
         <summary>Color Scheme</summary>
         <label for="theme_select">Scheme:</label>
         <select id="theme_select">
+          <option value="dark">Dark</option>
           <option value="tanna-dark">Dark Tanna</option>
           <option value="tanna">Tanna</option>
           <option value="transparent">Transparent</option>

--- a/interface/theme-manager.js
+++ b/interface/theme-manager.js
@@ -40,9 +40,9 @@ function initThemeSelection() {
   const select = document.getElementById('theme_select');
   const customBtn = document.getElementById('custom_theme_btn');
   const tannaCard = document.getElementById('tanna_color');
-  const themes = ['tanna-dark','tanna','transparent','ocean','desert','custom'];
-  const labels = ['Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Custom'];
-  let theme = localStorage.getItem('ethicom_theme') || 'tanna-dark';
+  const themes = ['dark','tanna-dark','tanna','transparent','ocean','desert','custom'];
+  const labels = ['Dark','Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Custom'];
+  let theme = localStorage.getItem('ethicom_theme') || 'dark';
   applyTheme(theme);
   if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
   if (select) {
@@ -238,6 +238,7 @@ function openColorSettingsPopin(){
 
   box.innerHTML=`<div id="theme_scheme_wrap" style="margin-bottom:0.5em;"><label for="theme_select_pop">Color Scheme:</label>
   <select id="theme_select_pop">
+    <option value="dark">Dark</option>
     <option value="tanna-dark">Dark Tanna</option>
     <option value="tanna">Tanna</option>
     <option value="transparent">Transparent</option>
@@ -302,11 +303,11 @@ function openColorSettingsPopin(){
   overlay.addEventListener('keydown',e=>{if(e.key==='Escape'){e.preventDefault();closePopin();}});
   setTimeout(()=>closeBtn.focus(),0);
 
-  const themes=['tanna-dark','tanna','transparent','ocean','desert','custom'];
-  const labels=['Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Custom'];
+  const themes=['dark','tanna-dark','tanna','transparent','ocean','desert','custom'];
+  const labels=['Dark','Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Custom'];
   const scheme=document.getElementById('theme_select_pop');
   if(scheme){
-    const stored=localStorage.getItem('ethicom_theme')||'tanna-dark';
+    const stored=localStorage.getItem('ethicom_theme')||'dark';
     scheme.value=stored;
     scheme.addEventListener('change',e=>{
       const val=e.target.value;


### PR DESCRIPTION
## Summary
- default to standard dark theme for better readability
- update theme options in settings and color wizard
- adjust theme manager and utils for new default

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_6840f3bc5af083219a485b63e289e6e6