### PR TITLE
Add map iframe and Flutter snippet

### DIFF
--- a/verax/app/main.dart
+++ b/verax/app/main.dart
@@ -1,4 +1,42 @@
-// Placeholder for Verax Flutter logic
-void main() {
-  // TODO: implement app logic
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+void main() => runApp(VeraxApp());
+
+class VeraxApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(home: VeraxHome());
+  }
+}
+
+class VeraxHome extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('VERAX – Limen')),
+      body: Column(
+        children: [
+          Expanded(
+            flex: 3,
+            child: VeraxMapWidget(), // GPX-Karte direkt beim Start
+          ),
+          Expanded(
+            flex: 2,
+            child: Center(child: Text('Wähle deine Richtung, 4789.')),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class VeraxMapWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return const WebView(
+      initialUrl: '/verax/map/leaflet.html',
+      javascriptMode: JavascriptMode.unrestricted,
+    );
+  }
 }

--- a/verax/codex/verax.yaml
+++ b/verax/codex/verax.yaml
@@ -88,6 +88,14 @@ protokoll:
   notfall:
     erlauben: true
 
+anzeige:
+  start_karte: true
+  fokus: "limen.startpunkt"
+  overlays:
+    - route
+    - engstellen
+    - gefahrensymbole
+
 meta:
   erstellt: "2025-06-07"
   autor: "R. Lauper / Aarulon"

--- a/verax/index.html
+++ b/verax/index.html
@@ -16,6 +16,7 @@
     <h1>Willkommen bei Verax</h1>
   </header>
   <main id="main_content">
+    <iframe src="/verax/map/leaflet.html" width="100%" height="500" style="border:none;"></iframe>
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- embed Leaflet map in Verax landing page
- implement minimal Flutter home screen with Verax map
- configure display options for map startup

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_684495c3cf808321bf0c4bac63830190