### PR TITLE
Add side menu and navigation drop

### DIFF
--- a/README.html
+++ b/README.html
@@ -20,6 +20,7 @@
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a aria-current="page" class="icon-only readme-link" aria-label="Help">?</a>
+    <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
   </nav>
   <section id="user_info" class="card" aria-live="polite"></section>
   <main id="main_content">
@@ -68,6 +69,9 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       initLogoBackground();
+      initSideDrop('interface/nav-menu.html');
+      const menu = document.getElementById('side_menu');
+      if (menu) menu.addEventListener('click', e => { e.preventDefault(); toggleSideDrop(); });
       fetch('README.md')
         .then(r => r.text())
         .then(t => {
@@ -80,5 +84,6 @@
         });
     });
   </script>
+  <div id="side_drop"></div>
 </body>
 </html>

--- a/bewertung.html
+++ b/bewertung.html
@@ -20,6 +20,7 @@
       <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>
+      <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
     </nav>
   </header>
   <main id="main_content">
@@ -41,7 +42,7 @@
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      initSideDrop('interface/op-navigation.html');
+      initSideDrop('interface/nav-menu.html');
       const menu = document.getElementById('side_menu');
       if(menu) menu.addEventListener('click', e => { e.preventDefault(); toggleSideDrop(); });
     });

--- a/bsvrb-fischerabteilung.html
+++ b/bsvrb-fischerabteilung.html
@@ -24,6 +24,7 @@
       <a href="interface/signup.html">Signup</a>
       <a href="interface/fish.html">Fish Interface</a>
       <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>
+      <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
       </nav>
   <main id="main_content">
     <section class="card">
@@ -131,7 +132,7 @@
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      initSideDrop('interface/op-navigation.html');
+      initSideDrop('interface/nav-menu.html');
       const menu = document.getElementById('side_menu');
       if(menu) menu.addEventListener('click', e => { e.preventDefault(); toggleSideDrop(); });
     });

--- a/bsvrb-kulturabteilung.html
+++ b/bsvrb-kulturabteilung.html
@@ -23,6 +23,7 @@
       <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>
+      <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
       </nav>
   <main id="main_content">
     <section class="card">
@@ -53,7 +54,7 @@
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      initSideDrop('interface/op-navigation.html');
+      initSideDrop('interface/nav-menu.html');
       const menu = document.getElementById('side_menu');
       if(menu) menu.addEventListener('click', e => { e.preventDefault(); toggleSideDrop(); });
     });

--- a/bsvrb-quality.html
+++ b/bsvrb-quality.html
@@ -23,6 +23,7 @@
       <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>
+      <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
       </nav>
   <main id="main_content">
     <section class="card">
@@ -125,7 +126,7 @@
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      initSideDrop('interface/op-navigation.html');
+      initSideDrop('interface/nav-menu.html');
       const menu = document.getElementById('side_menu');
       if(menu) menu.addEventListener('click', e => { e.preventDefault(); toggleSideDrop(); });
     });

--- a/bsvrb-start.html
+++ b/bsvrb-start.html
@@ -24,6 +24,7 @@
       <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>
+      <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
     </nav>
   <main id="main_content">
     <details class="card">
@@ -83,7 +84,7 @@
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      initSideDrop('interface/op-navigation.html');
+      initSideDrop('interface/nav-menu.html');
       const menu = document.getElementById('side_menu');
       if(menu) menu.addEventListener('click', e => { e.preventDefault(); toggleSideDrop(); });
     });

--- a/home.html
+++ b/home.html
@@ -24,6 +24,7 @@
       <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>
+      <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
   </nav>
   <main id="main_content">
     <details class="card">
@@ -86,7 +87,7 @@
       getLanguage();
       checkLanguageSetup();
       localStorage.setItem('visited_start', 'true');
-      initSideDrop('interface/op-navigation.html');
+      initSideDrop('interface/nav-menu.html');
       const menu = document.getElementById('side_menu');
       if(menu) menu.addEventListener('click', e => { e.preventDefault(); toggleSideDrop(); });
     });

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>
+      <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
   </nav>
   <main id="main_content">
     <details class="card">
@@ -86,7 +87,7 @@
       getLanguage();
       checkLanguageSetup();
       localStorage.setItem('visited_start', 'true');
