### PR TITLE
Show collision highlights above text

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -517,7 +517,7 @@ button:hover {
 #op_background {
   position: fixed;
   inset: 0;
-  z-index: 0;
+  z-index: -1;
   overflow: hidden;
   opacity: 0.08;
   pointer-events: none;

--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -84,9 +84,21 @@ function initLogoBackground() {
   container.appendChild(canvas);
   const ctx = canvas.getContext('2d');
 
+  const overlay = document.createElement('canvas');
+  overlay.style.position = 'fixed';
+  overlay.style.inset = '0';
+  overlay.style.pointerEvents = 'none';
+  overlay.style.zIndex = '1';
+  overlay.style.width = '100%';
+  overlay.style.height = '100%';
+  document.body.appendChild(overlay);
+  const octx = overlay.getContext('2d');
+
   function resize() {
     canvas.width = container.clientWidth || window.innerWidth;
     canvas.height = container.clientHeight || window.innerHeight;
+    overlay.width = canvas.width;
+    overlay.height = canvas.height;
   }
   window.addEventListener('resize', resize);
   resize();
@@ -207,6 +219,7 @@ function initLogoBackground() {
 
   function step() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    octx.clearRect(0, 0, overlay.width, overlay.height);
 
     for (let i = 0; i < symbols.length; i++) {
       const s = symbols[i];
@@ -348,12 +361,15 @@ function initLogoBackground() {
           );
         }
         if (s.highlightUntil > performance.now()) {
-          ctx.strokeStyle = getComputedStyle(document.documentElement)
+          octx.save();
+          octx.translate(s.x, s.y);
+          octx.strokeStyle = getComputedStyle(document.documentElement)
             .getPropertyValue('--accent-color') || '#ff0';
-          ctx.lineWidth = 2;
-          ctx.beginPath();
-          ctx.arc(0, 0, s.radius * s.scale, 0, Math.PI * 2);
-          ctx.stroke();
+          octx.lineWidth = 2;
+          octx.beginPath();
+          octx.arc(0, 0, s.radius * s.scale, 0, Math.PI * 2);
+          octx.stroke();
+          octx.restore();
         }
         ctx.filter = 'none';
         ctx.restore();

--- a/interface_OLD/ethicom-style.css
+++ b/interface_OLD/ethicom-style.css
@@ -352,7 +352,7 @@ button:hover {
 #op_background {
   position: fixed;
   inset: 0;
-  z-index: 0;
+  z-index: -1;
   overflow: hidden;
   opacity: 0.08;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- create an overlay canvas for collision highlights so they render in front
- rebundle interface scripts

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6844c66d45f48321b79d7722f3c9cd0d