### PR TITLE
Set default theme to Tanna Dark

### DIFF
--- a/interface/color-wizard.js
+++ b/interface/color-wizard.js
@@ -79,7 +79,7 @@ function openColorSettingsWizard(){
 
   cancelBtn.addEventListener('click', () => overlay.remove());
 
-  const tempTheme = localStorage.getItem('ethicom_theme') || 'dark';
+  const tempTheme = localStorage.getItem('ethicom_theme') || 'tanna-dark';
   tempColors = {};
 
   const steps = [];
@@ -158,7 +158,7 @@ window.openColorSettingsWizard = openColorSettingsWizard;
 
 function openColorSettingsWizardCLI(){
   const themes=['dark','tanna-dark','tanna','transparent','ocean','desert','custom'];
-  let theme=prompt('Color Scheme ('+themes.join(', ')+'):',localStorage.getItem('ethicom_theme')||'dark');
+  let theme=prompt('Color Scheme ('+themes.join(', ')+'):',localStorage.getItem('ethicom_theme')||'tanna-dark');
   if(theme&&themes.includes(theme)){
     localStorage.setItem('ethicom_theme',theme);
     if(typeof applyTheme==='function') applyTheme(theme);

--- a/interface/theme-manager.js
+++ b/interface/theme-manager.js
@@ -44,7 +44,7 @@ function initThemeSelection() {
   const label = document.getElementById('theme_slider_label');
   const themes = ['dark','tanna-dark','tanna','transparent','ocean','desert','custom'];
   const labels = ['Dark','Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Custom'];
-  let theme = localStorage.getItem('ethicom_theme') || 'dark';
+  let theme = localStorage.getItem('ethicom_theme') || 'tanna-dark';
   applyTheme(theme);
   if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
   if (select) {
@@ -311,7 +311,7 @@ function openColorSettingsPopin(){
   const labels=['Dark','Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Custom'];
   const scheme=document.getElementById('theme_select_pop');
   if(scheme){
-    const stored=localStorage.getItem('ethicom_theme')||'dark';
+    const stored=localStorage.getItem('ethicom_theme')||'tanna-dark';
     scheme.value=stored;
     scheme.addEventListener('change',e=>{
       const val=e.target.value;


### PR DESCRIPTION
## Summary
- make `tanna-dark` the default theme in the color wizard and theme manager

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6844361112fc8321a75ba0c0f3162d3a