-      initSideDrop('interface/op-navigation.html');
+      initSideDrop('interface/nav-menu.html');
       const menu = document.getElementById('side_menu');
       if(menu) menu.addEventListener('click', e => { e.preventDefault(); toggleSideDrop(); });
     });

--- a/interface/login.html
+++ b/interface/login.html
@@ -26,6 +26,7 @@
     <a href="signup.html">Signup</a>
       <a href="hermes.html">Hermes</a>
     <a href="../README.html" class="readme-link">README</a>
+    <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
   </nav>
   <main id="main_content">
     <div id="lang_selection" class="card" style="margin-bottom:1em;">
@@ -55,7 +56,7 @@
       initLanguageDropdown('lang_select');
       applyStoredModuleOrder();
       initLogin();
-      initSideDrop('op-navigation.html');
+      initSideDrop('nav-menu.html');
       const menu=document.getElementById('side_menu');
       if(menu) menu.addEventListener('click',e=>{e.preventDefault();toggleSideDrop();});
     });

--- a/interface/nav-menu.html
+++ b/interface/nav-menu.html
@@ -1,0 +1,15 @@
+<div class="card">
+  <h3>Main Navigation</h3>
+  <ul class="nav-menu">
+    <li><a href="../index.html">Start</a></li>
+    <li><a href="../bsvrb-dept-1.html">Abteilung 1</a></li>
+    <li><a href="../bsvrb-dept-2.html">Abteilung 2</a></li>
+    <li><a href="../bsvrb-dept-3.html">Abteilung 3</a></li>
+    <li><a href="../bsvrb-dept-4.html">Abteilung 4</a></li>
+    <li><a href="../bsvrb-dept-5.html">Abteilung 5</a></li>
+    <li><a href="settings.html">⚙ Einstellungen</a></li>
+    <li><a href="login.html">🔑 Login</a></li>
+    <li><a href="signup.html">Signup</a></li>
+    <li><a href="../README.html">?</a></li>
+  </ul>
+</div>

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -25,6 +25,7 @@
     <a href="signup.html">Signup</a>
       <a href="hermes.html">Hermes</a>
     <a href="../README.html" class="readme-link">README</a>
+    <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
   </nav>
   <main id="main_content">
     <p class="note">Settings are saved locally. Some options apply after reload.</p>
@@ -374,7 +375,11 @@
           }
         });
       });
+      initSideDrop('nav-menu.html');
+      const menu = document.getElementById('side_menu');
+      if (menu) menu.addEventListener('click', e => { e.preventDefault(); toggleSideDrop(); });
     });
   </script>
+  <div id="side_drop"></div>
 </body>
 </html>

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -25,6 +25,7 @@
     <a href="signup.html" aria-current="page">Signup</a>
       <a href="hermes.html">Hermes</a>
     <a href="../README.html" class="readme-link">README</a>
+    <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
   </nav>
   <main id="main_content">
     <div id="lang_selection" class="card" style="margin-bottom:1em;">
@@ -65,7 +66,7 @@
       initLanguageDropdown('lang_select');
       applyStoredModuleOrder();
       initSignup();
-      initSideDrop('op-navigation.html');
+      initSideDrop('nav-menu.html');
       const menu=document.getElementById('side_menu');
       if(menu) menu.addEventListener('click',e=>{e.preventDefault();toggleSideDrop();});
     });

--- a/personenbewertung.html
+++ b/personenbewertung.html
@@ -21,6 +21,7 @@
       <a href="wings/ratings.html">Ratings</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="readme-link">README</a>
+      <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
     </nav>
   </header>
   <main id="main_content">
@@ -31,7 +32,7 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       initBewertung();
-      initSideDrop('interface/op-navigation.html');
+      initSideDrop('interface/nav-menu.html');
       const menu = document.getElementById('side_menu');
       if(menu) menu.addEventListener('click', e => { e.preventDefault(); toggleSideDrop(); });
     });


### PR DESCRIPTION
## Summary
- enable a dropdown side navigation via a new `nav-menu.html`
- add Menu button to major pages and initialize side drop
- keep old navigation links for easy access

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6841d3e013888321b2e4fa9888d2c361