### PR TITLE
Add user info to README

### DIFF
--- a/README.html
+++ b/README.html
@@ -28,6 +28,7 @@
     <a href="interface/signup.html">Signup</a>
     <a aria-current="page" class="icon-only readme-link" aria-label="Help">?</a>
   </nav>
+  <section id="user_info" class="card" aria-live="polite"></section>
   <main id="main_content">
     <section class="card">
       <h2>Overview</h2>

--- a/interface/user-registers.js
+++ b/interface/user-registers.js
@@ -1,4 +1,5 @@
 window.addEventListener('DOMContentLoaded', () => {
+  localStorage.setItem('last_page', location.pathname.replace(/^\//, ''));
   const token = localStorage.getItem('jwt');
   if(!token) return;
 
@@ -15,4 +16,14 @@ window.addEventListener('DOMContentLoaded', () => {
   const base = location.pathname.includes('/interface/') || location.pathname.includes('/wings/') ? '../' : '';
   aside.innerHTML = modules.map(m => `<a href="${base}${m.href}">${m.name}</a>`).join('');
   document.body.prepend(aside);
+
+  const info = document.getElementById('user_info');
+  if (info) {
+    try {
+      const sig = JSON.parse(localStorage.getItem('ethicom_signature') || '{}');
+      const name = sig.nickname || sig.alias || sig.email || 'User';
+      const last = localStorage.getItem('last_page') || '';
+      info.textContent = `${name} – letzte Seite: ${last}`;
+    } catch {}
+  }
 });


### PR DESCRIPTION
## Summary
- show user info and last page on README.html
- track last page inside `user-registers.js`

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68417cf6b9f88321811d0806428e32d6