### PR TITLE
Add accessible color scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ README.md -> GET_STARTED.md -> index.html
 **Color verification of the chosen primary color starts once a user holds an OP-1 signature.**
 **From that level, the color choice is stored privately inside the user's signature and never shown publicly.**
 **Custom color schemes can be exported via `exportColorSettings()` and imported via `importColorSettings(json)` in the browser console.**
+**An additional Accessible scheme optimized for color-blind users is available in the settings.**
 **The settings page includes a Color Wizard and Text Wizard for step-by-step or command-line color selection.**
 **Header background color can be adjusted in the Color Wizard under "Header". Input fields follow the Module color and Text color settings.**
 **Providing a nickname during signup creates an alias formatted as `nickname@OP-x`, which updates when the OP level changes.**

--- a/docs/README.md
+++ b/docs/README.md
@@ -137,6 +137,7 @@ README.md -> GET_STARTED.md -> index.html
 **Color verification of the chosen primary color starts once a user holds an OP-1 signature.**
 **From that level, the color choice is stored privately inside the user's signature and never shown publicly.**
 **Custom color schemes can be exported via `exportColorSettings()` and imported via `importColorSettings(json)` in the browser console.**
+**An additional Accessible scheme optimized for color-blind users is available in the settings.**
 **The settings page includes a Color Wizard and Text Wizard for step-by-step or command-line color selection.**
 **Header background color can be adjusted in the Color Wizard under "Header". Input fields follow the Module color and Text color settings.**
 **Providing a nickname during signup creates an alias formatted as `nickname@OP-x`, which updates when the OP level changes.**

