### PR TITLE
Add tool GUI example with disclaimers

### DIFF
--- a/interface/time-tool.html
+++ b/interface/time-tool.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Time Tool</title>
+  <link rel="stylesheet" href="ethicom-style.css">
+  <script src="translation-manager.js"></script>
+  <script src="language-selector.js"></script>
+  <script src="disclaimer.js"></script>
+</head>
+<body>
+  <main>
+    <button id="time_btn" class="accent-button">Get Server Time</button>
+    <p id="time_out" class="note"></p>
+  </main>
+  <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    loadUiTexts().then(t => {
+      const lang = getLanguage();
+      const texts = t[lang] || t.en || {};
+      showDisclaimers(texts);
+    });
+    const timeBtn = document.getElementById('time_btn');
+    const out = document.getElementById('time_out');
+    timeBtn.addEventListener('click', () => {
+      fetch('/time').then(r => r.json()).then(d => {
+        out.textContent = d.time;
+      });
+    });
+  });
+  </script>
+</body>
+</html>

--- a/interface/time-tool.html
+++ b/interface/time-tool.html
@@ -5,8 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Time Tool</title>
   <link rel="stylesheet" href="ethicom-style.css">
-  <script src="translation-manager.js"></script>
-  <script src="language-selector.js"></script>
   <script src="disclaimer.js"></script>
 </head>
 <body>
@@ -16,10 +14,15 @@
   </main>
   <script>
   document.addEventListener('DOMContentLoaded', () => {
-    loadUiTexts().then(t => {
-      const lang = getLanguage();
-      const texts = t[lang] || t.en || {};
-      showDisclaimers(texts);
+    showDisclaimers({
+      disclaimer_title: 'Hinweise',
+      disclaimer_items: [
+        'Diese Struktur wird ohne Gew\u00e4hrleistung bereitgestellt.',
+        'Die Nutzung erfolgt auf eigene Verantwortung.',
+        '4789 ist ein Standard f\u00fcr Verantwortung, keine Person und kein Glaubenssystem.',
+        'Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung.'
+      ],
+      btn_disclaimer_accept: 'Verstanden'
     });
     const timeBtn = document.getElementById('time_btn');
     const out = document.getElementById('time_out');

--- a/tools/time-gui.js
+++ b/tools/time-gui.js
@@ -1,0 +1,59 @@
+const http = require('http');
+const path = require('path');
+const fs = require('fs');
+const { spawn } = require('child_process');
+const readline = require('readline');
+
+const disclaimers = [
+  'Diese Struktur wird ohne Gew\u00e4hrleistung bereitgestellt.',
+  'Die Nutzung erfolgt auf eigene Verantwortung.',
+  '4789 ist ein Standard f\u00fcr Verantwortung, keine Person und kein Glaubenssystem.',
+  'Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung.'
+];
+
+disclaimers.forEach(l => console.log(l));
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+rl.question('Fortfahren? (yes/no) ', answer => {
+  rl.close();
+  if (answer.trim() !== 'yes') {
+    console.log('Abbruch.');
+    process.exit(1);
+  }
+
+  const port = process.env.TIME_GUI_PORT || 8765;
+  const htmlPath = path.join(__dirname, '..', 'interface', 'time-tool.html');
+
+  const server = http.createServer((req, res) => {
+    const urlPath = decodeURIComponent(req.url.split('?')[0]);
+    if (urlPath === '/' || urlPath === '/time-tool.html') {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      fs.createReadStream(htmlPath).pipe(res);
+      return;
+    }
+    if (req.method === 'GET' && urlPath === '/time') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ time: new Date().toISOString() }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end('Not found');
+  });
+
+  server.listen(port, () => {
+    const url = `http://localhost:${port}/time-tool.html`;
+    console.log(`Tool GUI at ${url}`);
+    let cmd, args;
+    if (process.platform === 'win32') {
+      cmd = 'cmd';
+      args = ['/c', 'start', '', url];
+    } else if (process.platform === 'darwin') {
+      cmd = 'open';
+      args = [url];
+    } else {
+      cmd = 'xdg-open';
+      args = [url];
+    }
+    const opener = spawn(cmd, args, { stdio: 'ignore', detached: true });
+    opener.unref();
+  });
+});

--- a/tools/time-gui.js
+++ b/tools/time-gui.js
@@ -1,7 +1,6 @@
 const http = require('http');
 const path = require('path');
 const fs = require('fs');
-const { spawn } = require('child_process');
 const readline = require('readline');
 
 const disclaimers = [
@@ -41,19 +40,6 @@ rl.question('Fortfahren? (yes/no) ', answer => {
 
   server.listen(port, () => {
     const url = `http://localhost:${port}/time-tool.html`;
-    console.log(`Tool GUI at ${url}`);
-    let cmd, args;
-    if (process.platform === 'win32') {
-      cmd = 'cmd';
-      args = ['/c', 'start', '', url];
-    } else if (process.platform === 'darwin') {
-      cmd = 'open';
-      args = [url];
-    } else {
-      cmd = 'xdg-open';
-      args = [url];
-    }
-    const opener = spawn(cmd, args, { stdio: 'ignore', detached: true });
-    opener.unref();
+    console.log(`Time GUI at ${url}`);
   });
 });


### PR DESCRIPTION
## Summary
- add `tools/time-gui.js` server that prints DISCLAIMERS.md lines and serves a small web interface
- add `interface/time-tool.html` page with a button that fetches the server time and shows the disclaimer overlay

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6845651f23d88321a15b7ba70666c51c