### PR TITLE
Document gatekeeper limits

### DIFF
--- a/use_cases/gatekeeper_quickstart.md
+++ b/use_cases/gatekeeper_quickstart.md
@@ -19,3 +19,5 @@ node tools/gatekeeper-gui.js
 and open the shown URL (default `http://localhost:8675/gatekeeper.html`).
 
 All device and identity information is stored hashed as noted in `DISCLAIMERS.md`.
+The gatekeeper neither performs DNA analysis nor checks your geolocation. Only
+the hashed strings from `gatekeeper_config.yaml` are used for confirmation.


### PR DESCRIPTION
## Summary
- clarify in the quickstart guide that the gatekeeper doesn't analyze DNA or geolocation

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6841766cb1408321bae875aa38fd0aae