### PR TITLE
Handle token fetch error

### DIFF
--- a/interface/settings.html
+++ b/interface/settings.html
@@ -362,6 +362,9 @@
             .then(d => {
               tokenDisplay.textContent = d.token;
               localStorage.setItem('gate_temp_token', JSON.stringify({ token: d.token, expires: Date.now() + d.expires_in * 1000 }));
+            })
+            .catch(() => {
+              tokenDisplay.textContent = 'Token request failed. Please check your connection.';
             });
         });
       }


### PR DESCRIPTION
## Summary
- show an error message if generating a Gatekeeper token fails

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_6841d97a29f4832183f39ee26599fe3e