### PR TITLE
Offline fallback for OP-0

### DIFF
--- a/interface/language-selector.js
+++ b/interface/language-selector.js
@@ -1,5 +1,122 @@
 // language-selector.js – 4789: bewusste Sprachwahl ohne Priorisierung
 
+// Minimal English texts for offline OP-0 use
+const offlineUiText = {
+  "en": {
+    "title": "Ethicom: Human Evaluation",
+    "label_source": "Source (URL or Title)",
+    "label_srclvl": "Ethical Level (SRC)",
+    "label_aspects": "Optional Aspects",
+    "label_comment": "Comment",
+    "btn_generate": "Show My Evaluation",
+    "btn_download": "Download as File",
+    "aspects": [
+      "Transparency",
+      "Repairability",
+      "System Reflection",
+      "Error Handling",
+      "Purpose Clarity"
+    ],
+    "signup_title": "Sign up",
+    "signup_email": "Email:",
+    "signup_password": "Password:",
+    "signup_btn": "Create Account",
+    "signup_placeholder_email": "name@provider.com",
+    "signup_placeholder_pw": "At least 8 characters",
+    "signup_address": "Address:",
+    "signup_phone": "Phone:",
+    "signup_nick": "Nickname:",
+    "signup_placeholder_nick": "Optional nickname",
+    "signup_alias": "Alias (public): {alias}",
+    "signup_placeholder_address": "Optional address",
+    "signup_placeholder_phone": "+12025550123",
+    "signup_country": "Country/Region:",
+    "signup_placeholder_country": "US",
+    "signup_invalid_email": "Invalid email format.",
+    "signup_unsupported": "Email provider not supported. Use a secure host.",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5.",
+    "signup_pw_short": "Password must be at least 8 characters.",
+    "signup_saved": "Signup complete. ID stored.",
+    "signup_secret": "Authenticator secret: {secret}",
+    "help_title": "Help – Operator Conduct",
+    "help_items": [
+      "Always check if your actions meet the ethics of responsibility.",
+      "Use only the tools assigned to your OP level.",
+      "Document decisions in the manifest for verification.",
+      "Nominations and feedback are structured and without personal pressure.",
+      "Consult a higher structure (from OP-7) if unsure.",
+      "Responsibility outweighs convenience.",
+      "Create signatures locally and confirm them structurally.",
+      "Withdrawals or corrections are part of the process, not weakness.",
+      "Maintain transparency at every step, even with anonymous use."
+    ],
+    "access_title": "Accessibility Setup",
+    "access_label_vision": "Can you see the screen?",
+    "access_label_hearing": "Can you hear from this device?",
+    "access_label_speech": "Can you speak?",
+    "access_label_simple": "Simplified interface?",
+    "access_opt_yes": "Yes",
+    "access_save_btn": "Save Setup",
+    "access_opt_no": "No",
+    "access_opt_yes_nospeech": "Yes, but cannot speak",
+    "access_saved": "Accessibility preferences saved.",
+    "nav_start": "Start",
+    "nav_ratings": "Ratings",
+    "nav_signup": "Signup",
+    "nav_readme": "README",
+    "nav_tools": "Tools",
+    "nav_settings": "Settings",
+    "label_choose_language": "Choose your language (ISO 639-1):",
+    "status_verifying_sig": "Verifying signature...",
+    "status_sig_missing": "Signature not found or incomplete.",
+    "status_sig_invalid": "Signature invalid or password incorrect.",
+    "status_sig_valid": "Signature valid: {level}",
+    "status_loading_op0": "Loading OP-0...",
+    "rating_yes": "Yes",
+    "rating_partial": "Partly",
+    "rating_no": "No",
+    "simple_toggle_label": "Toggle Simple Mode",
+    "simple_mode_on": "Simple mode is active.",
+    "simple_mode_off": "Simple mode is off.",
+    "disclaimer_title": "Disclaimers",
+    "disclaimer_items": [
+      "This structure is provided without warranty.",
+      "Use is at your own risk.",
+      "The operators and contributors accept no liability; BSVRB is an association under Swiss law (Swiss Civil Code art. 60 ff.: https://www.fedlex.admin.ch/eli/cc/24/233_245_233/en).",
+      "4789 is a standard for responsibility, not a person or belief system.",
+      "Use only with reflection and consequence; no manipulation or uncontrolled automation.",
+      "If a contradiction arises, apply self-reflection (structure_9874).",
+      "Humor is allowed if responsibility and clarity remain.",
+      "Each user’s TOTP secret is stored as plain text."
+    ],
+    "btn_disclaimer_accept": "I understand",
+    "attention_toggle_wiggle": "Wiggle when idle",
+    "attention_toggle_beep": "Beep when idle",
+    "side_close": "Close",
+    "side_menu_need_op6": "OP-6 required.",
+    "rating_saved": "Rating saved.",
+    "login_title": "Login",
+    "login_email": "Email:",
+    "login_password": "Password:",
+    "login_time_hint": "Current time: {time}",
+    "login_auth": "Authenticator code:",
+    "login_btn": "Log in",
+    "login_github": "Login with GitHub",
+    "login_google": "Login with Google",
+    "login_invalid": "Login failed.",
+    "login_saved": "Login successful. ID stored.",
+    "connect_title": "Connect",
+    "connect_request": "Request connection",
+    "connect_enter_sig": "Target signature:",
+    "connect_pending": "Pending requests",
+    "connect_connections": "Your connections",
+    "connect_approve": "Approve",
+    "connect_request_sent": "Request sent.",
+    "connect_error": "Request failed.",
+    "nav_navigator": "Navigator Menu",
+    "nav_story": "Story"
+  }
+};
 
 function askLanguageChoice() {
   const lang = prompt(
@@ -125,17 +242,32 @@ function initLanguageDropdown(selectId = "lang_select", textPath = getUiTextPath
       });
     })
     .catch(() => {
-      displayLangNotice(
-        'Start the interface with `node tools/serve-interface.js`. Then open `http://localhost:8080/ethicom.html` in your browser. Opening the HTML file directly (e.g. via `file://`) bypasses the local server and causes the language list to remain empty. Always access the interface through the provided `localhost` address so that translation files load correctly.'
-      );
-      const select = document.getElementById(selectId);
-      if (select) {
-        select.innerHTML = '<option value="en">en</option>';
-        select.value = 'en';
+      const texts = typeof offlineUiText !== 'undefined' ? offlineUiText : null;
+      if (texts) {
+        const select = document.getElementById(selectId);
+        if (select) {
+          select.innerHTML = Object.keys(texts)
+            .sort()
+            .map(c => `<option value="${c}">${c}</option>`)
+            .join('');
+          select.value = 'en';
+        }
+        localStorage.setItem('ethicom_lang', 'en');
+        if (typeof applyTexts === 'function') applyTexts(texts.en || {});
+        if (typeof updateReadmeLinks === 'function') updateReadmeLinks('en');
+      } else {
+        displayLangNotice(
+          'Start the interface with `node tools/serve-interface.js`. Then open `http://localhost:8080/ethicom.html` in your browser. Opening the HTML file directly (e.g. via `file://`) bypasses the local server and causes the language list to remain empty. Always access the interface through the provided `localhost` address so that translation files load correctly.'
+        );
+        const select = document.getElementById(selectId);
+        if (select) {
+          select.innerHTML = '<option value="en">en</option>';
+          select.value = 'en';
+        }
+        localStorage.setItem('ethicom_lang', 'en');
+        if (typeof applyTexts === 'function') applyTexts({});
+        if (typeof updateReadmeLinks === 'function') updateReadmeLinks('en');
       }
-      localStorage.setItem('ethicom_lang', 'en');
-      if (typeof applyTexts === 'function') applyTexts({});
-      if (typeof updateReadmeLinks === 'function') updateReadmeLinks('en');
     });
 }
 


### PR DESCRIPTION
## Summary
- support offline use by embedding minimal English UI text
- use offline data when translation fetch fails

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_684625bcd84c832184e944e043a38ee6