### PR TITLE
Update highlight color for Tanna collisions

### DIFF
--- a/interface/bundle.js
+++ b/interface/bundle.js
@@ -2534,8 +2534,9 @@ function initLogoBackground() {
         if (s.highlightUntil > performance.now()) {
           octx.save();
           octx.translate(s.x, s.y);
-          octx.strokeStyle = getComputedStyle(document.documentElement)
-            .getPropertyValue('--accent-color') || '#ff0';
+          const style = getComputedStyle(document.documentElement);
+          octx.strokeStyle = style.getPropertyValue('--collision-color') ||
+            style.getPropertyValue('--accent-color') || '#ff0';
           octx.lineWidth = 2;
           octx.beginPath();
           octx.arc(0, 0, s.radius * s.scale, 0, Math.PI * 2);

--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -13,6 +13,7 @@
   --nav-bg: rgba(51, 51, 51, 0.9);
   --card-alpha-bg: rgba(43, 43, 43, 0.92);
   --accent-color: #ccaa22;
+  --collision-color: var(--accent-color);
   --module-color: #228B22;
   --highlight-text-color: var(--accent-color);
   --foreground-opacity: 0;
@@ -45,6 +46,7 @@
   --nav-bg: rgba(51, 51, 51, 0.9);
   --card-alpha-bg: rgba(255, 255, 255, 0.92);
   --accent-color: #228B22;
+  --collision-color: #ffff00;
   --module-color: #228B22;
 }
 
@@ -60,6 +62,7 @@
   --nav-bg: rgba(0, 0, 0, 0.85);
   --card-alpha-bg: rgba(34, 34, 34, 0.9);
   --accent-color: #33cc33;
+  --collision-color: #ffff00;
   --module-color: #228B22;
   --foreground-opacity: 0;
 }
@@ -75,6 +78,7 @@
   --nav-bg: rgba(34, 34, 34, 0.95);
   --card-alpha-bg: rgba(255, 255, 255, 0.95);
   --accent-color: #228B22;
+  --collision-color: #ffff00;
   --module-color: #228B22;
 }
 

--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -364,8 +364,10 @@ function initLogoBackground() {
         if (s.highlightUntil > performance.now()) {
           octx.save();
           octx.translate(s.x, s.y);
-          octx.strokeStyle = getComputedStyle(document.documentElement)
-            .getPropertyValue('--accent-color') || '#ff0';
+          const style = getComputedStyle(document.documentElement);
+          octx.strokeStyle =
+            style.getPropertyValue('--collision-color') ||
+            style.getPropertyValue('--accent-color') || '#ff0';
           octx.lineWidth = 2;
           octx.beginPath();
           octx.arc(0, 0, s.radius * s.scale, 0, Math.PI * 2);


### PR DESCRIPTION
## Summary
- add collision color variable to CSS and give Tanna themes bright yellow collisions
- draw collision highlights with `--collision-color`

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68460dadfe0883219cc0dd5e4fd101da