### PR TITLE
Implement language dropdown

### DIFF
--- a/home.html
+++ b/home.html
@@ -26,6 +26,10 @@
       <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
   </nav>
   <main id="main_content">
+    <div id="lang_selection" class="card" style="margin-bottom:1em;">
+      <label for="lang_select" data-ui="choose_language_label">Language:</label>
+      <select id="lang_select"></select>
+    </div>
     <div id="departments_section"></div>
     <section class="card">
       <h2>Qualitätskontrolle / Verantwortungssystem</h2>
@@ -46,6 +50,7 @@
     document.addEventListener('DOMContentLoaded', () => {
       getLanguage();
       checkLanguageSetup();
+      initLanguageDropdown('lang_select');
       localStorage.setItem('visited_start', 'true');
       initSideDrop('interface/nav-menu.html');
       const menu = document.getElementById('side_menu');

--- a/index.html
+++ b/index.html
@@ -27,6 +27,10 @@
       <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
   </nav>
   <main id="main_content">
+    <div id="lang_selection" class="card" style="margin-bottom:1em;">
+      <label for="lang_select" data-ui="choose_language_label">Language:</label>
+      <select id="lang_select"></select>
+    </div>
     <div id="departments_section"></div>
     <section class="card">
       <h2>Qualitätskontrolle / Verantwortungssystem</h2>
@@ -47,6 +51,7 @@
     document.addEventListener('DOMContentLoaded', () => {
       getLanguage();
       checkLanguageSetup();
+      initLanguageDropdown('lang_select');
       localStorage.setItem('visited_start', 'true');
       initSideDrop('interface/nav-menu.html');
       const menu = document.getElementById('side_menu');

--- a/interface/connect.html
+++ b/interface/connect.html
@@ -15,6 +15,10 @@
     <h1 data-ui="connect_title">Connect</h1>
   </header>
   <main id="main_content">
+    <div id="lang_selection" class="card" style="margin-bottom:1em;">
+      <label for="lang_select" data-ui="choose_language_label">Language:</label>
+      <select id="lang_select"></select>
+    </div>
     <label for="sig_input" data-ui="connect_enter_sig">Target signature:</label>
     <input id="sig_input" />
     <button id="request_btn" data-ui="connect_request">Request connection</button>
@@ -24,5 +28,12 @@
     <h2 data-ui="connect_connections">Your connections</h2>
     <ul id="conn_list"></ul>
   </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      getLanguage();
+      checkLanguageSetup();
+      initLanguageDropdown('lang_select');
+    });
+  </script>
 </body>
 </html>

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -28,6 +28,10 @@
     <a href="../README.html" class="readme-link">README</a>
   </nav>
   <main id="main_content">
+    <div id="lang_selection" class="card" style="margin-bottom:1em;">
+      <label for="lang_select" data-ui="choose_language_label">Language:</label>
+      <select id="lang_select"></select>
+    </div>
     <section id="cover_flow" class="cover-flow card"></section>
     <section class="card">
       <h2>Quelle suchen</h2>
@@ -52,6 +56,7 @@
     document.addEventListener('DOMContentLoaded', () => {
       getLanguage();
       checkLanguageSetup();
+      initLanguageDropdown('lang_select');
       if (typeof renderOpOverview === 'function') renderOpOverview();
       initSideDrop('op-navigation.html');
       const menu = document.getElementById('side_menu');

--- a/interface/hermes.html
+++ b/interface/hermes.html
@@ -26,6 +26,10 @@
     </nav>
   </header>
   <main id="main_content">
+    <div id="lang_selection" class="card" style="margin-bottom:1em;">
+      <label for="lang_select" data-ui="choose_language_label">Language:</label>
+      <select id="lang_select"></select>
+    </div>
     <section id="hermes_tree" class="card"></section>
     <section id="op_interface" class="card">
       <div id="hermes_content">Wähle einen Artikel.</div>
@@ -44,6 +48,7 @@
     document.addEventListener('DOMContentLoaded', () => {
       getLanguage();
       checkLanguageSetup();
+      initLanguageDropdown('lang_select');
       renderBadge(getStoredOpLevel() || 'OP-0', getStoredOpLevel() || 'OP-0');
       if (typeof initHermes === 'function') initHermes();
       initSideDrop('op-navigation.html');

--- a/interface/offline-signup.html
+++ b/interface/offline-signup.html
@@ -14,6 +14,10 @@
     <h1>Offline Signup</h1>
   </header>
   <main id="main_content">
+    <div id="lang_selection" class="card" style="margin-bottom:1em;">
+      <label for="lang_select" data-ui="choose_language_label">Language:</label>
+      <select id="lang_select"></select>
+    </div>
     <p>This page stores a local profile when no server is available.</p>
     <label for="email_input">Email:</label>
     <input type="email" id="email_input" placeholder="name@provider.com" />
@@ -32,5 +36,12 @@
       </ul>
     </section>
   </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      getLanguage();
+      checkLanguageSetup();
+      initLanguageDropdown('lang_select');
+    });
+  </script>
 </body>
 </html>

--- a/interface/start.html
+++ b/interface/start.html
@@ -32,6 +32,10 @@
     </nav>
   </header>
   <main id="main_content">
+    <div id="lang_selection" class="card" style="margin-bottom:1em;">
+      <label for="lang_select" data-ui="choose_language_label">Language:</label>
+      <select id="lang_select"></select>
+    </div>
     <section class="card">
       <h2>Operational Levels</h2>
       <ul class="op-list">
@@ -52,5 +56,12 @@
       <p id="op_info" class="info"></p>
     </section>
   </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      getLanguage();
+      checkLanguageSetup();
+      initLanguageDropdown('lang_select');
+    });
+  </script>
 </body>
 </html>

--- a/start.html
+++ b/start.html
@@ -28,6 +28,10 @@
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>
   </nav>
   <main id="main_content">
+    <div id="lang_selection" class="card" style="margin-bottom:1em;">
+      <label for="lang_select" data-ui="choose_language_label">Language:</label>
+      <select id="lang_select"></select>
+    </div>
     <section class="card">
       <h2>Interfaces</h2>
       <ul class="op-list">
@@ -58,5 +62,12 @@
       </ul>
     </section>
   </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      getLanguage();
+      checkLanguageSetup();
+      initLanguageDropdown('lang_select');
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add language selection section to multiple pages
- initialize dropdown on DOM ready across pages

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_68421a8d99688321835af78470cd58d7