### PR TITLE
Add starter script for interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 **Audience:** Developers, educators, and curious readers.
 
 1. Read `GET_STARTED.md` for the main files.
-2. Run `node tools/serve-interface.js` to start the local server. For GitHub
-   Pages deployments you can simply execute `npm run serve-gh`.
+2. Start the interface with `npm start` (opens a browser automatically) or run
+   `node tools/serve-interface.js`. For GitHub Pages deployments you can use
+   `npm run serve-gh`.
    Opening an HTML file directly (via `file://`) disables translations and
    settings. See [Local Deployment](#local-deployment) for details.
-3. Open `http://localhost:8080/index.html`.
+3. The interface opens at `http://localhost:8080/index.html`.
 
 ```
 README.md -> GET_STARTED.md -> index.html

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "verify": "node tools/check-file-integrity.js",
+    "start": "node tools/start-server.js",
     "serve-gh": "BASE_URL=https://4789-alpha.github.io node tools/serve-interface.js",
     "bundle-interface": "node tools/bundle-interface.js",
     "generate-wiki": "node tools/generate-wiki.js"

--- a/tools/start-server.js
+++ b/tools/start-server.js
@@ -1,0 +1,40 @@
+const { spawn } = require('child_process');
+const path = require('path');
+const readline = require('readline');
+
+const disclaimers = [
+  'Diese Struktur wird ohne Gew\u00e4hrleistung bereitgestellt.',
+  'Die Nutzung erfolgt auf eigene Verantwortung.',
+  '4789 ist ein Standard f\u00fcr Verantwortung, keine Person und kein Glaubenssystem.',
+  'Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung.'
+];
+
+disclaimers.forEach(l => console.log(l));
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+rl.question('Fortfahren? (yes/no) ', answer => {
+  rl.close();
+  if (answer.trim() !== 'yes') {
+    console.log('Abbruch.');
+    process.exit(1);
+  }
+
+  const server = spawn('node', [path.join(__dirname, 'serve-interface.js')], { stdio: 'inherit' });
+
+  const url = 'http://localhost:8080/index.html';
+  let cmd, args;
+  if (process.platform === 'win32') {
+    cmd = 'cmd';
+    args = ['/c', 'start', '', url];
+  } else if (process.platform === 'darwin') {
+    cmd = 'open';
+    args = [url];
+  } else {
+    cmd = 'xdg-open';
+    args = [url];
+  }
+  const opener = spawn(cmd, args, { stdio: 'ignore', detached: true });
+  opener.unref();
+
+  server.on('exit', code => process.exit(code));
+});
+


### PR DESCRIPTION
## Summary
- add `start-server.js` to automate launching the interface with disclaimers
- call this new script from `npm start`
- update Quick Start instructions accordingly

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68421591f6f8832196521269a05a3366