### PR TITLE
Add text-to-speech helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ README.md -> GET_STARTED.md -> index.html
 | `sources/images/` | Pictures for institutions (`institutions/`), persons (`persons/`), and fish (`fish/`) |
 | `sources/fish/ch/` | Text placeholders for Swiss fish images (e.g., `esox_ch.png`) |
 | `test/` | Node.js test suite |
-| `tools/` | Utility scripts (e.g., trust-demotion engine, reliability monitor, correction engine, Python API example) |
+| `tools/` | Utility scripts (e.g., trust-demotion engine, reliability monitor, correction engine, Python API example, `text_to_speech.py`) |
 | `use_cases/` | Example scenarios and dissemination ideas |
 | `sources/images/op-logo/` | Stages of the Tanna symbol |
 | `wings/` | Minimal mobile interface |

--- a/docs/improvements.md
+++ b/docs/improvements.md
@@ -22,7 +22,7 @@ Diese Liste enthält konkrete Vorschläge zur Verbesserung der Benutzerfreundlic
 ## 4. Barrierefreiheit (Accessibility)
 - [ ] Texte screenreaderfreundlich gestalten.
 - [ ] Kontrastreiche Farben im Terminal, optional deaktivierbar.
-- [ ] Text-to-Speech-Ausgabe (pyttsx3/edge-tts) als Option.
+- [x] Text-to-Speech-Ausgabe (pyttsx3/edge-tts) als Option.
 - [ ] Vollständige Bedienung per Tastatur sicherstellen.
 - [ ] Langsam-Modus: aktivierbare Pausen und ausführlichere Erklärungen.
 

--- a/improvements.md
+++ b/improvements.md
@@ -22,7 +22,7 @@ Diese Liste enthält konkrete Vorschläge zur Verbesserung der Benutzerfreundlic
 ## 4. Barrierefreiheit (Accessibility)
 - [ ] Texte screenreaderfreundlich gestalten.
 - [ ] Kontrastreiche Farben im Terminal, optional deaktivierbar.
-- [ ] Text-to-Speech-Ausgabe (pyttsx3/edge-tts) als Option.
+- [x] Text-to-Speech-Ausgabe (pyttsx3/edge-tts) als Option.
 - [ ] Vollständige Bedienung per Tastatur sicherstellen.
 - [ ] Langsam-Modus: aktivierbare Pausen und ausführlichere Erklärungen.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2
+pyttsx3>=2

--- a/tools/text_to_speech.py
+++ b/tools/text_to_speech.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Simple text-to-speech helper for 4789ethics."""
+import sys
+
+try:
+    import pyttsx3
+except ImportError:  # pragma: no cover - optional dependency
+    print("pyttsx3 not installed. Please install it with 'pip install pyttsx3'.")
+    sys.exit(1)
+
+engine = pyttsx3.init()
+text = " ".join(sys.argv[1:]).strip()
+if not text:
+    print("Usage: text_to_speech.py <text>")
+    sys.exit(1)
+
+engine.say(text)
+engine.runAndWait()


### PR DESCRIPTION
## Summary
- add `tools/text_to_speech.py` to provide a simple pyttsx3-based text-to-speech option
- mention the helper in the README tools table
- mark the TTS improvement as complete
- list `pyttsx3` in `requirements.txt`

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6846173cc660832183181a4569a450cd