### PR TITLE
Add clickable OP status link

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -200,6 +200,18 @@ header.with-logo {
   background-position: 0.5em center;
 }
 
+header .op-status-link {
+  position: absolute;
+  top: 0.4em;
+  right: 0.5em;
+  line-height: 1;
+}
+
+header .op-status-link img {
+  height: 2em;
+  width: auto;
+}
+
 header .title-logo {
   height: 2em;
   vertical-align: middle;

--- a/interface/module-logo.js
+++ b/interface/module-logo.js
@@ -29,6 +29,21 @@ function insertModuleLogo() {
   header.style.backgroundSize = `auto ${size}`;
   header.style.paddingLeft = `calc(${size} + 1em)`;
 
+  // Insert clickable OP status logo in the top-right corner
+  const link = document.createElement('a');
+  link.className = 'op-status-link';
+  const base = window.location.pathname.includes('/interface/') ||
+               window.location.pathname.includes('/wings/')
+                 ? '../'
+                 : '';
+  link.href = `${base}interface/start.html`;
+  const logoImg = new Image();
+  logoImg.src = src;
+  logoImg.alt = 'OP Status';
+  logoImg.onerror = () => { logoImg.src = fallback; };
+  link.appendChild(logoImg);
+  header.appendChild(link);
+
   if (!h1) return;
   const img = new Image();
   img.onerror = () => { header.style.backgroundImage = `url('${fallback}')`; };


### PR DESCRIPTION
## Summary
- add clickable OP status logo in module-header
- style new logo link so it sits in the header's top-right corner

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_6841762f2f5883218c629e8fae6560f4