### PR TITLE
Add automated data setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ README.md -> GET_STARTED.md -> index.html
 - [Local Deployment](#local-deployment)
 - [Automated Server Setup](#automated-server-setup)
 - [Automated Gatekeeper Setup](#automated-gatekeeper-setup)
+- [Automated Data Setup](#automated-data-setup)
 - [Running Tests](#running-tests)
 - [Contributing](#contributing)
 
@@ -496,6 +497,13 @@ local server. The script shows key lines from `DISCLAIMERS.md` before starting
 
 Run `tools/auto-gatekeeper-setup.sh` to install Node.js 18 on Debian/Ubuntu or macOS (with Homebrew) if needed.
 The script displays key lines from `DISCLAIMERS.md` and creates a minimal gatekeeper folder.
+
+### Automated Data Setup
+[⇧](#contents)
+
+Run `tools/auto-data-setup.sh` to install Node.js 18 if needed and fetch optional
+offline data. The script installs Python and JavaScript dependencies, downloads
+currency rates and pulls candidate images from Wikipedia.
 
 ### Running Tests
 [⇧](#contents)

--- a/tools/auto-data-setup.sh
+++ b/tools/auto-data-setup.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Automatic data setup for the 4789 project.
+set -e
+
+echo "Diese Struktur wird ohne Gew\u00e4hrleistung bereitgestellt. Fehler oder Auslassungen sind m\u00f6glich."
+echo "Die Nutzung erfolgt auf eigene Verantwortung. Weder Signature 4789 noch die Maintainer haften f\u00fcr Folgen oder Anspr\u00fcche."
+echo "4789 ist ein Standard f\u00fcr Verantwortung, keine Person und kein Glaubenssystem."
+echo "Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung."
+printf "Fortfahren? (yes/no) "
+read answer
+[ "$answer" = "yes" ] || { echo "Abbruch."; exit 1; }
+
+need_node() {
+  echo "Node.js 18+ wird ben\u00f6tigt."
+  if [ "$(uname)" = "Darwin" ]; then
+    if command -v brew >/dev/null 2>&1; then
+      echo "Installing Node.js via Homebrew..."
+      brew install node@18
+      brew link --force --overwrite node@18
+    else
+      echo "Homebrew fehlt. Bitte Node.js manuell installieren."
+      exit 1
+    fi
+  elif [ -f /etc/debian_version ]; then
+    echo "Installing Node.js via apt..."
+    curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+    sudo apt-get install -y nodejs
+  else
+    echo "Automatic Node.js installation nicht unterst\u00fctzt."
+    exit 1
+  fi
+}
+
+if command -v node >/dev/null 2>&1; then
+  ver=$(node -v | cut -c2- | cut -d. -f1)
+  if [ "$ver" -lt 18 ]; then
+    need_node
+  fi
+else
+  need_node
+fi
+
+echo "Installing npm dependencies..."
+npm install
+
+echo "Installing Python dependencies..."
+pip install -r requirements.txt
+
+echo "Fetching exchange rates..."
+node tools/currency-sync.js
+
+echo "Fetching wiki images..."
+node tools/fetch-wiki-images.js
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add `auto-data-setup.sh` to fetch optional offline data with network access
- document the script in README

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68421507fc9c83219851b93cc5a96a61