### PR TITLE
Link left tanna to OP status

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -202,14 +202,16 @@ header.with-logo {
 
 header .op-status-link {
   position: absolute;
-  top: 0.4em;
-  right: 0.5em;
+  top: 0;
+  left: 0;
+  right: auto;
   line-height: 1;
+  display: block;
+  height: 100%;
 }
 
 header .op-status-link img {
-  height: 2em;
-  width: auto;
+  display: none;
 }
 
 header .title-logo {

--- a/interface/module-logo.js
+++ b/interface/module-logo.js
@@ -29,7 +29,7 @@ function insertModuleLogo() {
   header.style.backgroundSize = `auto calc(${size} * 1.5)`;
   header.style.paddingLeft = `calc(${size} * 1.5 + 1em)`;
 
-  // Insert clickable OP status logo in the top-right corner
+  // Make the OP logo area on the left clickable
   const link = document.createElement('a');
   link.className = 'op-status-link';
   const base = window.location.pathname.includes('/interface/') ||
@@ -37,11 +37,9 @@ function insertModuleLogo() {
                  ? '../'
                  : '';
   link.href = `${base}interface/start.html`;
-  const logoImg = new Image();
-  logoImg.src = src;
-  logoImg.alt = 'OP Status';
-  logoImg.onerror = () => { logoImg.src = fallback; };
-  link.appendChild(logoImg);
+  link.setAttribute('aria-label', 'OP Status');
+  link.style.width = `calc(${size} * 1.5 + 1em)`;
+  link.style.height = '100%';
   header.appendChild(link);
 
   if (!h1) return;


### PR DESCRIPTION
## Summary
- make the left Tanna symbol clickable by inserting a link in `module-logo.js`
- adjust CSS so the link overlays the left logo and hide the old image element

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_6841a3e1dbcc8321bce2e13226b28ca8