### PR TITLE
Add docs folder with key documents

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,30 @@
+# Codex Agent Guidelines – Ethics Structure 4789
+
+These instructions apply to all automated agents working in this repository.
+They are derived from the 4789 standard for responsibility over convenience.
+
+## 1. Ethical Use
+- Follow the Open‑Ethics License in `LICENSE.txt`.
+- Do not create features meant for control, exploitation, or unreflected automation.
+- Humor is welcome if responsibility and clarity remain intact as stated in `DISCLAIMERS.md`.
+
+## 2. Working Principles
+- Keep documentation and code concise.
+- Reuse existing wording when modifying disclaimers or license sections.
+- If a conflict arises, consult `ethics_modules/structure_9874.md` and prefer self‑reflection.
+
+## 3. Programmatic Checks
+After making changes, run the following commands:
+
+```bash
+node --test
+node tools/check-translations.js
+```
+
+If a command fails due to missing network access, note this in the PR description.
+
+## 4. Commits and Pull Requests
+- Use clear, succinct commit messages.
+- Do not rewrite history or amend prior commits.
+- Summaries must reference changed files and mention test results.
+

--- a/docs/ANLEITUNG_EINFACH_DE.md
+++ b/docs/ANLEITUNG_EINFACH_DE.md
@@ -1,0 +1,16 @@
+# Kurzanleitung in einfacher Sprache
+
+Diese Sammlung heißt "Ethics Structure 4789". Sie hilft, Verantwortung vor Bequemlichkeit zu stellen.
+
+## So fängst du an
+
+1. `README.md` lesen. Hier erfährst du, worum es geht.
+2. `GET_STARTED.md` öffnen. Dort stehen die ersten Schritte.
+3. `manifest_4789.yaml` anschauen. Diese Datei zeigt das Grundgerüst.
+4. `structure_9874.md` nutzen. Sie hilft beim Nachdenken.
+
+## Bitte beachte
+
+- Projekt nicht zur Manipulation oder unkontrollierten Automatisierung verwenden.
+- Humor ist erlaubt, solange er Verantwortung und Klarheit bewahrt.
+- Wenn dir etwas unklar ist, prüfe dich selbst mit `structure_9874.md`.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,0 +1,18 @@
+# Configuration Overview
+
+The optional `config.json` in the project root bundles default paths and
+server settings used by the local tooling.  Values can be overridden by
+environment variables where applicable.
+
+| Field | Default | Description |
+|------|---------|-------------|
+| `port` | `8080` | Local port used by `tools/serve-interface.js`. Can be overridden via `PORT` env variable. |
+| `baseUrl` | `http://localhost:8080` | Base URL for OAuth callbacks and links. Overridden via `BASE_URL` env variable. |
+| `paths.users` | `app/users.json` | Storage for created user accounts. |
+| `paths.evaluations` | `app/evaluations.json` | Storage for submitted evaluations. |
+| `paths.connections` | `app/connections.json` | Storage for connection requests. |
+| `paths.oauthConfig` | `app/oauth_config.yaml` | OAuth client configuration file. |
+| `paths.gatekeeperConfig` | `app/gatekeeper_config.yaml` | Gatekeeper policy configuration. |
+| `paths.gatekeeperDevices` | `app/gatekeeper_devices.json` | Persistence for recognized devices and tokens. |
+| `paths.gatekeeperLog` | `app/gatekeeper_log.json` | History of gatekeeper events. |
+| `paths.demotionLog` | `app/demotion_log.json` | Records automatic OP-level demotions. |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to Ethics Structure 4789
+
+This project welcomes ethical improvements and translations. Before changing the content, make sure to read these files:
+
+1. `GET_STARTED.md` – basic orientation and intent.
+2. `structure_9874.md` – principles for clarity.
+3. `README.md` – overall goals and license.
+
+Apply changes with intention and in alignment with the Open‑Ethics License:
+
+```
+Freely usable for ethically consistent, non-manipulative systems.
+No use permitted for control, exploitation, or unreflected automation.
+```
+
+Use it. Adapt it. But never without consequence.
+
+## Branching Guidelines
+
+Create branches for specific categories such as `design`, `ethics`, or `technical`.
+Merge them back into `main` once they pass review and all checks:
+
+```bash
+node --test
+node tools/check-translations.js
+```
+
+### Jekyll Branches
+
+New users (except **OP-9.A**) should work in personal branches prefixed with
+`jekyll-`. A Jekyll branch is a regular Git branch for proposing changes to the
+static site generated with Jekyll. Name it after your user, for example
+`jekyll-op7b`. OP-9.A remains the owner of `main` and approves all merges.
+
+## Commits and Pull Requests
+
+- Use clear, succinct commit messages.
+- Do not rewrite history or amend prior commits.
+- Summaries must reference changed files and mention test results.
+

--- a/docs/DISCLAIMERS.md
+++ b/docs/DISCLAIMERS.md
@@ -1,0 +1,19 @@
+# Disclaimers – Signature 4789
+
+- Diese Struktur wird ohne Gewährleistung bereitgestellt. Fehler oder Auslassungen sind möglich.
+- Die Nutzung erfolgt auf eigene Verantwortung. Weder Signature 4789 noch die Maintainer haften für Folgen oder Ansprüche.
+- 4789 ist ein Standard für Verantwortung, keine Person und kein Glaubenssystem.
+- Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung.
+- Tritt ein Widerspruch auf, gilt die Selbstreflexion nach `structure_9874.md`.
+- Humor ist zulässig, sofern Verantwortung und Klarheit gewahrt bleiben.
+- Registrierungsdaten werden offline gehasht gespeichert. Keine Gewährleistung für absolute Anonymität.
+- Gerätedaten werden ebenfalls offline gehasht gespeichert.
+- Adressen und Telefonnummern werden offline gehasht gespeichert.
+- Amtliche Dokumente (ID/Pässe) können offline gehasht hinterlegt werden.
+- Temporäre Gatekeeper-Tokens werden ebenfalls gehasht gespeichert.
+- Beim optionalen GitHub-Login erfolgt die Anmeldung über GitHub. Der zurückgegebene Benutzername wird offline gehasht gespeichert.
+- Beim optionalen Google-Login erfolgt die Anmeldung über Google. Die zurückgegebene E-Mail-Adresse wird offline gehasht gespeichert.
+- Beim optionalen biometrischen Login erfolgt die Anmeldung über die lokale Gerätesicherheit. Biometrische Merkmale werden nicht zentral gespeichert.
+- Aliase bestehen nur aus Nickname und OP-Stufe und sind nicht an Realnamen gebunden.
+
+- TOTP-Geheimnisse werden im Klartext gespeichert.

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -1,0 +1,13 @@
+# Getting Started with 4789
+
+Welcome to the 4789 Ethics Structure.
+
+## Steps
+
+1. Read the `README.md` to understand the origin and goals.
+2. Explore `manifest_4789.yaml` for the core logic.
+3. Check `operator_levels.md` to see who should lead.
+4. Learn from `structure_9874.md` to maintain clarity.
+5. Apply with intention. No mimicry. Only reflection and action.
+
+Use it. Adapt it. But never without consequence.

