### PR TITLE
Ensure collisions default to enabled

### DIFF
--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -131,8 +131,12 @@ function initLogoBackground() {
   const avgArea = avgSize * avgSize;
   const maxSymbols = Math.floor(canvas.width * canvas.height / avgArea);
   const total = Math.max(20, Math.floor(maxSymbols * fillRatio));
-  const collisionsEnabled = !lowMotion &&
-    localStorage.getItem('ethicom_bg_collisions') !== 'false';
+  let collValue = localStorage.getItem('ethicom_bg_collisions');
+  if (collValue === null) {
+    collValue = 'true';
+    localStorage.setItem('ethicom_bg_collisions', 'true');
+  }
+  const collisionsEnabled = !lowMotion && collValue !== 'false';
   for (let i = 0; i < total; i++) {
     const lvl = levels[i % levels.length];
     const img = images[lvl >= 8 ? 7 : lvl];

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -280,7 +280,12 @@
 
         const collChk = document.getElementById('bg_collisions');
         if (collChk) {
-          collChk.checked = localStorage.getItem('ethicom_bg_collisions') !== 'false';
+          let collValue = localStorage.getItem('ethicom_bg_collisions');
+          if (collValue === null) {
+            collValue = 'true';
+            localStorage.setItem('ethicom_bg_collisions', 'true');
+          }
+          collChk.checked = collValue !== 'false';
           collChk.addEventListener('change', e => {
             localStorage.setItem('ethicom_bg_collisions', e.target.checked ? 'true' : 'false');
           });


### PR DESCRIPTION
## Summary
- persist default background collision setting in localStorage
- keep checkbox checked unless user disables collisions

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68443d52a9e883218d69186765ba77aa