### PR TITLE
Add fetch error message for language selector

### DIFF
--- a/interface/bundle.js
+++ b/interface/bundle.js
@@ -2035,6 +2035,11 @@ function initLanguageDropdown(selectId = "lang_select", textPath = getUiTextPath
         localStorage.setItem("ethicom_lang", lang);
         applyLanguage(lang);
       });
+    })
+    .catch(() => {
+      displayLangNotice(
+        'Start the interface with `node tools/serve-interface.js`. Then open `http://localhost:8080/ethicom.html` in your browser. Opening the HTML file directly (e.g. via `file://`) bypasses the local server and causes the language list to remain empty. Always access the interface through the provided `localhost` address so that translation files load correctly.'
+      );
     });
 }
 

--- a/interface/language-selector.js
+++ b/interface/language-selector.js
@@ -123,6 +123,11 @@ function initLanguageDropdown(selectId = "lang_select", textPath = getUiTextPath
         localStorage.setItem("ethicom_lang", lang);
         applyLanguage(lang);
       });
+    })
+    .catch(() => {
+      displayLangNotice(
+        'Start the interface with `node tools/serve-interface.js`. Then open `http://localhost:8080/ethicom.html` in your browser. Opening the HTML file directly (e.g. via `file://`) bypasses the local server and causes the language list to remain empty. Always access the interface through the provided `localhost` address so that translation files load correctly.'
+      );
     });
 }
 


### PR DESCRIPTION
## Summary
- show a server startup hint when language file loading fails in `language-selector.js`
- regenerate `bundle.js` with the same message

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_684216f1f9808321b4a423eb40c13ca2