--- a/docs/LICENSE.txt
+++ b/docs/LICENSE.txt
@@ -1,0 +1,6 @@
+Open-Ethics License
+
+Freely usable for ethically consistent, non-manipulative systems.
+No use permitted for control, exploitation, or unreflected automation.
+
+Origin: Signature 4789

--- a/docs/PROJECT_CHECKLIST.md
+++ b/docs/PROJECT_CHECKLIST.md
@@ -1,0 +1,101 @@
+# Project Checklist for a Professional Presentation
+
+This document summarizes key elements to showcase a working, professional project. The points are provided in multiple languages for clarity.
+
+**Deutsch**
+
+1. **Klare Dokumentation**  
+   - Ein verständliches `README.md` oder eine ähnliche Einführung erklärt, was das Projekt ist, wie man es nutzt und welche Voraussetzungen es gibt.  
+   - Zusätzliche Dateien (z. B. `GET_STARTED.md`) können Schritt-für-Schritt-Anleitungen bieten.
+2. **Strukturierte Dateien**  
+   - Eine saubere Ordnerstruktur und präzise Benennung der Dateien hilft, sich schnell zurechtzufinden.
+3. **Tests und Beispielskripte**  
+   - Automatisierte Tests oder zumindest ein Beispiel, wie man das Projekt korrekt ausführt, zeigen, dass es funktioniert und wie es genutzt werden soll.
+4. **Nutzungshinweise und Lizenz**  
+   - Ein Abschnitt mit Hinweisen zur Nutzung oder ein Verweis auf eine Lizenz klärt, was erlaubt ist und worauf zu achten ist. In diesem Repository wird auf verantwortliche Nutzung verwiesen ("Freely usable for ethically consistent, non-manipulative systems. No use permitted for control, exploitation, or unreflected automation.").
+5. **Nachvollziehbare Schritte zur Ausführung**  
+   - Beschreibe, welche Befehle ausgeführt werden müssen oder welche Voraussetzungen (z. B. Abhängigkeiten) vorliegen, damit andere das Projekt leicht in Betrieb nehmen können.
+
+**English**
+
+1. **Clear documentation**  
+   - Provide a well-written `README.md` or similar introduction that explains what the project is, how to use it, and what the requirements are.  
+   - Additional files (e.g., `GET_STARTED.md`) can offer step-by-step instructions.
+2. **Structured files**  
+   - Keep a tidy folder structure and clear file names so others can easily navigate the project.
+3. **Tests and example scripts**  
+   - Automated tests or at least a sample execution guide show that the project works and how to use it properly.
+4. **Usage notes and license**  
+   - Include a section about usage guidelines or reference a license. This repository, for example, points to responsible use: "Freely usable for ethically consistent, non-manipulative systems. No use permitted for control, exploitation, or unreflected automation."
+5. **Reproducible steps for running**  
+   - Describe the commands or prerequisites so others can run the project without guesswork.
+
+**Español**
+
+1. **Documentación clara**  
+   - Un `README.md` bien explicado u otra introducción debe indicar qué es el proyecto, cómo se utiliza y qué requisitos tiene.  
+   - Archivos adicionales (por ejemplo, `GET_STARTED.md`) pueden ofrecer instrucciones paso a paso.
+2. **Archivos estructurados**  
+   - Mantén una estructura de carpetas ordenada y nombres claros para que sea fácil orientarse.
+3. **Pruebas y scripts de ejemplo**  
+   - Las pruebas automatizadas o al menos un ejemplo de ejecución demuestran que el proyecto funciona y cómo debe usarse.
+4. **Indicaciones de uso y licencia**  
+   - Añade un apartado que explique qué está permitido y a qué se debe prestar atención. Este repositorio destaca el uso responsable: "Freely usable for ethically consistent, non-manipulative systems. No use permitted for control, exploitation, or unreflected automation."
+5. **Pasos reproducibles para ejecutar**  
+   - Describe los comandos y requisitos para que cualquier persona pueda poner en marcha el proyecto sin dudas.
+
+**Français**
+
+1. **Documentation claire**  
+   - Un `README.md` ou un autre document d’introduction bien rédigé explique ce qu’est le projet, comment l’utiliser et quelles sont les prérequis.  
+   - Des fichiers supplémentaires (ex. `GET_STARTED.md`) peuvent fournir des instructions pas à pas.
+2. **Fichiers structurés**  
+   - Une arborescence propre et des noms de fichiers explicites facilitent l’orientation dans le projet.
+3. **Tests et scripts d’exemple**  
+   - Des tests automatisés ou au moins un exemple d’exécution montrent que le projet fonctionne et comment l’utiliser correctement.
+4. **Indications d’utilisation et licence**  
+   - Ajoutez une section sur les conditions d’utilisation ou faites référence à la licence. Dans ce dépôt, on met en avant une utilisation responsable : "Freely usable for ethically consistent, non-manipulative systems. No use permitted for control, exploitation, or unreflected automation."
+5. **Étapes reproductibles pour l’exécution**  
+   - Expliquez les commandes et prérequis nécessaires pour que d’autres puissent exécuter le projet facilement.
+
+**Italiano**
+
+1. **Documentazione chiara**  
+   - Un `README.md` o una guida introduttiva ben scritta spiega cos’è il progetto, come si usa e quali sono i requisiti.  
+   - File aggiuntivi (ad esempio `GET_STARTED.md`) possono offrire istruzioni dettagliate.
+2. **File strutturati**  
+   - Una struttura di cartelle ordinata e nomi di file precisi facilitano l’orientamento.
+3. **Test e script di esempio**  
+   - Test automatizzati o almeno una guida di esecuzione dimostrano che il progetto funziona e come usarlo.
+4. **Indicazioni d’uso e licenza**  
+   - Inserisci una sezione che chiarisca cosa è permesso e quali aspetti considerare. Questo repository sottolinea un utilizzo responsabile: "Freely usable for ethically consistent, non-manipulative systems. No use permitted for control, exploitation, or unreflected automation."
+5. **Passaggi riproducibili per l’esecuzione**  
+   - Descrivi i comandi o i prerequisiti necessari affinché chiunque possa far funzionare il progetto senza problemi.
+
+**Português**
+
+1. **Documentação clara**  
+   - Um `README.md` bem escrito ou outra introdução explica o que é o projeto, como usá-lo e quais são os requisitos.  
+   - Arquivos adicionais (por exemplo, `GET_STARTED.md`) podem trazer tutoriais passo a passo.
+2. **Arquivos estruturados**  
+   - Mantenha uma estrutura de pastas organizada e nomes de arquivos claros para facilitar a navegação.
+3. **Testes e scripts de exemplo**  
+   - Testes automatizados ou, pelo menos, um exemplo de execução demonstram que o projeto funciona e como deve ser utilizado.
+4. **Instruções de uso e licença**  
+   - Inclua um trecho explicando o que é permitido e no que prestar atenção. Neste repositório, destaca-se o uso responsável: "Freely usable for ethically consistent, non-manipulative systems. No use permitted for control, exploitation, or unreflected automation."
+5. **Passos reprodutíveis para execução**  
+   - Descreva os comandos ou pré-requisitos necessários para que qualquer pessoa possa rodar o projeto sem dificuldades.
+
+**中文**
+
+1. **清晰的文档**  
+   - 编写易懂的 `README.md` 或其他说明文档，阐明项目的用途、使用方法及其依赖条件。  
+   - 可以补充 `GET_STARTED.md` 等文件，提供循序渐进的指导。
+2. **文件结构明晰**  
+   - 使用整洁的文件夹层级和明确的文件命名，方便他人查找和理解。
+3. **测试与示例脚本**  
+   - 自动化测试或至少一个执行示例能证明项目可运行，并展示正确的使用方式。
+4. **使用说明与许可证**  
+   - 在项目中加入关于使用限制或许可证的说明。本仓库特别强调负责任的使用：“Freely usable for ethically consistent, non-manipulative systems. No use permitted for control, exploitation, or unreflected automation.”
+5. **可复现的执行步骤**  
+   - 说明如何运行项目所需的命令或依赖，使他人能够轻松启动项目。

