### PR TITLE
Fix meta tag self-closing markup

### DIFF
--- a/interface/apple-hig.html
+++ b/interface/apple-hig.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Apple Human Interface Guidelines</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="color-utils.js"></script>

--- a/interface/connect.html
+++ b/interface/connect.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Connect</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>

--- a/interface/designregeln.html
+++ b/interface/designregeln.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Designregeln</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="color-utils.js"></script>

--- a/interface/donate.html
+++ b/interface/donate.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Spenden</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ethicom</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>

--- a/interface/fish-interface/fischEditor.html
+++ b/interface/fish-interface/fischEditor.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fische Editor</title>
   <link rel="stylesheet" href="../ethicom-style.css" />
   <script src="../../utils/op-level.js"></script>

--- a/interface/fish-interface/fischeBern.html
+++ b/interface/fish-interface/fischeBern.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fische Bern</title>
   <link rel="stylesheet" href="../ethicom-style.css" />
   <script src="../../utils/op-level.js"></script>

--- a/interface/fish-interface/fischeSchweiz.html
+++ b/interface/fish-interface/fischeSchweiz.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fische Schweiz</title>
   <link rel="stylesheet" href="../ethicom-style.css" />
   <script src="../../utils/op-level.js"></script>

--- a/interface/fish-interface/gewaesserBern.html
+++ b/interface/fish-interface/gewaesserBern.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Gewässer Bern</title>
   <link rel="stylesheet" href="../ethicom-style.css" />
   <script src="../../utils/op-level.js"></script>

--- a/interface/fish.html
+++ b/interface/fish.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fish Interface</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>

--- a/interface/gatekeeper.html
+++ b/interface/gatekeeper.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Gatekeeper</title>
   <link rel="stylesheet" href="ethicom-style.css" />
 </head>

--- a/interface/hermes.html
+++ b/interface/hermes.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Hermes</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>

--- a/interface/login.html
+++ b/interface/login.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Login – BSVRB</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>

--- a/interface/material.html
+++ b/interface/material.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Material Design Prinzipien</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="color-utils.js"></script>

--- a/interface/navigator.html
+++ b/interface/navigator.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Navigator</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>

--- a/interface/nielsen.html
+++ b/interface/nielsen.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Nielsens Heuristiken</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="color-utils.js"></script>

--- a/interface/norman.html
+++ b/interface/norman.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Normans Prinzipien</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="color-utils.js"></script>

--- a/interface/offline-signup.html
+++ b/interface/offline-signup.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Offline Signup</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="ethicom-utils.js"></script>

--- a/interface/op-story.html
+++ b/interface/op-story.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>OP Story</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Settings</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>

--- a/interface/shneiderman.html
+++ b/interface/shneiderman.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Shneidermans Regeln</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="color-utils.js"></script>

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Registrierung – BSVRB</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>

--- a/interface/start.html
+++ b/interface/start.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>BSVRB Interface</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>

--- a/interface/tanna-animation.html
+++ b/interface/tanna-animation.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Tanna Animation</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="color-utils.js"></script>

--- a/interface_OLD/README.html
+++ b/interface_OLD/README.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>README</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="side-drop.js"></script>

--- a/interface_OLD/about.html
+++ b/interface_OLD/about.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Über das Modul</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>

--- a/interface_OLD/chat.html
+++ b/interface_OLD/chat.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Chat</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="interface-loader.js"></script>

--- a/interface_OLD/erstkontakt.html
+++ b/interface_OLD/erstkontakt.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Willkommen</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>

--- a/interface_OLD/ethicom.html
+++ b/interface_OLD/ethicom.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ethik-Kompass</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>

--- a/interface_OLD/ethikom.html
+++ b/interface_OLD/ethikom.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ethik-Kompass</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="../utils/op-level.js"></script>

--- a/interface_OLD/page-flow-demo.html
+++ b/interface_OLD/page-flow-demo.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Page Flow Demo</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="theme-manager.js"></script>

--- a/interface_OLD/ratings.html
+++ b/interface_OLD/ratings.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Bewertungen</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>

--- a/interface_OLD/settings.html
+++ b/interface_OLD/settings.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Einstellungen</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>

--- a/interface_OLD/signup.html
+++ b/interface_OLD/signup.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Registrierung</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="language-selector.js"></script>

--- a/interface_OLD/tanna-tabs.html
+++ b/interface_OLD/tanna-tabs.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ethicom 4789</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="theme-manager.js"></script>

--- a/interface_OLD/tanna-template-dark.html
+++ b/interface_OLD/tanna-template-dark.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Template</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="theme-manager.js"></script>

--- a/interface_OLD/tanna-template-light.html
+++ b/interface_OLD/tanna-template-light.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Template</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="theme-manager.js"></script>

--- a/interface_OLD/tanna-template.html
+++ b/interface_OLD/tanna-template.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Template</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="theme-manager.js"></script>

--- a/interface_OLD/tools.html
+++ b/interface_OLD/tools.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Tools</title>
   <link rel="stylesheet" href="ethicom-style.css" />
   <script src="interface-loader.js"></script>


### PR DESCRIPTION
## Summary
- remove trailing slashes from `<meta>` tags across interface pages to silence HTML validator warnings

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6841cc5bf7dc8321931fd87e68ceaf3b