### PR TITLE
Expand VERAX documentation with module details

### DIFF
--- a/verax/README.md
+++ b/verax/README.md
@@ -24,6 +24,47 @@ Nicht Geschwindigkeit entscheidet, sondern ob man würdig besteht.
 | `index.html` & `style.css` | Landing-Page und Styles |
 | `logs/` | Gespeicherte Entscheidungen und Bewegungen |
 
+## Moduldetails
+
+Die folgenden Abschnitte fassen die Kernbausteine von VERAX zusammen.
+
+### limen
+
+- Definiert einen mindestens 2 km langen Vektor mit einem Bewegungsband von ±300 m.
+- Enthält Pflichtengstellen: mindestens zwei physische, eine taktische und zwei entscheidungsrelevante.
+- Eine zugehörige `.gpx`-Datei legt Start, Ziel und Wegpunkte fest und trägt Namen, Jahr und optional eine Gefahrenstufe (z. B. `VX-4`).
+
+### umwelt
+
+- Berücksichtigt Wetter, Licht und Temperatur als Einflussfaktoren.
+- Optional können Naturgefahren wie Sturzrisiken, Flussquerungen oder Tierbegegnungen einbezogen werden.
+
+### bewegung
+
+- Interpretiert GPS-Daten zu Richtung, Geschwindigkeit und Pausen.
+- Beispiele: "Stillstand über 90 s" weist auf Tarnung oder Erschöpfung hin; "Sprint auf Engstelle" deutet Konfrontation an.
+
+### entscheidung
+
+- Vier Optionen über die Lautstärketasten: kurz gedrückt = impulsiv, lang gedrückt = verantwortlich.
+- Entscheidungen können dokumentiert, kommentiert und gewichtet werden.
+- Beispiel: Punkt "Verletztes Tier" mit den Optionen zurückweichen, erlösen, beobachten oder ausnehmen.
+
+### inventar
+
+- Erlaubt sind ein Sackmesser, eine Symbolwaffe (Speer, Schleuder, Bogen) und optional eine Fischerrute.
+- Maximal fünf Gegenstände dürfen im Rucksack mitgeführt werden.
+- Verboten sind Metallwaffen, Navigationsgeräte und verpackte Nahrung.
+
+### protokoll
+
+- Speichert Zeit, Ort, Aktionen und Auswahl lokal oder als JSON-Export.
+- Optionale Felder umfassen Puls, Energie und Kommentare.
+
+### meta
+
+- Enthält Verwaltungsangaben wie Version, Erstellungsjahr und Sichtbarkeit.
+
 ## Features
 
 - Echtzeit-Entscheidungen per Lautstärketasten oder Spracheingabe


### PR DESCRIPTION
## Summary
- document VERAX modules in detail in `verax/README.md`

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6844bab2a80c8321b54d6e78abc0316e