### PR TITLE
Implement gatekeeper watchdog feed feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ The private identity is hashed too and remains local-only. Only you have access 
 Temporary tokens can be issued with `node tools/gatekeeper.js token` and expire after the configured duration.
 Tokens and device hashes are stored hashed in `app/gatekeeper_devices.json`.
 Run `node tools/gatekeeper.js prune` regularly to remove expired tokens and keep the file minimal.
+Monitor repeated failed attempts with `node tools/watchdog.js`. The script reads `app/gatekeeper_log.json` and warns when too many denials occur. Calm the watchdog with `node tools/watchdog.js feed` which appends a success entry.
 Verify the stored hashes after updates with:
 
 ```bash

--- a/test/watchdog.test.js
+++ b/test/watchdog.test.js
@@ -1,0 +1,48 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { watchdogCheck, feedWatchdog } = require('../tools/watchdog');
+
+function makeLog(entries) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wd-'));
+  const file = path.join(dir, 'log.json');
+  fs.writeFileSync(file, JSON.stringify(entries, null, 2));
+  return { dir, file };
+}
+
+test('watchdog allows when failures below limit', () => {
+  const now = Date.now();
+  const entries = [
+    { ts: now - 1000, action: 'gate_check', success: false },
+    { ts: now - 2000, action: 'gate_check', success: false },
+    { ts: now - 3000, action: 'gate_check', success: true }
+  ];
+  const { dir, file } = makeLog(entries);
+  assert.strictEqual(watchdogCheck(file, 3, 60000), true);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('watchdog blocks when failures exceed limit', () => {
+  const now = Date.now();
+  const entries = [
+    { ts: now - 1000, action: 'gate_check', success: false },
+    { ts: now - 2000, action: 'gate_check', success: false },
+    { ts: now - 3000, action: 'gate_check', success: false },
+    { ts: now - 4000, action: 'gate_check', success: false }
+  ];
+  const { dir, file } = makeLog(entries);
+  assert.strictEqual(watchdogCheck(file, 3, 60000), false);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('feedWatchdog appends calming entry', () => {
+  const { dir, file } = makeLog([]);
+  feedWatchdog(file);
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  assert.strictEqual(data.length, 1);
+  assert.strictEqual(data[0].action, 'watchdog_feed');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+

--- a/tools/watchdog.js
+++ b/tools/watchdog.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+function readLog(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) return [];
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return [];
+  }
+}
+
+function watchdogCheck(logPath, limit = 5, windowMs = 300000) {
+  const entries = readLog(logPath);
+  if (!Array.isArray(entries)) return true;
+  const since = Date.now() - windowMs;
+  const recent = entries.filter(e => e.ts && e.ts >= since);
+  const failures = recent.filter(e => e.action === 'gate_check' && e.success === false);
+  return failures.length < limit;
+}
+
+if (require.main === module) {
+  const isFeed = process.argv[2] === 'feed';
+  const argStart = isFeed ? 3 : 2;
+  const logFile = process.argv[argStart] || path.join(__dirname, '..', 'app', 'gatekeeper_log.json');
+  if (isFeed) {
+    feedWatchdog(logFile);
+    console.log('Watchdog fed.');
+    process.exit(0);
+  }
+  const limit = parseInt(process.argv[argStart + 1] || '5', 10);
+  const windowMs = parseInt(process.argv[argStart + 2] || '300000', 10);
+  const ok = watchdogCheck(logFile, limit, windowMs);
+  console.log(ok ? 'Watchdog: access stable.' : 'Watchdog: too many denied attempts.');
+  if (!ok) process.exit(1);
+}
+
+function feedWatchdog(logPath) {
+  const file = logPath || path.join(__dirname, '..', 'app', 'gatekeeper_log.json');
+  const entries = readLog(file);
+  entries.push({ ts: Date.now(), action: 'watchdog_feed' });
+  fs.writeFileSync(file, JSON.stringify(entries, null, 2));
+}
+
+module.exports = { watchdogCheck, feedWatchdog };


### PR DESCRIPTION
## Summary
- extend `tools/watchdog.js` with a `feed` command to append a calming entry
- test `feedWatchdog` and export it in `watchdog.js`
- note the feed feature in the README

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6841af7edbc0832190746e79b715c0d1