### PR TITLE
Enable offline theme control

### DIFF
--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -131,12 +131,8 @@ function initLogoBackground() {
   const avgArea = avgSize * avgSize;
   const maxSymbols = Math.floor(canvas.width * canvas.height / avgArea);
   const total = Math.max(20, Math.floor(maxSymbols * fillRatio));
-  let collValue = localStorage.getItem('ethicom_bg_collisions');
-  if (collValue === null) {
-    collValue = 'true';
-    localStorage.setItem('ethicom_bg_collisions', 'true');
-  }
-  const collisionsEnabled = !lowMotion && collValue !== 'false';
+  localStorage.setItem('ethicom_bg_collisions', 'true');
+  const collisionsEnabled = !lowMotion;
   for (let i = 0; i < total; i++) {
     const lvl = levels[i % levels.length];
     const img = images[lvl >= 8 ? 7 : lvl];

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -225,6 +225,12 @@
       const sameSlider = document.getElementById('bg_same_level_count');
       const sameVal = document.getElementById('bg_same_level_val');
       const lvlNum = typeof getStoredOpLevel === 'function' ? opLevelToNumber(getStoredOpLevel()) : 0;
+      const themeWrap = document.getElementById('theme_selection');
+      const colorWrap = document.getElementById('color_settings');
+      if (lvlNum < 3) {
+        if (themeWrap) themeWrap.style.display = 'none';
+        if (colorWrap) colorWrap.style.display = 'none';
+      }
       if (sameWrap) sameWrap.style.display = lvlNum >= 1 ? 'block' : 'none';
       if (lvlNum >= 1 && sameSlider && sameVal) {
         const storedSame = parseInt(localStorage.getItem('ethicom_same_level_count') || '1', 10);

--- a/interface/theme-manager.js
+++ b/interface/theme-manager.js
@@ -44,42 +44,50 @@ function initThemeSelection() {
   const label = document.getElementById('theme_slider_label');
   const themes = ['dark','tanna-dark','tanna','transparent','ocean','desert','custom'];
   const labels = ['Dark','Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Custom'];
+  const opLevel = window.opLevelToNumber ? window.opLevelToNumber(window.getStoredOpLevel()) : 0;
   let theme = localStorage.getItem('ethicom_theme') || 'tanna-dark';
   applyTheme(theme);
   if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
   if (select) {
     select.value = theme;
-    select.addEventListener('change', e => {
-      theme = e.target.value;
-      localStorage.setItem('ethicom_theme', theme);
-      applyTheme(theme);
-      resetSlidersFromTheme();
-      if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
-      const idx = themes.indexOf(theme);
-      if (slider && idx >= 0) {
-        slider.value = idx;
-        if (label) label.textContent = labels[idx];
-      }
-    });
+    if (opLevel >= 3) {
+      select.addEventListener('change', e => {
+        theme = e.target.value;
+        localStorage.setItem('ethicom_theme', theme);
+        applyTheme(theme);
+        resetSlidersFromTheme();
+        if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
+        const idx = themes.indexOf(theme);
+        if (slider && idx >= 0) {
+          slider.value = idx;
+          if (label) label.textContent = labels[idx];
+        }
+      });
+    } else {
+      select.disabled = true;
+    }
   }
   if (slider) {
     slider.max = themes.length - 1;
     const cur = themes.indexOf(theme);
     slider.value = cur >= 0 ? cur : 0;
     if (label) label.textContent = labels[slider.value];
-    slider.addEventListener('input', e => {
-      const idx = parseInt(e.target.value, 10);
-      theme = themes[idx] || themes[0];
-      if (label) label.textContent = labels[idx] || labels[0];
-      localStorage.setItem('ethicom_theme', theme);
-      applyTheme(theme);
-      resetSlidersFromTheme();
-      if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
-      if (select) select.value = theme;
-    });
+    if (opLevel >= 3) {
+      slider.addEventListener('input', e => {
+        const idx = parseInt(e.target.value, 10);
+        theme = themes[idx] || themes[0];
+        if (label) label.textContent = labels[idx] || labels[0];
+        localStorage.setItem('ethicom_theme', theme);
+        applyTheme(theme);
+        resetSlidersFromTheme();
+        if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
+        if (select) select.value = theme;
+      });
+    } else {
+      slider.disabled = true;
+    }
   }
   if (customBtn) {
-    const opLevel = window.opLevelToNumber ? window.opLevelToNumber(window.getStoredOpLevel()) : 0;
     if (opLevel >= 4) {
       customBtn.style.display = 'block';
       customBtn.addEventListener('click', createCustomTheme);

--- a/interface/translation-manager.js
+++ b/interface/translation-manager.js
@@ -15,6 +15,7 @@ function getSignatureId() {
 function loadUiTexts() {
   return fetch("../i18n/ui-text.json")
     .then(r => r.json())
+    .catch(() => ({}))
     .then(data => {
       uiTexts = data;
       // merge pending translations


### PR DESCRIPTION
## Summary
- enforce collisions so the Tanna animation appears by default
- restrict color settings to OP‑3 and higher
- disable theme controls for low OP levels
- allow translations to fall back when offline

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6843634b3a8c8321bb2b58ba7c9caa30