### PR TITLE
Remove translation_notice for English

### DIFF
--- a/i18n/ui-text.json
+++ b/i18n/ui-text.json
@@ -101,7 +101,6 @@
     "login_google": "Login with Google",
     "login_invalid": "Login failed.",
     "login_saved": "Login successful. ID stored.",
-    "translation_notice": "Language not fully implemented. Contributions welcome.",
     "connect_title": "Connect",
     "connect_request": "Request connection",
     "connect_enter_sig": "Target signature:",


### PR DESCRIPTION
## Summary
- clean up the English UI text by dropping the `translation_notice` field

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6843718a152483218d15d2a73979c50f