### PR TITLE
Improve tanna background controls

### DIFF
--- a/interface/color-utils.js
+++ b/interface/color-utils.js
@@ -21,6 +21,7 @@ function applyTannaColor(c){
     document.documentElement.style.setProperty('--header-bg', h);
     document.documentElement.style.setProperty('--nav-bg', n);
   }
+  document.dispatchEvent(new CustomEvent('themeChanged'));
 }
 
 if(typeof window !== 'undefined'){

--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -35,9 +35,16 @@ function initLogoBackground() {
   }
 
   function getThemeHueDiff() {
-    const style = getComputedStyle(document.documentElement);
-    const c = style.getPropertyValue('--primary-color');
-    const h = colorToHue(c);
+    let color;
+    try {
+      const stored = JSON.parse(localStorage.getItem('ethicom_tanna_color') || 'null');
+      if (stored) color = `rgb(${stored.r},${stored.g},${stored.b})`;
+    } catch {}
+    if (!color) {
+      const style = getComputedStyle(document.documentElement);
+      color = style.getPropertyValue('--primary-color');
+    }
+    const h = colorToHue(color);
     return isNaN(h) ? 0 : h - 120;
   }
 
@@ -56,6 +63,21 @@ function initLogoBackground() {
     themeHue = getThemeHueDiff();
     bgHue = getBgHue();
     symbolHue = parseInt(localStorage.getItem('ethicom_bg_symbol_hue') || '0', 10);
+  });
+
+  window.addEventListener('storage', e => {
+    if (!e.key) return;
+    const keys = [
+      'ethicom_tanna_color',
+      'ethicom_bg_symbol_hue',
+      'ethicom_bg_color',
+      'ethicom_theme'
+    ];
+    if (keys.includes(e.key)) {
+      themeHue = getThemeHueDiff();
+      bgHue = getBgHue();
+      symbolHue = parseInt(localStorage.getItem('ethicom_bg_symbol_hue') || '0', 10);
+    }
   });
 
   const canvas = document.createElement('canvas');

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -91,7 +91,7 @@
         <div id="bg_symbol_hue_wrap">
           <label for="bg_symbol_hue">Tanna hue offset: <span id="bg_symbol_hue_val">0</span>&deg;</label>
           <input type="range" id="bg_symbol_hue" min="0" max="360" step="1" value="0" />
-            <small class="note">Reload to apply.</small>
+            <small class="note">Applies instantly.</small>
         </div>
         <div id="bg_symbol_size_wrap">
           <label for="bg_symbol_size">Tanna size: <span id="bg_symbol_size_val">100</span>%</label>
@@ -274,7 +274,7 @@
         hueSlider.addEventListener('input', e => hueVal.textContent = e.target.value);
         hueSlider.addEventListener('change', e => {
           localStorage.setItem('ethicom_bg_symbol_hue', e.target.value);
-          alert('Reload the page to apply.');
+          document.dispatchEvent(new CustomEvent('themeChanged'));
         });
       }
 


### PR DESCRIPTION
## Summary
- fire `themeChanged` when applying a new Tanna color
- read stored Tanna color for background hue
- update background hue when storage entries change
- apply hue offset immediately in settings

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6841b44a3ec4832199081d9a29c8e345