### PR TITLE
Improve settings page fallback

### DIFF
--- a/interface/language-selector.js
+++ b/interface/language-selector.js
@@ -118,7 +118,7 @@ function initLanguageDropdown(selectId = "lang_select", textPath = getUiTextPath
       }
 
       applyLanguage(current);
-      select.addEventListener("change", e => {
+  select.addEventListener("change", e => {
         const lang = e.target.value.replace(/\*$/, "");
         localStorage.setItem("ethicom_lang", lang);
         applyLanguage(lang);
@@ -128,6 +128,14 @@ function initLanguageDropdown(selectId = "lang_select", textPath = getUiTextPath
       displayLangNotice(
         'Start the interface with `node tools/serve-interface.js`. Then open `http://localhost:8080/ethicom.html` in your browser. Opening the HTML file directly (e.g. via `file://`) bypasses the local server and causes the language list to remain empty. Always access the interface through the provided `localhost` address so that translation files load correctly.'
       );
+      const select = document.getElementById(selectId);
+      if (select) {
+        select.innerHTML = '<option value="en">en</option>';
+        select.value = 'en';
+      }
+      localStorage.setItem('ethicom_lang', 'en');
+      if (typeof applyTexts === 'function') applyTexts({});
+      if (typeof updateReadmeLinks === 'function') updateReadmeLinks('en');
     });
 }
 


### PR DESCRIPTION
## Summary
- handle failed translation fetch on settings page by defaulting to English

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_68434a344ae08321bf99bf712e76c110