### PR TITLE
Replace Mühlethurnen example

### DIFF
--- a/verax/codex/verax.yaml
+++ b/verax/codex/verax.yaml
@@ -17,7 +17,7 @@ modules:
   - meta
 
 limen:
-  name: "Mühlethurnen-Korridor"
+  name: "Korridor"
   typ: "natürlich"
   vektor: "start=46.8392,7.5010 / end=46.8297,7.4894"
   breite: 300


### PR DESCRIPTION
## Summary
- use generic name "Korridor" in the Verax codex example

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_684436fd8bfc8321801f2e0a228cdd6c