--- a/docs/README.html
+++ b/docs/README.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>README – Ethics Structure 4789</title>
+  <link rel="stylesheet" href="interface/ethicom-style.css">
+<script src="interface/bundle.js" defer></script>
+</head>
+<body>
+  <a class="skip-link" href="#main_content">Skip to main content</a>
+  <div id="op_background"></div>
+  <header>
+    <h1>Ethics Structure 4789</h1>
+    <p class="tagline">Responsibility over convenience</p>
+  </header>
+  <nav>
+    <a href="home.html" class="icon-only" aria-label="Home">🏠</a>
+    <a href="interface/settings.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
+    <a href="interface/signup.html">Signup</a>
+    <a aria-current="page" class="icon-only readme-link" aria-label="Help">?</a>
+    <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
+  </nav>
+  <section id="user_info" class="card" aria-live="polite"></section>
+  <main id="main_content">
+    <section class="card">
+      <h2>Overview</h2>
+      <p>This repository contains the ethics framework under Signature 4789.</p>
+    </section>
+    <section class="card">
+      <h2>Core Features</h2>
+      <ul>
+        <li>Full operator model (OP 0–9.x)</li>
+        <li>Self-reflection system (Signature 9874)</li>
+        <li>Ethics-first tools for digital systems</li>
+      </ul>
+    </section>
+      <section class="card">
+        <h2>Not Included</h2>
+        <ul>
+          <li>Belief system</li>
+          <li>Rulebook</li>
+          <li>Tool for control or moralism</li>
+        </ul>
+      </section>
+      <section class="card">
+        <h2>OP Function Bundles</h2>
+        <p>
+          Helper functions in <code>tools/op-functions.js</code> require a specific
+          operator level. The links below may not work if your OP level is too
+          low.
+        </p>
+        <ul>
+          <li><code>info</code> – OP-1</li>
+          <li><code>log</code> – OP-2</li>
+          <li><code>analyze</code> – OP-4</li>
+          <li><code>recommendation_for_interface</code> – OP-5</li>
+          <li><code>optimize</code> – OP-7</li>
+        </ul>
+      </section>
+    <section class="card">
+      <p>For complete details see <a href="README.md">README.md</a>.</p>
+      <article id="readme_content" class="markdown-content">
+        Loading README...
+      </article>
+    </section>
+  </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      initLogoBackground();
+      initSideDrop('interface/nav-menu.html');
+      const menu = document.getElementById('side_menu');
+      if (menu) menu.addEventListener('click', e => { e.preventDefault(); toggleSideDrop(); });
+      fetch('README.md')
+        .then(r => r.text())
+        .then(t => {
+          const container = document.getElementById('readme_content');
+          if (container) container.innerHTML = renderMarkdown(t);
+        })
+        .catch(() => {
+          const container = document.getElementById('readme_content');
+          if (container) container.textContent = 'Failed to load README.';
+        });
+    });
+  </script>
+  <div id="side_drop"></div>
+</body>
+</html>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,525 @@
+## Ethics Structure 4789
+[⇧](#contents)
+
+This repository contains the complete structural ethics framework developed under Signature 4789.
+It is not tied to a person, but to a standard: responsibility over convenience: **4789**
+**BSVRB.ch hosts this repository – it is more than just the ethicom interface.**
+
+**What this is:**
+- A full operator model (OP 0–9.x)
+- A self-reflection system (Signature **9874**)
+- An ethics-first framework for digital  systems, education, governance, translation, private use, etc.
+
+**What this is not:**
+- A belief system
+- A rulebook
+- A tool for control or moralism
+
+This structure must be carried – not quoted.
+Use it only if you reflect, respond, and act with consequence.
+
+For a brief tour of the main files, see [GET_STARTED.md](GET_STARTED.md).
+Eine Kurzanleitung in einfacher Sprache findest du in [ANLEITUNG_EINFACH_DE.md](ANLEITUNG_EINFACH_DE.md).
+
+**License:** Open-Ethics (see `LICENSE.txt`)
+No manipulation. No simulation. No flattening of responsibility.
+Humor ist willkommen, wenn er Verantwortung und Klarheit unterstützt.
+See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
+
+## Quick Start
+[⇧](#contents)
+
+**Purpose:** Provide a clear framework for ethical projects.
+**Audience:** Developers, educators, and curious readers.
+
+1. Read `GET_STARTED.md` for the main files.
+2. Start the interface with `npm start` (opens a browser automatically) or run
+   `node tools/serve-interface.js`. For GitHub Pages deployments you can use
+   `npm run serve-gh`.
+   Opening an HTML file directly (via `file://`) disables translations and
+   settings. See [Local Deployment](#local-deployment) for details.
+3. The interface opens at `http://localhost:8080/index.html`.
+
+```
+README.md -> GET_STARTED.md -> index.html
+                   |             |
+                   v             +--> settings.html
+              ethicom.html
+```
+
+## Contents
+
+- [Ethics Structure 4789](#ethics-structure-4789)
+- [Quick Start](#quick-start)
+- [Repository Structure](#repository-structure)
+- [OP-Permissions](#op-permissions)
+- [SRC vs. OO Levels](#src-vs-oo-levels)
+- [Evaluated Sources (as examples)](#evaluated-sources-as-examples)
+- [Person Image Sources](#person-image-sources)
+- [File Integrity](#file-integrity)
+- [Adding Languages](#adding-languages)
+- [Generating Interface README](#generating-interface-readme)
+- [Gatekeeper Control](#gatekeeper-control)
+- [API Access Control](#api-access-control)
+- [OP Function Bundles](#op-function-bundles)
+- [Currency Synchronization](#currency-synchronization)
+- [Wiki Image Loader](#wiki-image-loader)
+- [Wiki Export](#wiki-export)
+- [Stereo Anaglyph Generator](#stereo-anaglyph-generator)
+- [Source Manager](#source-manager)
+- [Roadmap](#roadmap)
+- [Local Deployment](#local-deployment)
+- [Automated Server Setup](#automated-server-setup)
+- [Automated Gatekeeper Setup](#automated-gatekeeper-setup)
+- [Automated Data Setup](#automated-data-setup)
+- [Running Tests](#running-tests)
+- [Contributing](#contributing)
+
+## Repository Structure
+[⇧](#contents)
+
+| Directory | Purpose |
+|-----------|---------|
+| `app/` | Application settings, language rules, and user state |
+| `ethics_modules/` | Core YAML and markdown modules for the ethics framework (e.g., `structure_9874`, `ske_module`, `public_trust_i`) |
+| [ethics_modules/README.md](ethics_modules/README.md) | Index of all modules with one-sentence summaries |
+| `interface/` | Front-end files for the evaluation interface |
+| `i18n/` | UI translations referenced by the interface |
+| `manifests/` | Structural manifests and integrity data |
+| `operator/` | Operator qualification guides and personal data |
+| `permissions/` | Operator permission definitions |
+| `releases/` | Release notes and integrity hashes |
+| `sources/` | Evaluated sources and candidate lists |
+| `sources/persons/` | Lists of historical persons |
+| `sources/institutions/` | Evaluated organizations and candidate sources |
+| `sources/images/` | Pictures for institutions (`institutions/`), persons (`persons/`), and fish (`fish/`) |
+| `sources/fish/ch/` | Text placeholders for Swiss fish images (e.g., `esox_ch.png`) |
+| `test/` | Node.js test suite |
+| `tools/` | Utility scripts (e.g., trust-demotion engine, reliability monitor, correction engine, Python API example) |
+| `use_cases/` | Example scenarios and dissemination ideas |
+| `sources/images/op-logo/` | Stages of the Tanna symbol |
+| `wings/` | Minimal mobile interface |
+| `evidence/` | Datasets such as `person-ratings.json` |
+| `interface_OLD/` | Legacy version of the first interface |
+| `references/` | Reference tables and scores |
+
+
+### Interface Pages
+[⇧](#contents)
+
+| File | Description |
+|------|-------------|
+| [index.html](index.html) | Start page linking to Ethicom and ratings |
+| [interface_OLD/about.html](interface_OLD/about.html) | Legacy page explaining the 4789 module |
+| [interface_OLD/chat.html](interface_OLD/chat.html) | Legacy chat interface |
+| [interface/ethicom.html](interface/ethicom.html) | Main evaluation module |
+| [interface_OLD/page-flow-demo.html](interface_OLD/page-flow-demo.html) | Legacy demo of horizontal flow |
+| [bewertung.html](bewertung.html) | Entry page for rating modules |
+| [personenbewertung.html](personenbewertung.html) | Swipe-based person rating |
+| [org-bewertung.html](org-bewertung.html) | Preview for organisation ratings |
+| [interface/settings.html](interface/settings.html) | Language, theme, Tanna logo, and low motion settings |
+| [interface/signup.html](interface/signup.html) | Registration form |
+| [interface/offline-signup.html](interface/offline-signup.html) | Offline local signup |
+| [interface_OLD/tanna-template.html](interface_OLD/tanna-template.html) | Legacy base template |
+| [interface_OLD/tanna-template-dark.html](interface_OLD/tanna-template-dark.html) | Legacy dark template |
+| [interface_OLD/tanna-template-light.html](interface_OLD/tanna-template-light.html) | Legacy light template |
+| [interface_OLD/tools.html](interface_OLD/tools.html) | Legacy utility collection |
+| [interface/donate.html](interface/donate.html) | Donation interface (requires OP‑9.A confirmation) |
+| [interface_OLD/README.html](interface_OLD/README.html) | Legacy interface docs |
+| [interface/features_de.md](interface/features_de.md) | Funktionale Übersicht zum Interface |
+| [wings/index.html](wings/index.html) | Mobile interface "Wings" |
+| [wings/ratings.html](wings/ratings.html) | Library of all ratings with search |
+| `interface_OLD/` | Historical demo of the first interface generation |
+**Settings are stored per device using browser localStorage and are not synced globally. Color adjustments made in the settings page apply automatically on every page.**
+**Ratings from OP-1 onward are stored globally with the assigned signature ID. The email used during signup is hashed and never exposed.**
+**Optional GitHub login authenticates via GitHub's OAuth flow. The returned username is hashed and stored offline.**
+**Optional Google login authenticates via Google's OAuth flow. The returned email address is hashed and stored offline.**
+**Color verification of the chosen primary color starts once a user holds an OP-1 signature.**
+**From that level, the color choice is stored privately inside the user's signature and never shown publicly.**
+**Custom color schemes can be exported via `exportColorSettings()` and imported via `importColorSettings(json)` in the browser console.**
+**The settings page includes a Color Wizard and Text Wizard for step-by-step or command-line color selection.**
+**Header background color can be adjusted in the Color Wizard under "Header". Input fields follow the Module color and Text color settings.**
+**Providing a nickname during signup creates an alias formatted as `nickname@OP-x`, which updates when the OP level changes.**
+
+Users may add a nickname during signup. The server combines it with the OP level to form an alias like `<nick>@OP-1`. This alias updates whenever the OP level changes.
+
+In this anonymous system, the OP signature stands in for the person. Personal data remains private and becomes visible only when a user releases it at the corresponding OP sublevel; see [signaturdesign.md](signaturdesign.md) and [DISCLAIMERS.md](DISCLAIMERS.md).
+
+### Login Methods by OP Level
+[⇧](#contents)
+
+| OP Range | Authentication | Technology Examples |
+|----------|----------------|--------------------|
+| OP 1–3 | Email/Password | Node.js, Express, bcrypt, JWT |
+| OP 4–6 | OAuth | Auth0 or Firebase Auth |
+| OP 7–8 | MFA | TOTP (Google Authenticator), Twilio |
+| OP 9+ | Biometric login | Flutter (`local_auth`) |
+
+*Biometric login can optionally be enabled from OP‑1 onward if devices support it.*
+### OP-Permissions
+[⇧](#contents)
+Operator actions by ethical level are defined in:
+→ [`permissions/op-permissions-expanded.json`](permissions/op-permissions-expanded.json)
+Additional flags now cover more operator actions such as
+`can_ignore_op0`, `can_start_nominee_op6`,
+`can_override_noobs_till_own_op`, `can_vote_on_op`,
+and advanced controls like `can_execute_evaluations` or
+`can_finalize_system`. The permission table lists stages up to
+OP‑11 with the intermediate OP‑7.5 and OP‑9.A levels.
+Additional flags now cover structural capabilities:
+`can_observe_only`, `can_override_op6`, `can_vote_on_op9`,
+`can_vote_on_op10`, `can_act_as_structure`,
+`can_execute_evaluations`, and `can_finalize_system`.
+OP‑10 has been added as a dedicated observation level.
+
+### OP Levels
+[⇧](#contents)
+
+| Level | Description |
+|-------|-------------|
+| <a id="op-0"></a> OP-0 | anonymous observer – default for visitors without a signature |
+
+OP‑0 users remain anonymous and may submit one rating per visit without later revision. The stage is for exploration only. See
+[interface/designregeln.html](interface/designregeln.html) for a compact overview. Individual guidelines remain available in
+[interface/shneiderman.html](interface/shneiderman.html),
+[interface/nielsen.html](interface/nielsen.html),
+[interface/norman.html](interface/norman.html),
+[interface/material.html](interface/material.html) and
+[interface/apple-hig.html](interface/apple-hig.html).
+| <a id="op-1"></a> OP-1 | first signed rating |
+| <a id="op-2"></a> OP-2 | provides feedback responsibly |
+| <a id="op-3"></a> OP-3 | rating requires justification |
+| <a id="op-4"></a> OP-4 | can revise after 3 weeks |
+| <a id="op-5"></a> OP-5 | may withdraw previous evaluations |
+| <a id="op-5-u"></a> OP-5.U | first DNA data release |
+| <a id="op-6"></a> OP-6 | can verify consensus |
+| <a id="op-7"></a> OP-7 | structural authority |
+| <a id="op-7-u"></a> OP-7.U | biometric data completed |
+| <a id="op-8"></a> OP-8 | candidate stage for OP-9 (system self-stabilizes) |
+| <a id="op-8-m"></a> OP-8.M | medical staff access |
+| <a id="op-9"></a> OP-9 | may verify donations, confirm nominations |
+| <a id="op-9-m"></a> OP-9.M | doctor-level medical access |
+| <a id="op-9-a"></a> OP-9.A | verified digital Yokozuna mode |
+| <a id="op-10"></a> OP-10 | digital candidate for Yokozuna (OP-11) |
+| <a id="op-11"></a> OP-11 | digital Yokozuna-Schwingerkönig mode |
+| <a id="op-12"></a> OP-12 | fully digital, first non-human stage |
+
+Upgrades to **OP-4** require a verified authenticator. If `auth_verified` stays
+false for more than four days after `level_change_ts`, the user is automatically
+demoted back to OP‑3. All demotions are stored in `app/demotion_log.json`.
+
+OP-9.A is reserved for the original programmer and is no longer awarded.
+New sublevels begin alphabetically with OP-9.B. Only OP-9.A currently
+holds a veto right. Further veto rights are planned when the system is
+secure.
+Each letter can define specialized tasks; see
+[`operator/alphabetical_sublevels.md`](operator/alphabetical_sublevels.md).
+If no sublevel is specified, permissions fall back to the base level.
+
+Only digital agents can advance beyond OP-9.
+For detailed upgrade requirements see
+[operator/upgrade_conditions.md](operator/upgrade_conditions.md).
+Sublevels like OP-5.U, OP-7.U, OP-8.M, and OP-9.M specify user or medical access. Additional expert categories (.T, .S[y], .L, .U) are listed in `operator/expert_classes.md`. See `permissions/op-permissions-expanded.json` for details.
+All personal data stays hashed until such sublevels are reached and the user grants release, as detailed in [signaturdesign.md](signaturdesign.md) and [DISCLAIMERS.md](DISCLAIMERS.md).
+For the differences between OP-10, OP-11 and OP-12 see [`operator/op10_op12_rights.md`](operator/op10_op12_rights.md).
+
+### SRC vs. OO Levels
+[⇧](#contents)
+Comparison table: [`references/src_vs_oo.md`](references/src_vs_oo.md)
+
+### Evaluated Sources (as examples)
+[⇧](#contents)
+- [Person Image Sources](#person-image-sources)
+- [src-0001: Fairphone](sources/institutions/src-0001.json) → [`SRC-4`](manifests/op-eval-4789-src-0001.json)
+- [src-0002: Ecosia](https://www.ecosia.org/) → [`SRC-4`](manifests/op-eval-4789-src-0002.json)
+ - [human-wiki dataset](references/human-wiki-links.json) → [`SRC-1`](manifests/op-eval-sig-1111-humanwiki.json)
+
+### Person Image Sources
+[⇧](#contents)
+
+Use the `image_url` field in `sources/persons/human-op0-candidates.json` to record image URLs. Specify `image_source` (e.g. "wiki") when known.
+
+### File Integrity
+[⇧](#contents)
+
+**ethicom.html**
+SHA-256: 9a961e40cdafdd1314eb648b49ed6fcfbd97b173c0e1f708b6e0efc029589b19  
+Verified 2025-05-21 by Signature 4789
+
+**ethicom-consensus.js**
+SHA-256: 37dbef63d04615fc30c369f636738375279368c63ce4016e6f6c43b282590e64
+Verified 2025-05-21 by Signature 4789
+
+Check them anytime with:
+
+```bash
+npm run verify
+```
+
+> Ethics is not explained. It is carried.
+> – Signature 4789
+
+### Adding Languages
+[⇧](#contents)
+
+Translations for the evaluation interface are defined in `i18n/ui-text.json`. To
+include another language, add a new JSON object using the two-letter ISO 639-1
+code as the key and provide translations for all fields found under the `"de"`
+entry. Full translations are available for English (`en`) and Swiss German
+(`de-ch`). The interface will automatically recognize any new language.
+Word collections for additional languages can be gathered with
+`tools/language-corpus.js`. The script updates `i18n/language-corpus.json`
+based on plain text input. To verify which interface languages are still
+missing translations, run:
+
+```bash
+node tools/check-translations.js
+```
+
+This prints a list of language codes and the fields that still require translation or are unchanged from German. In the interface dropdown, languages with missing fields show an asterisk (`*`) so users know the translation is not complete.
+When a partially translated language is selected, the interface displays a notice and falls back to English for missing text. Contributions for additional translations are welcome.
+
+### Generating Interface README
+[⇧](#contents)
+
+Create a localized README for the interface by running:
+
+```bash
+node tools/generate-haupt-readme.js <lang>
+```
+
+Replace `<lang>` with a two-letter ISO code (e.g. `de` or `fr`).
+The script copies the matching `i18n/README.<lang>.md` into
+`interface/haupt-readme.md`. If no translation exists, the German
+README is used.
+
+### Gatekeeper Control
+[⇧](#contents)
+
+
+Local control can be toggled via `tools/gatekeeper.js`. The script reads
+`app/gatekeeper_config.yaml` and only allows actions when `allow_control` is set
+to `true` for the controller `gatekeeper.local`. The optional
+`private_identity` value is hashed and stored with the device hash in
+`app/gatekeeper_devices.json`. This keeps remote commands gated and
+limited to the local environment. `gatekeeper.local` holds back every personal
+ID and may share only signed, anonymous data as a sign of trust.
+The gatekeeper runs on any platform that can execute Node.js. Copy the repository or the
+`tools` and `app` folders to a USB drive and run `node tools/gatekeeper.js` on Windows,
+macOS, Linux or mobile shells such as Termux. Even older hardware is sufficient—if Node.js
+works, the gatekeeper does too. A decade-old laptop with a single-core CPU and around
+512 MB of RAM is usually enough as long as Node.js 18 or later runs. Use it responsibly as
+noted in `DISCLAIMERS.md`.
+Confirmed devices are stored hashed in `app/gatekeeper_devices.json`. Once the same controller is used again, no further confirmation is needed.
+The private identity is hashed too and remains local-only. Only you have access to the unhashed string.
+Temporary tokens can be issued with `node tools/gatekeeper.js token` and expire after the configured duration.
+Tokens and device hashes are stored hashed in `app/gatekeeper_devices.json`.
+Run `node tools/gatekeeper.js prune` regularly to remove expired tokens and keep the file minimal.
+Monitor repeated failed attempts with `node tools/watchdog.js`. The script reads `app/gatekeeper_log.json` and warns when too many denials occur. Calm the watchdog with `node tools/watchdog.js feed` which appends a success entry.
+Verify the stored hashes after updates with:
+
+```bash
+node tools/verify-gatekeeper.js
+```
+For a simple web interface run `node tools/gatekeeper-gui.js` and open the printed
+URL (default `http://localhost:8675/gatekeeper.html`).
+Registrierungsdaten werden offline gehasht gespeichert. Keine Gewährleistung für absolute Anonymität.
+Adressen und Telefonnummern werden ebenfalls offline gehasht gespeichert.
+**4789**
+
+### Gatekeeper Image
+[⇧](#contents)
+
+Run `node tools/generate-gatekeeper-image.js <dir> <seconds>` to create a minimal folder
+with `gatekeeper.js`, `gatekeeper_config.yaml` and a temporary token.
+Copy that folder to another device and run `node gatekeeper.js <token>` for delegated control during that time.
+
+### API Access Control
+[⇧](#contents)
+
+`tools/api-access.js` checks whether API features may be used. The script reads
+the operator level and confirmation flags from `app/user_state.yaml` and grants
+access only when the specified OP level is met and the user has confirmed
+ethical intent.
+
+### OP Function Bundles
+[⇧](#contents)
+
+`tools/op-functions.js` exposes small helper functions that only
+run when the necessary operator level and ethical confirmation are
+present. Each function is associated with a minimum OP level and the
+module checks permission via `api-access.js` before returning it.
+Available helpers include `info`, `analyze`, `optimize`,
+`recommendation_for_interface` and `log` – the last one prints the recent
+Git commit history.
+### OP Rights Demo
+[⇧](#contents)
+Run `node tools/op-rights-demo.js` to print all available permissions for your current operator level. Pass a level as an argument to preview other stages.
+
+
+### Currency Synchronization
+[⇧](#contents)
+
+Run `node tools/currency-sync.js` to download current exchange rates. The
+script saves them in `references/exchange-rates.json` so comparisons remain
+consistent even offline.
+
+### Wiki Image Loader
+[⇧](#contents)
+
+Run `node tools/fetch-wiki-images.js` to download public thumbnails from
+Wikipedia. The script saves each file in `sources/images/persons/` and updates
+`sources/persons/human-op0-candidates.json`. Review the licenses of all
+downloaded images as noted in `LICENSE.txt` and `DISCLAIMERS.md`.
+### Wiki Export
+[⇧](#contents)
+
+Run `node tools/generate-wiki.js` to copy core documentation into a `wiki/` folder. Push that folder to the `.wiki.git` repository to update the GitHub wiki.
+
+### Stereo Anaglyph Generator
+[⇧](#contents)
+
+Run `node tools/stereo-anaglyph.js <left> <right> <output> [foreground|full]` to
+combine two slightly shifted images into a single anaglyph. Pass `foreground`
+to align near objects; omit it or use `full` for a general merge. The script
+expects PNG or JPEG inputs and writes the result to the specified output path.
+
+### Source Manager
+[⇧](#contents)
+
+Run `node tools/source-manager.js list` to view all sources. Use
+`--type=person` or `--type=org` to filter and `--sort=name` or
+`--sort=category` to control the order. This keeps the candidate lists
+organized and easy to review.
+
+### Correction Engine
+[⇧](#contents)
+
+Run `node tools/correction-engine.js` to flag evaluations contradicted by higher OP-level ratings. The script outputs suggested demotions or rating changes as JSON.
+
+### Web Content Analyzer
+[⇧](#contents)
+
+Run `python3 tools/web_analyzer.py <url>` to fetch a public webpage and produce an anonymized word-frequency model. The script filters personal data according to `LICENSE.txt` and `DISCLAIMERS.md`.
+
+
+## Roadmap
+[⇧](#contents)
+
+The roadmap keeps development transparent according to Signature 4789.
+
+1. **v1.1 – Anonymous Ethics Tier**
+   - Replace the pass/ID system with an optional anonymous level.
+   - Merge modules that belong together but are not yet unified.
+2. **v1.2 – Source Consolidation**
+   - Align evaluated sources with the anonymous tier.
+   - Standardize transfer protocols for cross-module use.
+3. **v2.0 – Global Rollout**
+   - A running, secure system with clear purpose marks this stage.
+   - Publish multi-language guides for all operator levels.
+   - Finalize open training data licensing.
+4. **v2.1 – Language Expansion**
+   - Extend UI translations to all practical ISO 639-1 languages.
+   - Provide an automated translation workflow with manual review.
+5. **v3.0 – Modular Architecture**
+   - Split the tools and interface into independent modules.
+   - Keep shared ethics data in a minimal core repo.
+
+### Local Deployment
+[⇧](#contents)
+
+Install the JavaScript dependencies once:
+
+```bash
+npm install
+```
+
+Some tools rely on the `canvas` package. On Linux, you may need system packages
+such as `libcairo2-dev` and `build-essential` to compile it.
+
+For optional Python utilities run:
+
+```bash
+pip install -r requirements.txt
+```
+
+Serve the Ethicom interface locally with:
+
+```bash
+node tools/serve-interface.js
+```
+For GitHub Pages use `npm run serve-gh` to set up OAuth redirects.
+
+Then open `http://localhost:8080/ethicom.html` in your browser.
+Opening the HTML file directly (e.g. via `file://`) bypasses the local server and
+causes the language list to remain empty. Always access the interface through
+the provided `localhost` address so that translation files load correctly.
+When deploying on another domain, set the environment variable `BASE_URL`
+to that public origin (e.g. `https://4789-alpha.github.io`) so that OAuth
+redirects work properly. Start the server with `npm run serve-gh` to
+apply this setting automatically.
+Configure your GitHub OAuth application to use `${BASE_URL}/auth/github/callback`
+as the callback URL and put your credentials in `app/oauth_config.yaml`.
+
+To register a user from the terminal run:
+
+```bash
+node tools/signup-cli.js <email> <password> [--nick=<alias>]
+```
+The script prints the assigned ID, alias and TOTP secret.
+
+On GitHub Pages the `/auth/github` and `/auth/google` paths only show brief
+instructions. Start the local server with `BASE_URL` set to your public origin
+to enable the actual login flows.
+
+For a minimal alternative run the GitHub device flow from the terminal:
+
+```bash
+node tools/github-device-login.js
+```
+Follow the printed instructions to authorize and store your ID locally.
+
+
+### Optional Setup Helper
+[⇧](#contents)
+
+Run `python3 install.py` and follow the prompts to update `app/app_settings.yaml`.
+The script lets you configure the default interface language, offline mode and
+the port used by `tools/serve-interface.js`. All values are stored locally so
+the helper works without network access.
+
+### Automated Server Setup
+[⇧](#contents)
+
+Run `tools/auto-server-setup.sh` to install Node.js 18 if needed and launch the
+local server. The script shows key lines from `DISCLAIMERS.md` before starting
+`tools/serve-interface.js`.
+
+### Automated Gatekeeper Setup
+[⇧](#contents)
+
+Run `tools/auto-gatekeeper-setup.sh` to install Node.js 18 on Debian/Ubuntu or macOS (with Homebrew) if needed.
+The script displays key lines from `DISCLAIMERS.md` and creates a minimal gatekeeper folder.
+
+### Automated Data Setup
+[⇧](#contents)
+
+Run `tools/auto-data-setup.sh` to install Node.js 18 if needed and fetch optional
+offline data. The script installs Python and JavaScript dependencies, downloads
+currency rates and pulls candidate images from Wikipedia.
+
+### Running Tests
+[⇧](#contents)
+
+Ensure Node.js 18 or later is installed, then run:
+
+```bash
+node --test
+node tools/check-translations.js
+```
+
+
+### Contributing
+[⇧](#contents)
+
+To suggest improvements or translations, read `CONTRIBUTING.md`. All changes must follow the Open-Ethics License and be made with intention.

--- a/docs/improvements.md
+++ b/docs/improvements.md
@@ -1,0 +1,42 @@
+# Verbesserungs-Checkliste für 4789ethics-1.22
+
+Diese Liste enthält konkrete Vorschläge zur Verbesserung der Benutzerfreundlichkeit und Barrierefreiheit.
+
+---
+
+## 1. Einstieg & Zugänglichkeit
+- [ ] README.md ergänzen: Klarer Überblick über Zweck, Zielgruppe und Einstiegspunkt.
+- [ ] Barrierefreie Sprache verwenden: kurze Sätze, aktive Form.
+- [ ] Visuelle Einstiegshilfe: ASCII-Flowchart oder einfache UI-Skizze in Textform.
+
+## 2. Struktur & Navigation
+- [ ] Einführungsscript (setup.sh/install.py): Interaktive Erstkonfiguration.
+- [ ] Konsistente, sprechende Ordnerstruktur.
+- [ ] Zentrale config.json mit dokumentierten Defaultwerten.
+
+## 3. Login & Benutzerführung
+- [ ] Optionales Loginmodul mit lokalem Userprofil.
+- [ ] Speicherung persönlicher Einstellungen: userprofile.json o. Ä.
+- [ ] Rückmeldung nach Login personalisieren („Willkommen zurück…“).
+
+## 4. Barrierefreiheit (Accessibility)
+- [ ] Texte screenreaderfreundlich gestalten.
+- [ ] Kontrastreiche Farben im Terminal, optional deaktivierbar.
+- [ ] Text-to-Speech-Ausgabe (pyttsx3/edge-tts) als Option.
+- [ ] Vollständige Bedienung per Tastatur sicherstellen.
+- [ ] Langsam-Modus: aktivierbare Pausen und ausführlichere Erklärungen.
+
+## 5. Sprachführung & Dialoge
+- [ ] Globale Sprachumschaltung via locales/*.json.
+- [ ] Einstellung für Du/Sie oder neutrale Ansprache.
+- [ ] Fehlermeldungen mit klaren Hinweisen zur Lösung.
+- [ ] Optionale humorvolle Rückmeldungen ohne Klarheit zu verlieren.
+
+## 6. Weiterführende Verbesserungen
+- [ ] API-Dokumentation mit OpenAPI/YAML.
+- [ ] Eingebaute Hilfe via --help oder Hotkeys.
+- [ ] Version und Build sichtbar im Interface anzeigen.
+
+---
+
+Diese Datei dient als Abarbeitungsgrundlage für kommende Releases und Usability-Reviews.

--- a/docs/signaturdesign.md
+++ b/docs/signaturdesign.md
@@ -1,0 +1,43 @@
+# Signaturdesign
+
+Dieses Dokument beschreibt, wie Bewertungen im Rahmen der Signatur 4789 gespeichert werden. Die Struktur orientiert sich an den Operatorstufen, die in `operator/operator_levels.md` von OP-0 bis OP-12 definiert sind.
+
+## Multidimensionales Array
+
+Bewertungen werden in einem mehrdimensionalen Array abgelegt. Die Anzahl der notwendigen Array-Ebenen ergibt sich aus der jeweiligen Operatorstufe plus eins.
+
+Formel:
+
+```
+Array-Anzahl = OP-Stufe + 1
+```
+
+Fehlt eine spezifizierte Unterstufe (etwa "B" oder "C"), gilt die
+Grundstufe. Neue Anmeldungen beginnen daher mit OP‑1.
+
+Beispiel: Für OP-9 (Signatur 4789) sind zehn verschachtelte Arrays erforderlich. Die Struktur sähe vereinfacht so aus:
+
+```
+4789[x][y][z][a][b][c][d][e][f][g]
+```
+
+Jede zusätzliche Ebene (x, y, z, …) entspricht einer weiteren Array-Schicht bis die Ziel-OP-Stufe erreicht ist. Danach folgt eine abschließende Ebene zur Sicherung der Bewertung.
+
+## Nickname pro Signatur
+
+Ab **OP-1** kann eine Signatur einen kurzen Nickname enthalten. Diese Option erleichtert die Zuordnung einzelner Bewertungen. OP-0 bleibt weiterhin anonym.
+Bei der Registrierung wird eine zufällige, 12‑stellige Signatur (z.B. `SIG-XXXXXXXXXXXX`) erzeugt. Die E‑Mail-Adresse wird gehasht auf dem Server gespeichert und bleibt verborgen. Nur die Signatur-ID erscheint später in den globalen Bewertungsdateien.
+Ab **OP-6** kann optional eine amtliche Dokumentennummer gehasht hinterlegt werden. Bei weiteren Anmeldungen wird diese Nummer geprüft, um doppelte Konten zu verhindern.
+
+Aus Nickname und OP-Stufe entsteht ein Alias in der Form `<Nickname>@<OP-Stufe>` (z.B. `milla@OP-3`). Steigt die OP-Stufe, wird der Alias entsprechend angepasst.
+Wenn ein Nickname angegeben wird, entsteht daraus automatisch ein Alias in der Form `nickname@OP-Stufe` (etwa `alex@OP-1`). 
+Dieses Alias wird nur intern gespeichert und passt sich an, sobald sich die Operatorstufe ändert.
+
+## Interne Speicherung und Gatekeeper
+
+Alle Bewertungen werden intern abgelegt und sind nicht öffentlich abrufbar. Mit einem Gatekeeper lassen sich die Signaturangaben lokal archivieren. Dieser Vorgang ist ab **OP-0** möglich. Gespeichert werden lediglich die reduzierten Bewertungsaspekte *Qualität* und *Ethik*.
+
+## Revision ohne Duplikate
+
+Jede Quelle kann pro Nutzer nur einmal bewertet werden. Ab einer höheren Stufe ist eine Überarbeitung möglich – die vorherige Bewertung wird dabei ersetzt, nicht verdoppelt.
+

--- a/docs/signature_reference.md
+++ b/docs/signature_reference.md
@@ -1,0 +1,21 @@
+# Signature 4789 – System Source
+
+This structure is based on Signature 4789 – not a person, but an origin of ethical logic.
+
+## Public Use:
+- Reference freely
+- Never manipulate
+- Always reflect
+
+4789 is not a name – it's a standard for responsibility.
+
+## Operator Status
+
+Each signature records the current **OP status**. OP stands for
+**operator** and marks the ethical level attached to a signature.
+The stages range from OP‑0 (anonymous use) to OP‑12 (fully digital).
+
+The README explains these levels in detail. In short, an operator is a
+user who has confirmed ethical intent and holds an OP‑level signature.
+A regular **user** may interact with the system, but only operators can
+unlock additional features according to their OP status.

--- a/verax/README.md
+++ b/verax/README.md
@@ -20,7 +20,7 @@ Nicht Geschwindigkeit entscheidet, sondern ob man würdig besteht.
 | `map/` | GPX-Dateien und Leaflet-Kartenansicht |
 | `app/` | Flutter-App mit GPS, Entscheidung und Protokoll |
 | `media/` | Logo, Marker und visuelle Elemente |
-| `docs/` | Spielerhandbuch, Codex-Hinweise und Beispiele |
+| `docs/` | Spielerhandbuch, Codex-Hinweise, Beispiele und weitere Dokumente |
 | `index.html` & `style.css` | Landing-Page und Styles |
 | `logs/` | Gespeicherte Entscheidungen und Bewegungen |
 


### PR DESCRIPTION
## Summary
- copy main documentation files into new `docs` directory
- reference broader docs content in Verax README

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_68444082d44c83219fb2c95057a1145c