### PR TITLE
Implement checkLanguageSetup

### DIFF
--- a/interface/bundle.js
+++ b/interface/bundle.js
@@ -2035,6 +2035,17 @@ function initLanguageDropdown(selectId = "lang_select", textPath = getUiTextPath
     });
 }
 
+function checkLanguageSetup() {
+  const supported = ["de-ch", "en"];
+  let lang = localStorage.getItem("ethicom_lang") || (navigator.language || "de-CH").toLowerCase();
+  if (!supported.includes(lang)) {
+    lang = askLanguageChoice() || "de-ch";
+  }
+  document.documentElement.lang = lang;
+  localStorage.setItem("ethicom_lang", lang);
+  if (typeof updateReadmeLinks === "function") updateReadmeLinks(lang);
+}
+
 
 
 //----- login.js -----

--- a/interface/language-selector.js
+++ b/interface/language-selector.js
@@ -124,3 +124,15 @@ function initLanguageDropdown(selectId = "lang_select", textPath = getUiTextPath
     });
 }
 
+// Ensure a language is set and supported
+function checkLanguageSetup() {
+  const supported = ["de-ch", "en"];
+  let lang = localStorage.getItem("ethicom_lang") || (navigator.language || "de-CH").toLowerCase();
+  if (!supported.includes(lang)) {
+    lang = askLanguageChoice() || "de-ch";
+  }
+  document.documentElement.lang = lang;
+  localStorage.setItem("ethicom_lang", lang);
+  if (typeof updateReadmeLinks === "function") updateReadmeLinks(lang);
+}
+


### PR DESCRIPTION
## Summary
- ensure pages can set UI language by default
- support Swiss German (`de-ch`) and English

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_68420c6d395083218ee92731a51bb65b