### PR TITLE
Enable collisions by default

### DIFF
--- a/interface/bundle.js
+++ b/interface/bundle.js
@@ -2172,6 +2172,7 @@ window.addEventListener('DOMContentLoaded', initLogin);
 function initLogoBackground() {
   const container = document.getElementById('op_background');
   if (!container) return;
+  localStorage.setItem('ethicom_bg_collisions', 'true');
 
   let RESTITUTION = 1;
   const storedRest = parseFloat(localStorage.getItem('ethicom_bg_restitution'));
@@ -2314,8 +2315,7 @@ function initLogoBackground() {
   const avgArea = avgSize * avgSize;
   const maxSymbols = Math.floor(canvas.width * canvas.height / avgArea);
   const total = Math.max(20, Math.floor(maxSymbols * fillRatio));
-  const collisionsEnabled =
-    localStorage.getItem('ethicom_bg_collisions') !== 'false';
+  const collisionsEnabled = true;
   for (let i = 0; i < total; i++) {
     const lvl = levels[i % levels.length];
     const img = images[lvl >= 8 ? 7 : lvl];

--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -1,7 +1,7 @@
 function initLogoBackground() {
   const container = document.getElementById('op_background');
   if (!container) return;
-
+  localStorage.setItem('ethicom_bg_collisions', 'true');
 
   let RESTITUTION = 1;
   const storedRest = parseFloat(localStorage.getItem('ethicom_bg_restitution'));
@@ -144,8 +144,7 @@ function initLogoBackground() {
   const avgArea = avgSize * avgSize;
   const maxSymbols = Math.floor(canvas.width * canvas.height / avgArea);
   const total = Math.max(20, Math.floor(maxSymbols * fillRatio));
-  const collisionsEnabled =
-    localStorage.getItem('ethicom_bg_collisions') !== 'false';
+  const collisionsEnabled = true;
   for (let i = 0; i < total; i++) {
     const lvl = levels[i % levels.length];
     const img = images[lvl >= 8 ? 7 : lvl];

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -72,10 +72,6 @@
           <input type="range" id="bg_same_level_count" min="1" max="10" step="1" value="1" />
             <small class="note">Reload to apply.</small>
         </div>
-        <div id="bg_collisions_wrap">
-          <label><input type="checkbox" id="bg_collisions"/> Enable collisions</label>
-          <small class="note">Reload to apply.</small>
-        </div>
         <div id="bg_low_motion_wrap">
           <label><input type="checkbox" id="bg_low_motion"/> Low motion background</label>
           <small class="note">Reload to apply.</small>
@@ -284,30 +280,12 @@
             alert('Reload the page to apply.');
           });
         }
-
-        const collChk = document.getElementById('bg_collisions');
-        if (collChk) {
-          let collValue = localStorage.getItem('ethicom_bg_collisions');
-          if (collValue === null) {
-            collValue = 'true';
-            localStorage.setItem('ethicom_bg_collisions', 'true');
-          }
-          collChk.checked = collValue !== 'false';
-          collChk.addEventListener('change', e => {
-            localStorage.setItem('ethicom_bg_collisions', e.target.checked ? 'true' : 'false');
-          });
-        }
-
-
         const lowMotionChk = document.getElementById('bg_low_motion');
         if (lowMotionChk) {
           lowMotionChk.checked = localStorage.getItem('ethicom_bg_low_motion') === 'true';
           lowMotionChk.addEventListener('change', e => {
             localStorage.setItem('ethicom_bg_low_motion', e.target.checked ? 'true' : 'false');
           });
-        }
-
-
       const fgSlider = document.getElementById('fg_opacity');
       const fgVal = document.getElementById('fg_opacity_val');
       if (fgSlider && fgVal) {


### PR DESCRIPTION
## Summary
- remove checkbox for background collisions from settings
- always set `ethicom_bg_collisions` to true on page load
- keep collisions logic permanently enabled

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_684618eb6a48832193db7f525ef05da8