--- a/interface/bundle.js
+++ b/interface/bundle.js
@@ -824,6 +824,7 @@ function openColorSettingsWizard(){
       <option value="transparent">Transparent</option>
       <option value="ocean">Sea Blue</option>
       <option value="desert">Desert</option>
+      <option value="accessible">Accessible</option>
       <option value="custom">Custom</option>
     </select>`;
   const themeSelect = step0.querySelector('#cw_theme_select');
@@ -888,7 +889,7 @@ function openColorSettingsWizard(){
 window.openColorSettingsWizard = openColorSettingsWizard;
 
 function openColorSettingsWizardCLI(){
-  const themes=['dark','tanna-dark','tanna','transparent','ocean','desert','custom'];
+  const themes=['dark','tanna-dark','tanna','transparent','ocean','desert','accessible','custom'];
   let theme=prompt('Color Scheme ('+themes.join(', ')+'):',localStorage.getItem('ethicom_theme')||'dark');
   if(theme&&themes.includes(theme)){
     localStorage.setItem('ethicom_theme',theme);
@@ -3546,8 +3547,8 @@ function initThemeSelection() {
   const tannaCard = document.getElementById('tanna_color');
   const slider = document.getElementById('theme_slider');
   const label = document.getElementById('theme_slider_label');
-  const themes = ['dark','tanna-dark','tanna','transparent','ocean','desert','custom'];
-  const labels = ['Dark','Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Custom'];
+  const themes = ['dark','tanna-dark','tanna','transparent','ocean','desert','accessible','custom'];
+  const labels = ['Dark','Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Accessible','Custom'];
   let theme = localStorage.getItem('ethicom_theme') || 'dark';
   applyTheme(theme);
   if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
@@ -3752,6 +3753,7 @@ function openColorSettingsPopin(){
     <option value="transparent">Transparent</option>
     <option value="ocean">Sea Blue</option>
     <option value="desert">Desert</option>
+    <option value="accessible">Accessible</option>
     <option value="custom">Custom</option>
   </select></div>`+
   `
@@ -3811,8 +3813,8 @@ function openColorSettingsPopin(){
   overlay.addEventListener('keydown',e=>{if(e.key==='Escape'){e.preventDefault();closePopin();}});
   setTimeout(()=>closeBtn.focus(),0);
 
-  const themes=['dark','tanna-dark','tanna','transparent','ocean','desert','custom'];
-  const labels=['Dark','Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Custom'];
+  const themes=['dark','tanna-dark','tanna','transparent','ocean','desert','accessible','custom'];
+  const labels=['Dark','Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Accessible','Custom'];
   const scheme=document.getElementById('theme_select_pop');
   if(scheme){
     const stored=localStorage.getItem('ethicom_theme')||'dark';

--- a/interface/color-wizard.js
+++ b/interface/color-wizard.js
@@ -93,6 +93,7 @@ function openColorSettingsWizard(){
       <option value="transparent">Transparent</option>
       <option value="ocean">Sea Blue</option>
       <option value="desert">Desert</option>
+      <option value="accessible">Accessible</option>
       <option value="custom">Custom</option>
     </select>`;
   const themeSelect = step0.querySelector('#cw_theme_select');
@@ -157,7 +158,7 @@ function openColorSettingsWizard(){
 window.openColorSettingsWizard = openColorSettingsWizard;
 
 function openColorSettingsWizardCLI(){
-  const themes=['dark','tanna-dark','tanna','transparent','ocean','desert','custom'];
+  const themes=['dark','tanna-dark','tanna','transparent','ocean','desert','accessible','custom'];
   let theme=prompt('Color Scheme ('+themes.join(', ')+'):',localStorage.getItem('ethicom_theme')||'tanna-dark');
   if(theme&&themes.includes(theme)){
     localStorage.setItem('ethicom_theme',theme);

--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -120,6 +120,20 @@
   --module-color: #ffff00;
 }
 
+.theme-accessible {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+  --header-text-color: #000000;
+  --nav-text-color: #000000;
+  --primary-color: #0072b2;
+  --card-bg: #f7f7f7;
+  --header-bg: #e0e0e0;
+  --nav-bg: #e0e0e0;
+  --card-alpha-bg: rgba(255, 255, 255, 0.95);
+  --accent-color: #d55e00;
+  --module-color: #0072b2;
+}
+
 .theme-transparent {
   --bg-color: transparent;
   --text-color: #e0e0e0;

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -47,6 +47,7 @@
           <option value="transparent">Transparent</option>
           <option value="ocean">Sea Blue</option>
           <option value="desert">Desert</option>
+          <option value="accessible">Accessible</option>
           <option value="custom">Custom</option>
         </select>
         <button id="custom_theme_btn" style="display:none;margin-top:0.5em;" class="accent-button">Create Custom Scheme</button>

--- a/interface/theme-manager.js
+++ b/interface/theme-manager.js
@@ -9,7 +9,8 @@ function applyTheme(theme) {
     'theme-desert',
     'theme-transparent',
     'theme-custom',
-    'theme-high-contrast'
+    'theme-high-contrast',
+    'theme-accessible'
   );
   document.documentElement.style.removeProperty('--primary-color');
   document.documentElement.style.removeProperty('--accent-color');
@@ -42,8 +43,8 @@ function initThemeSelection() {
   const tannaCard = document.getElementById('tanna_color');
   const slider = document.getElementById('theme_slider');
   const label = document.getElementById('theme_slider_label');
-  const themes = ['dark','tanna-dark','tanna','transparent','ocean','desert','custom'];
-  const labels = ['Dark','Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Custom'];
+  const themes = ['dark','tanna-dark','tanna','transparent','ocean','desert','accessible','custom'];
+  const labels = ['Dark','Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Accessible','Custom'];
   let theme = localStorage.getItem('ethicom_theme') || 'tanna-dark';
   applyTheme(theme);
   if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
@@ -248,6 +249,7 @@ function openColorSettingsPopin(){
     <option value="transparent">Transparent</option>
     <option value="ocean">Sea Blue</option>
     <option value="desert">Desert</option>
+    <option value="accessible">Accessible</option>
     <option value="custom">Custom</option>
   </select></div>`+
   `
@@ -307,8 +309,8 @@ function openColorSettingsPopin(){
   overlay.addEventListener('keydown',e=>{if(e.key==='Escape'){e.preventDefault();closePopin();}});
   setTimeout(()=>closeBtn.focus(),0);
 
-  const themes=['dark','tanna-dark','tanna','transparent','ocean','desert','custom'];
-  const labels=['Dark','Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Custom'];
+  const themes=['dark','tanna-dark','tanna','transparent','ocean','desert','accessible','custom'];
+  const labels=['Dark','Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Accessible','Custom'];
   const scheme=document.getElementById('theme_select_pop');
   if(scheme){
     const stored=localStorage.getItem('ethicom_theme')||'tanna-dark';

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -133,6 +133,7 @@ README.md -> GET_STARTED.md -> index.html
 **Color verification of the chosen primary color starts once a user holds an OP-1 signature.**
 **From that level, the color choice is stored privately inside the user's signature and never shown publicly.**
 **Custom color schemes can be exported via `exportColorSettings()` and imported via `importColorSettings(json)` in the browser console.**
+**An additional Accessible scheme optimized for color-blind users is available in the settings.**
 **The settings page includes a Color Wizard and Text Wizard for step-by-step or command-line color selection.**
 **Header background color can be adjusted in the Color Wizard under "Header". Input fields follow the Module color and Text color settings.**
 **Providing a nickname during signup creates an alias formatted as `nickname@OP-x`, which updates when the OP level changes.**


### PR DESCRIPTION
## Summary
- introduce `theme-accessible` color scheme
- add the option to pick the Accessible scheme in settings and wizards
- update docs to mention the new color scheme

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6844c24b52e0832184f4c914c43803c6