### PR TITLE
Add touch option for Verax decisions

### DIFF
--- a/verax/README.md
+++ b/verax/README.md
@@ -5,6 +5,7 @@ This folder stores the base structure for the Verax project.
 - `index.html` and `style.css` – landing page and styles.
 - `app/` – Flutter or JavaScript client files.
 - `codex/` – game system and rules.
+- `lautstaerke_steuerung.md` – Entscheidungssteuerung per Lautstärketasten oder Touch (DE).
 - `map/` – interactive map and GPX data.
 - `logs/` – stored decisions and movements.
 - `media/` – logos and other assets.

--- a/verax/lautstaerke_steuerung.md
+++ b/verax/lautstaerke_steuerung.md
@@ -1,0 +1,25 @@
+# Entscheidungssteuerung über Lautstärketasten und Touch
+
+Diese kurze Anleitung beschreibt, wie im Verax-Spiel Entscheidungen über die Lautstärketasten oder per Touch getroffen werden.
+
+## Steuerungsmatrix
+
+| Taste  | Dauer        | Entscheidung | Bedeutung                                   |
+|-------|-------------|--------------|---------------------------------------------|
+| Lauter | kurz        | zurückweichen| Impulsiv reagieren, ausweichen              |
+| Leiser | kurz        | beobachten   | aufmerksam bleiben, nicht eingreifen        |
+| Lauter | lang (>1.5 s)| erlösen     | aktiv eingreifen, töten                     |
+| Leiser | lang (>1.5 s)| ausnehmen   | vollständige Übernahme, Konsequenz          |
+
+## Philosophie
+
+- Kurze Eingaben bedeuten eine impulsive Reaktion.
+- Lange Eingaben zeigen eine bewusste, folgenreiche Entscheidung.
+
+## Hinweise
+
+- Die Erkennung funktioniert nur in freigeschalteten Entscheidungsphasen.
+- Es wird kein Audio aufgezeichnet, die Eingabe erfolgt rein über die Tasten oder Touch-Gesten.
+- Optional stehen eingeblendete Touch-Flächen zur Verfügung, wenn die Tasten schwer erreichbar sind.
+- Entscheidungen können im Codex-Protokoll gespeichert werden.
+


### PR DESCRIPTION
## Summary
- clarify the Verax decision guide to include touch controls
- update README bullet to mention touch alternative

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_684439e531d083219021df379ceb9152