### PR TITLE
Add starter doc links

### DIFF
--- a/ANLEITUNG_EINFACH_DE.md
+++ b/ANLEITUNG_EINFACH_DE.md
@@ -4,10 +4,10 @@ Diese Sammlung heißt "Ethics Structure 4789". Sie hilft, Verantwortung vor Bequ
 
 ## So fängst du an
 
-1. `README.md` lesen. Hier erfährst du, worum es geht.
-2. `GET_STARTED.md` öffnen. Dort stehen die ersten Schritte.
-3. `manifest_4789.yaml` anschauen. Diese Datei zeigt das Grundgerüst.
-4. `structure_9874.md` nutzen. Sie hilft beim Nachdenken.
+1. [README.md](README.md) lesen. Hier erfährst du, worum es geht.
+2. [GET_STARTED.md](GET_STARTED.md) öffnen. Dort stehen die ersten Schritte.
+3. [manifest_4789.yaml](manifests/manifest_4789.yaml) anschauen. Diese Datei zeigt das Grundgerüst.
+4. [structure_9874.md](ethics_modules/structure_9874.md) nutzen. Sie hilft beim Nachdenken.
 
 ## Bitte beachte
 

--- a/GET_STARTED.md
+++ b/GET_STARTED.md
@@ -4,10 +4,10 @@ Welcome to the 4789 Ethics Structure.
 
 ## Steps
 
-1. Read the `README.md` to understand the origin and goals.
-2. Explore `manifest_4789.yaml` for the core logic.
-3. Check `operator_levels.md` to see who should lead.
-4. Learn from `structure_9874.md` to maintain clarity.
+1. Read [README.md](README.md) to understand the origin and goals.
+2. Explore [manifest_4789.yaml](manifests/manifest_4789.yaml) for the core logic.
+3. Check [operator_levels.md](operator_levels.md) to see who should lead.
+4. Learn from [structure_9874.md](ethics_modules/structure_9874.md) to maintain clarity.
 5. Apply with intention. No mimicry. Only reflection and action.
 
 Use it. Adapt it. But never without consequence.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use it only if you reflect, respond, and act with consequence.
 For a brief tour of the main files, see [GET_STARTED.md](GET_STARTED.md).
 Eine Kurzanleitung in einfacher Sprache findest du in [ANLEITUNG_EINFACH_DE.md](ANLEITUNG_EINFACH_DE.md).
 
-**License:** Open-Ethics (see `LICENSE.txt`)
+**License:** Open-Ethics (see [LICENSE.txt](LICENSE.txt))
 No manipulation. No simulation. No flattening of responsibility.
 Humor ist willkommen, wenn er Verantwortung und Klarheit unterstützt.
 See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
@@ -32,7 +32,7 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 **Purpose:** Provide a clear framework for ethical projects.
 **Audience:** Developers, educators, and curious readers.
 
-1. Read `GET_STARTED.md` for the main files.
+1. Read [GET_STARTED.md](GET_STARTED.md) for the main files.
 2. Start the interface with `npm start` (opens a browser automatically) or run
    `node tools/serve-interface.js`. For GitHub Pages deployments you can use
    `npm run serve-gh`.
@@ -523,4 +523,4 @@ node tools/check-translations.js
 ### Contributing
 [⇧](#contents)
 
-To suggest improvements or translations, read `CONTRIBUTING.md`. All changes must follow the Open-Ethics License and be made with intention.
+To suggest improvements or translations, read [CONTRIBUTING.md](CONTRIBUTING.md). All changes must follow the Open-Ethics License and be made with intention.

--- a/docs/ANLEITUNG_EINFACH_DE.md
+++ b/docs/ANLEITUNG_EINFACH_DE.md
@@ -4,10 +4,10 @@ Diese Sammlung heißt "Ethics Structure 4789". Sie hilft, Verantwortung vor Bequ
 
 ## So fängst du an
 
-1. `README.md` lesen. Hier erfährst du, worum es geht.
-2. `GET_STARTED.md` öffnen. Dort stehen die ersten Schritte.
-3. `manifest_4789.yaml` anschauen. Diese Datei zeigt das Grundgerüst.
-4. `structure_9874.md` nutzen. Sie hilft beim Nachdenken.
+1. [README.md](../README.md) lesen. Hier erfährst du, worum es geht.
+2. [GET_STARTED.md](GET_STARTED.md) öffnen. Dort stehen die ersten Schritte.
+3. [manifest_4789.yaml](../manifests/manifest_4789.yaml) anschauen. Diese Datei zeigt das Grundgerüst.
+4. [structure_9874.md](../ethics_modules/structure_9874.md) nutzen. Sie hilft beim Nachdenken.
 
 ## Bitte beachte
 

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -4,10 +4,10 @@ Welcome to the 4789 Ethics Structure.
 
 ## Steps
 
-1. Read the `README.md` to understand the origin and goals.
-2. Explore `manifest_4789.yaml` for the core logic.
-3. Check `operator_levels.md` to see who should lead.
-4. Learn from `structure_9874.md` to maintain clarity.
+1. Read [README.md](../README.md) to understand the origin and goals.
+2. Explore [manifest_4789.yaml](../manifests/manifest_4789.yaml) for the core logic.
+3. Check [operator_levels.md](../operator_levels.md) to see who should lead.
+4. Learn from [structure_9874.md](../ethics_modules/structure_9874.md) to maintain clarity.
 5. Apply with intention. No mimicry. Only reflection and action.
 
 Use it. Adapt it. But never without consequence.

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Use it only if you reflect, respond, and act with consequence.
 For a brief tour of the main files, see [GET_STARTED.md](GET_STARTED.md).
 Eine Kurzanleitung in einfacher Sprache findest du in [ANLEITUNG_EINFACH_DE.md](ANLEITUNG_EINFACH_DE.md).
 
-**License:** Open-Ethics (see `LICENSE.txt`)
+**License:** Open-Ethics (see [LICENSE.txt](../LICENSE.txt))
 No manipulation. No simulation. No flattening of responsibility.
 Humor ist willkommen, wenn er Verantwortung und Klarheit unterstützt.
 See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
@@ -32,7 +32,7 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 **Purpose:** Provide a clear framework for ethical projects.
 **Audience:** Developers, educators, and curious readers.
 
-1. Read `GET_STARTED.md` for the main files.
+1. Read [GET_STARTED.md](GET_STARTED.md) for the main files.
 2. Start the interface with `npm start` (opens a browser automatically) or run
    `node tools/serve-interface.js`. For GitHub Pages deployments you can use
    `npm run serve-gh`.
@@ -523,4 +523,4 @@ node tools/check-translations.js
 ### Contributing
 [⇧](#contents)
 
-To suggest improvements or translations, read `CONTRIBUTING.md`. All changes must follow the Open-Ethics License and be made with intention.
+To suggest improvements or translations, read [CONTRIBUTING.md](../CONTRIBUTING.md). All changes must follow the Open-Ethics License and be made with intention.


### PR DESCRIPTION
## Summary
- link to key docs in GET_STARTED
- link to key docs in GET_STARTED copy under docs/
- use links in simplified German guide and docs copy
- link references in README and docs README

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68456b15f84483219b4def88f1e8e533