### PR TITLE
Add German README for VERAX project

### DIFF
--- a/verax/README.md
+++ b/verax/README.md
@@ -1,13 +1,50 @@
-# Verax
+# Verax – Entscheidung in Bewegung
 
-This folder stores the base structure for the Verax project.
+VERAX ist ein realweltliches Spielsystem, das Bewegung, Ethik und Entscheidungsfähigkeit in einem natürlichen Raum verbindet. Es entstand aus der Arbeit des BSVRB (Departement 4 – Gesellschaft & Genuss) und setzt auf Wahrhaftigkeit statt Wettkampf.
 
-- `index.html` and `style.css` – landing page and styles.
-- `app/` – Flutter or JavaScript client files.
-- `codex/` – game system and rules.
-- `lautstaerke_steuerung.md` – Entscheidungssteuerung per Lautstärketasten oder Touch (DE).
-- `map/` – interactive map and GPX data.
-- `logs/` – stored decisions and movements.
-- `media/` – logos and other assets.
+## Grundidee
 
-All contents fall under the Open‑Ethics License.
+- Bewegung in einem etwa 300 m breiten Korridor (Limen) entlang eines vorgegebenen Vektors
+- Engstellen aus Fels, Wasser oder dichter Vegetation
+- Entscheidungspunkte wie verletzte Tiere oder Spurensignale
+- Begrenzte Ressourcen wie Ausrüstung, Energie und Zeit
+- Ein System, das Richtung, Verhalten und Urteil protokolliert
+
+Nicht Geschwindigkeit entscheidet, sondern ob man würdig besteht.
+
+## Systemübersicht
+
+| Modul | Beschreibung |
+|-------|-------------|
+| `codex/` | YAML-Regelwerk für Bewegung, Umwelt und Entscheidungen |
+| `map/` | GPX-Dateien und Leaflet-Kartenansicht |
+| `app/` | Flutter-App mit GPS, Entscheidung und Protokoll |
+| `media/` | Logo, Marker und visuelle Elemente |
+| `docs/` | Spielerhandbuch, Codex-Hinweise und Beispiele |
+| `index.html` & `style.css` | Landing-Page und Styles |
+| `logs/` | Gespeicherte Entscheidungen und Bewegungen |
+
+## Features
+
+- Echtzeit-Entscheidungen per Lautstärketasten oder Spracheingabe
+- GPS-Interpretation von Bewegung, Stillstand und Richtung
+- Gefahren wie Bären, Wildflüsse, Kälte oder moralische Dilemmata
+- Authentische Einbindung historisch-helvetischer Symbolik
+- Interaktive Karte mit GPX-Vektor und Engstellenanzeige (Leaflet.js)
+
+## Voraussetzungen
+
+- Moderner Browser (für `leaflet.html`)
+- Flutter SDK (für App-Entwicklung)
+- Zugriff auf `/verax/` auf bsvrb.ch
+- Optionaler Swisstopo-Zugang für Schweizer Kartenlayer
+
+## Projektstatus
+
+VERAX befindet sich im aktiven Aufbau. Neue Limen-Routen, Tierprofile, Codex-Mappings und Entscheidungslogiken werden fortlaufend ergänzt.
+
+## Lizenz
+
+BSVRB-intern – nicht-kommerzielle Nutzung im Rahmen des Verbands. Entwickelt mit Aarulon. Kontakt: <https://www.bsvrb.ch>
+
+Alle Inhalte fallen unter die Open-Ethics License.


### PR DESCRIPTION
## Summary
- expand documentation in `verax/README.md` with a German overview

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68443e8235e48321a63d4e343ad691d3