### PR TITLE
Integrate 4789 styling for Verax

### DIFF
--- a/verax/index.html
+++ b/verax/index.html
@@ -1,11 +1,26 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-<meta charset="UTF-8">
-<title>Verax</title>
-<link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Verax</title>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <link rel="stylesheet" href="style.css">
+  <script src="../interface/theme-manager.js"></script>
+  <script src="../interface/logo-background.js"></script>
+  <script src="../interface/module-logo.js"></script>
 </head>
 <body>
-<h1>Willkommen bei Verax</h1>
+  <div id="op_background" aria-hidden="true"></div>
+  <header>
+    <h1>Willkommen bei Verax</h1>
+  </header>
+  <main id="main_content">
+  </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      applyTheme('tanna-dark');
+    });
+  </script>
 </body>
 </html>

--- a/verax/map/leaflet.html
+++ b/verax/map/leaflet.html
@@ -1,18 +1,26 @@
 <!DOCTYPE html>
-<html>
+<html lang="de">
 <head>
   <meta charset="utf-8" />
   <title>VERAX Karte</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="../../interface/ethicom-style.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
   <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-gpx/1.5.1/gpx.min.js"></script>
+  <script src="../../interface/theme-manager.js"></script>
+  <script src="../../interface/logo-background.js"></script>
+  <script src="../../interface/module-logo.js"></script>
   <style>
     body, html { margin: 0; padding: 0; }
     #map { height: 100vh; width: 100vw; }
   </style>
 </head>
 <body>
+  <div id="op_background" aria-hidden="true"></div>
+  <header>
+    <h1>VERAX Karte</h1>
+  </header>
   <div id="map"></div>
   <script>
     const map = L.map('map').setView([46.8345, 7.4953], 14);
@@ -46,6 +54,11 @@
     map.on('locationerror', onLocationError);
 
     map.locate({setView: true, maxZoom: 16, watch: true, enableHighAccuracy: true});
+  </script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      applyTheme('tanna-dark');
+    });
   </script>
 </body>
 </html>

--- a/verax/style.css
+++ b/verax/style.css
@@ -1,4 +1,3 @@
-body {
-  font-family: Arial, sans-serif;
-  margin: 2rem;
+main {
+  padding: 2rem;
 }


### PR DESCRIPTION
## Summary
- adopt ethicom-style.css for the Verax landing page
- add Tanna themed background and header logo
- extend Leaflet map page with the shared theme
- keep simple spacing via local style.css

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68443ff7d7e08321a0d9600b1c8acf06