### PR TITLE
Fix signup nickname handling

### DIFF
--- a/test/data-hashing.test.js
+++ b/test/data-hashing.test.js
@@ -66,12 +66,12 @@ test('registration hashes email and password as noted in DISCLAIMERS lines 9-10'
   }
 });
 
-test('signup assigns classic nickname for OP-1', () => {
+test('signup uses provided nickname for OP-1', () => {
   const usersPath = path.join(__dirname, '..', 'app', 'users.json');
   const backup = fs.existsSync(usersPath) ? fs.readFileSync(usersPath, 'utf8') : null;
   try {
     fs.writeFileSync(usersPath, '[]');
-    const { handleSignup, suggestNickname } = require('../tools/serve-interface.js');
+    const { handleSignup } = require('../tools/serve-interface.js');
     const body = JSON.stringify({ email: 'n@example.com', password: 'safePass123', nickname: 'nick', country: 'DE' });
     const req = new events.EventEmitter();
     const res = { status: 0, writeHead(code) { this.status = code; }, end() {} };
@@ -80,8 +80,7 @@ test('signup assigns classic nickname for OP-1', () => {
     req.emit('end');
     assert.strictEqual(res.status, 200);
     const stored = JSON.parse(fs.readFileSync(usersPath, 'utf8'))[0];
-    const expected = `${suggestNickname('DE')}@OP-1`;
-    assert.strictEqual(stored.alias, expected);
+    assert.strictEqual(stored.alias, 'nick@OP-1');
   } finally {
     restore(usersPath, backup);
     delete require.cache[require.resolve('../tools/serve-interface.js')];

--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -193,7 +193,15 @@ function handleSignup(req, res) {
   req.on('data', c => { body += c; });
   req.on('end', () => {
     try {
-      const { email, password, address, phone, country, id_number } = JSON.parse(body);
+      const {
+        email,
+        password,
+        address,
+        phone,
+        country,
+        id_number,
+        nickname
+      } = JSON.parse(body);
       if (!/^[^@]+@[^@]+\.[^@]+$/.test(email) || !password || password.length < 8) {
         res.writeHead(400); res.end('Invalid data'); return;
       }
@@ -217,7 +225,7 @@ function handleSignup(req, res) {
         pwHash,
         salt,
         op_level: 'OP-1',
-        nickname: autoNick,
+        nickname: nickname || autoNick,
         totpSecret: secret,
         addrHash,
         phoneHash,


### PR DESCRIPTION
## Summary
- respect provided nickname in `/api/signup`
- update tests to expect given nickname
- all tests pass

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_684361578c388321b7c25251cecd08f4