### PR TITLE
Fix layering for Tanna animation

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -485,7 +485,7 @@ button:hover {
 #op_background {
   position: fixed;
   inset: 0;
-  z-index: -1;
+  z-index: 0;
   overflow: hidden;
   opacity: 0.08;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- adjust `z-index` so animated Tanna canvas appears above the background layer but below interface modules

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6841da4d21bc8321863474cca482380a