### PR TITLE
Implement auto nickname

### DIFF
--- a/interface/signup.js
+++ b/interface/signup.js
@@ -59,6 +59,20 @@ function applySignupTexts() {
   updatePhonePlaceholder();
 }
 
+function hideNickInputIfNoob() {
+  const level = getStoredOpLevel() || 'OP-1';
+  const levelNum = opLevelToNumber(level);
+  if (levelNum < 2) {
+    const nickLabel = document.querySelector('label[for="nick_input"]');
+    const nickInput = document.getElementById('nick_input');
+    if (nickLabel) nickLabel.style.display = 'none';
+    if (nickInput) {
+      nickInput.style.display = 'none';
+      nickInput.disabled = true;
+    }
+  }
+}
+
 function initSignup() {
   const lang = getLanguage();
   fetch('../i18n/ui-text.json')
@@ -69,6 +83,7 @@ function initSignup() {
       const countryInput = document.getElementById('country_input');
       if (countryInput) countryInput.addEventListener('change', updatePhonePlaceholder);
       updatePhonePlaceholder();
+      hideNickInputIfNoob();
     });
 }
 
@@ -123,7 +138,8 @@ function handleSignup() {
       return r.json();
     })
     .then(data => {
-      const sig = { email, id: data.id, op_level: 'OP-1', nickname, alias: data.alias };
+      const nick = data.nickname || nickname;
+      const sig = { email, id: data.id, op_level: 'OP-1', nickname: nick, alias: data.alias };
       localStorage.setItem('ethicom_signature', JSON.stringify(sig));
       const msgSaved = uiText.signup_saved || 'Signup complete. ID stored.';
       const msgAlias = (uiText.signup_alias || 'Alias: {alias}').replace('{alias}', data.alias);

--- a/test/data-hashing.test.js
+++ b/test/data-hashing.test.js
@@ -66,13 +66,13 @@ test('registration hashes email and password as noted in DISCLAIMERS lines 9-10'
   }
 });
 
-test('signup with nickname stores alias with level', () => {
+test('signup assigns classic nickname for OP-1', () => {
   const usersPath = path.join(__dirname, '..', 'app', 'users.json');
   const backup = fs.existsSync(usersPath) ? fs.readFileSync(usersPath, 'utf8') : null;
   try {
     fs.writeFileSync(usersPath, '[]');
-    const { handleSignup } = require('../tools/serve-interface.js');
-    const body = JSON.stringify({ email: 'n@example.com', password: 'safePass123', nickname: 'nick' });
+    const { handleSignup, suggestNickname } = require('../tools/serve-interface.js');
+    const body = JSON.stringify({ email: 'n@example.com', password: 'safePass123', nickname: 'nick', country: 'DE' });
     const req = new events.EventEmitter();
     const res = { status: 0, writeHead(code) { this.status = code; }, end() {} };
     handleSignup(req, res);
@@ -80,7 +80,8 @@ test('signup with nickname stores alias with level', () => {
     req.emit('end');
     assert.strictEqual(res.status, 200);
     const stored = JSON.parse(fs.readFileSync(usersPath, 'utf8'))[0];
-    assert.strictEqual(stored.alias, 'nick@OP-1');
+    const expected = `${suggestNickname('DE')}@OP-1`;
+    assert.strictEqual(stored.alias, expected);
   } finally {
     restore(usersPath, backup);
     delete require.cache[require.resolve('../tools/serve-interface.js')];


### PR DESCRIPTION
## Summary
- assign a classic nickname at signup
- hide nickname field for OP-1 signups
- store server provided nickname on client
- update hashing test for nickname change

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6841796ebe308321a41756fae94c0b60