### PR TITLE
Remove redundant text from Verax map

### DIFF
--- a/verax/map/leaflet.html
+++ b/verax/map/leaflet.html
@@ -42,7 +42,7 @@
     function onLocationFound(e) {
       const radius = e.accuracy;
       L.marker(e.latlng).addTo(map)
-        .bindPopup("Du bist hier (±" + Math.round(radius) + " m)").openPopup();
+        .bindPopup("±" + Math.round(radius) + " m").openPopup();
       L.circle(e.latlng, radius).addTo(map);
     }
 


### PR DESCRIPTION
## Summary
- tweak Verax map popup text by removing "Du bist hier"

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68454b41f6e88321910843cbba6f2e09