### PR TITLE
Update liability note

### DIFF
--- a/DISCLAIMERS.md
+++ b/DISCLAIMERS.md
@@ -2,6 +2,7 @@
 
 - Diese Struktur wird ohne Gewährleistung bereitgestellt. Fehler oder Auslassungen sind möglich.
 - Die Nutzung erfolgt auf eigene Verantwortung. Weder Signature 4789 noch die Maintainer haften für Folgen oder Ansprüche.
+- Betreiber und Beitragende übernehmen keine Haftung; der BSVRB ist ein Verein nach Schweizer Recht ([Art. 60 ff. ZGB](https://www.fedlex.admin.ch/eli/cc/24/233_245_233/de)).
 - 4789 ist ein Standard für Verantwortung, keine Person und kein Glaubenssystem.
 - Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung.
 - Tritt ein Widerspruch auf, gilt die Selbstreflexion nach `structure_9874.md`.

--- a/docs/DISCLAIMERS.md
+++ b/docs/DISCLAIMERS.md
@@ -2,6 +2,7 @@
 
 - Diese Struktur wird ohne Gewährleistung bereitgestellt. Fehler oder Auslassungen sind möglich.
 - Die Nutzung erfolgt auf eigene Verantwortung. Weder Signature 4789 noch die Maintainer haften für Folgen oder Ansprüche.
+- Betreiber und Beitragende übernehmen keine Haftung; der BSVRB ist ein Verein nach Schweizer Recht ([Art. 60 ff. ZGB](https://www.fedlex.admin.ch/eli/cc/24/233_245_233/de)).
 - 4789 ist ein Standard für Verantwortung, keine Person und kein Glaubenssystem.
 - Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung.
 - Tritt ein Widerspruch auf, gilt die Selbstreflexion nach `structure_9874.md`.

--- a/i18n/ui-text.json
+++ b/i18n/ui-text.json
@@ -79,6 +79,7 @@
     "disclaimer_items": [
       "This structure is provided without warranty.",
       "Use is at your own risk.",
+      "The operators and contributors accept no liability; BSVRB is an association under Swiss law (Swiss Civil Code art. 60 ff.: https://www.fedlex.admin.ch/eli/cc/24/233_245_233/en).",
       "4789 is a standard for responsibility, not a person or belief system.",
       "Use only with reflection and consequence; no manipulation or uncontrolled automation.",
       "If a contradiction arises, apply self-reflection (structure_9874).",
@@ -192,6 +193,7 @@
     "disclaimer_items": [
       "Diese Struktur wird ohne Gewährleistung bereitgestellt.",
       "Die Nutzung erfolgt auf eigene Verantwortung.",
+      "Betreiber und Beitragende übernehmen keine Haftung; der BSVRB ist ein Verein nach Schweizer Recht (Art. 60 ff. ZGB: https://www.fedlex.admin.ch/eli/cc/24/233_245_233/de).",
       "4789 ist ein Standard für Verantwortung, keine Person oder Ideologie.",
       "Nutzung nur reflektiert und mit Konsequenz; keine Manipulation oder unkontrollierte Automatisierung.",
       "Bei Widerspruch gilt Selbstreflexion nach structure_9874.md.",
@@ -305,6 +307,7 @@
     "disclaimer_items": [
       "Diese Struktur wird ohne Gewährleistung bereitgestellt.",
       "Die Nutzung erfolgt auf eigene Verantwortung.",
+      "Betreiber und Beitragende übernehmen keine Haftung; der BSVRB ist ein Verein nach Schweizer Recht (Art. 60 ff. ZGB: https://www.fedlex.admin.ch/eli/cc/24/233_245_233/de).",
       "4789 ist ein Standard für Verantwortung, keine Person oder Ideologie.",
       "Nutzung nur reflektiert und mit Konsequenz; keine Manipulation oder unkontrollierte Automatisierung.",
       "Bei Widerspruch gilt Selbstreflexion nach structure_9874.md.",

--- a/wiki/Disclaimers.md
+++ b/wiki/Disclaimers.md
@@ -2,6 +2,7 @@
 
 - Diese Struktur wird ohne Gewährleistung bereitgestellt. Fehler oder Auslassungen sind möglich.
 - Die Nutzung erfolgt auf eigene Verantwortung. Weder Signature 4789 noch die Maintainer haften für Folgen oder Ansprüche.
+- Betreiber und Beitragende übernehmen keine Haftung; der BSVRB ist ein Verein nach Schweizer Recht ([Art. 60 ff. ZGB](https://www.fedlex.admin.ch/eli/cc/24/233_245_233/de)).
 - 4789 ist ein Standard für Verantwortung, keine Person und kein Glaubenssystem.
 - Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung.
 - Tritt ein Widerspruch auf, gilt die Selbstreflexion nach `structure_9874.md`.


### PR DESCRIPTION
## Summary
- clarify liability note that BSVRB is a Swiss association, referencing Swiss Civil Code

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6844cb4153c08321a8a454d83ed24d95