### PR TITLE
Add Flutter launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,17 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 **Audience:** Developers, educators, and curious readers.
 
 1. Read [GET_STARTED.md](GET_STARTED.md) for the main files.
-2. Start the interface with `npm start` (opens a browser automatically) or run
-   `node tools/serve-interface.js`. For GitHub Pages deployments you can use
+2. Start the interface with `npm start` or use
+   `npm run easy-start` to install dependencies automatically. You can also run
+   `node tools/serve-interface.js`. If you only have the website, download
+   [`tools/easy-start.js`](https://www.bsvrb.ch/tools/easy-start.js) and run it
+   with Node. For GitHub Pages deployments you can use
    `npm run serve-gh`.
    Opening an HTML file directly (via `file://`) disables translations and
    settings. See [Local Deployment](#local-deployment) for details.
-3. The interface opens at `http://localhost:8080/index.html`.
+3. Optionally compile the Flutter launcher in `launcher/` to start the server
+   without the terminal (`flutter run launcher`).
+4. The interface opens at `http://localhost:8080/index.html`.
 
 ```
 README.md -> GET_STARTED.md -> index.html

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,12 +35,17 @@ See [DISCLAIMERS.md](../DISCLAIMERS.md) for warranty and liability notes.
 **Audience:** Developers, educators, and curious readers.
 
 1. Read [GET_STARTED.md](../GET_STARTED.md) for the main files.
-2. Start the interface with `npm start` (opens a browser automatically) or run
-   `node tools/serve-interface.js`. For GitHub Pages deployments you can use
+2. Start the interface with `npm start` or use
+   `npm run easy-start` to install dependencies automatically. You can also run
+   `node tools/serve-interface.js`. If you only have the website, download
+   [`tools/easy-start.js`](https://www.bsvrb.ch/tools/easy-start.js) and run it
+   with Node. For GitHub Pages deployments you can use
    `npm run serve-gh`.
    Opening an HTML file directly (via `file://`) disables translations and
    settings. See [Local Deployment](#local-deployment) for details.
-3. The interface opens at `http://localhost:8080/index.html`.
+3. Optionally compile the Flutter launcher in `launcher/` to start the server
+   without the terminal (`flutter run launcher`).
+4. The interface opens at `http://localhost:8080/index.html`.
 
 ```
 README.md -> GET_STARTED.md -> index.html

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -128,6 +128,7 @@
       <summary>Repository</summary>
       <div id="repo_download">
         <a href="/download.zip" class="accent-button">Download .zip</a>
+        <a href="/tools/easy-start.js" class="accent-button">easy-start.js</a>
       </div>
     </details>
     <details class="card">

--- a/launcher/README.md
+++ b/launcher/README.md
@@ -1,0 +1,5 @@
+# BSVRB Launcher
+
+This Flutter app starts `tools/start-server.js` and opens the interface.
+Node.js must be installed locally. Run `flutter run` inside this directory to
+launch the app.

--- a/launcher/main.dart
+++ b/launcher/main.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:path/path.dart' as p;
+import 'package:url_launcher/url_launcher.dart';
+
+void main() => runApp(const LauncherApp());
+
+class LauncherApp extends StatelessWidget {
+  const LauncherApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('BSVRB Launcher')),
+        body: const LauncherBody(),
+      ),
+    );
+  }
+}
+
+class LauncherBody extends StatefulWidget {
+  const LauncherBody({super.key});
+
+  @override
+  State<LauncherBody> createState() => _LauncherBodyState();
+}
+
+class _LauncherBodyState extends State<LauncherBody> {
+  String _status = '';
+  Process? _server;
+
+  static const disclaimers = [
+    'Diese Struktur wird ohne Gew\u00e4hrleistung bereitgestellt.',
+    'Die Nutzung erfolgt auf eigene Verantwortung.',
+    '4789 ist ein Standard f\u00fcr Verantwortung, keine Person und kein Glaubenssystem.',
+    'Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung.'
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _status = disclaimers.join('\n');
+  }
+
+  Future<void> _start() async {
+    if (_server != null) return;
+    final script = p.join('tools', 'start-server.js');
+    try {
+      _server = await Process.start('node', [script]);
+      unawaited(launchUrl(Uri.parse('http://localhost:8080/index.html')));
+      setState(() => _status = 'Server gestartet.');
+    } catch (e) {
+      setState(() => _status = 'Fehler: $e');
+    }
+  }
+
+  @override
+  void dispose() {
+    _server?.kill();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(child: SingleChildScrollView(child: Text(_status))),
+          ElevatedButton(onPressed: _start, child: const Text('Interface starten')),
+        ],
+      ),
+    );
+  }
+}
+
+void unawaited(Future<void> future) {}

--- a/launcher/pubspec.yaml
+++ b/launcher/pubspec.yaml
@@ -1,0 +1,11 @@
+name: bsvrb_launcher
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  url_launcher: ^6.1.8
+
+flutter:
+  uses-material-design: true

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "verify": "node tools/check-file-integrity.js",
     "start": "node tools/start-server.js",
+    "easy-start": "node tools/easy-start.js",
     "serve-gh": "BASE_URL=https://4789-alpha.github.io node tools/serve-interface.js",
     "bundle-interface": "node tools/bundle-interface.js",
     "generate-wiki": "node tools/generate-wiki.js"

--- a/tools/easy-start.js
+++ b/tools/easy-start.js
@@ -1,0 +1,38 @@
+const { spawn } = require('child_process');
+const path = require('path');
+const readline = require('readline');
+
+const disclaimers = [
+  'Diese Struktur wird ohne Gew\u00e4hrleistung bereitgestellt.',
+  'Die Nutzung erfolgt auf eigene Verantwortung.',
+  '4789 ist ein Standard f\u00fcr Verantwortung, keine Person und kein Glaubenssystem.',
+  'Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung.'
+];
+
+disclaimers.forEach(l => console.log(l));
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+rl.question('Fortfahren? (yes/no) ', answer => {
+  rl.close();
+  if (answer.trim() !== 'yes') {
+    console.log('Abbruch.');
+    process.exit(1);
+  }
+
+  const major = parseInt(process.versions.node.split('.')[0], 10);
+  if (major < 18) {
+    console.error('Node.js 18+ wird ben\u00f6tigt.');
+    process.exit(1);
+  }
+
+  const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const install = spawn(npmCmd, ['install'], { stdio: 'inherit' });
+
+  install.on('exit', code => {
+    if (code !== 0) {
+      process.exit(code);
+    }
+
+    const server = spawn('node', [path.join(__dirname, 'start-server.js')], { stdio: 'inherit' });
+    server.on('exit', code => process.exit(code));
+  });
+});


### PR DESCRIPTION
## Summary
- add `launcher/` with minimal Flutter app to run the server
- document Flutter launcher in README and docs

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_684619ebfca0832183805d0cbabe2c1f