### PR TITLE
Add ethics modules index

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ README.md -> GET_STARTED.md -> index.html
 | Directory | Purpose |
 |-----------|---------|
 | `app/` | Application settings, language rules, and user state |
-| `ethics_modules/` | Core YAML and markdown modules for the ethics framework, including `structure_9874`, `ske_module`, and `public_trust_i` |
+| `ethics_modules/` | Core YAML and markdown modules for the ethics framework (e.g., `structure_9874`, `ske_module`, `public_trust_i`) |
+| [ethics_modules/README.md](ethics_modules/README.md) | Index of all modules with one-sentence summaries |
 | `interface/` | Front-end files for the evaluation interface |
 | `i18n/` | UI translations referenced by the interface |
 | `manifests/` | Structural manifests and integrity data |

--- a/ethics_modules/README.md
+++ b/ethics_modules/README.md
@@ -1,0 +1,12 @@
+# Ethics Modules Index
+
+This folder holds the core modules that define the 4789 standard. Each file describes a specific aspect of the ethics framework.
+
+- [public_trust_i.md](public_trust_i.md) – Maintains public transparency with anonymized signatures and Bluetooth Trust Layer support.
+- [public_trust_ii.md](public_trust_ii.md) – Shows OP reliability without exposing personal data, using optional zero‑knowledge checks.
+- [ske_module.md](ske_module.md) – Provides structured, empathy‑driven language to de‑escalate conflicts.
+- [structure_9874.md](structure_9874.md) – Enables ongoing self‑reflection to prevent rhetorical drift.
+- [transfer_protocol_4789.md](transfer_protocol_4789.md) – Lists core 4789 principles such as frustration filtering and feedback‑first logic.
+- [absolution_4789.yaml](absolution_4789.yaml) – Defines when structural responsibility no longer requires active action.
+
+Integrity records like `*_hash.json` store SHA‑256 hashes for verification.


### PR DESCRIPTION
## Summary
- add README index for ethics modules
- reference the index in the repository structure table

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6841ebd177088321bc924bbd33517f66