### PR TITLE
Add Aarulon chat entry and themed collisions

### DIFF
--- a/bsvrb.ch/aari.html
+++ b/bsvrb.ch/aari.html
@@ -2,10 +2,37 @@
 <html lang="de">
 <head>
   <meta charset="UTF-8">
-  <title>Aarulon</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Aarulon.L</title>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <link rel="stylesheet" href="aari/styles/aari.css">
+  <style>
+    :root {
+      --collision-color: #39ff14;
+      --bg-color: #000;
+    }
+    @media (prefers-color-scheme: light) {
+      :root {
+        --collision-color: #b000b0;
+        --bg-color: #fff;
+      }
+    }
+    body {
+      margin: 0;
+      background: var(--bg-color);
+      font-family: system-ui, sans-serif;
+    }
+    #chat-container { padding: 1em; }
+  </style>
 </head>
 <body>
-  <h1>Aarulon Einstiegspunkt</h1>
+  <div id="op_background"></div>
+  <div id="chat-container">
+    <div id="chat-output"></div>
+    <input id="chat-input" placeholder="Schreibe Aarulon.L" />
+    <button id="chat-send">Senden</button>
+  </div>
+  <script src="../interface/bundle.js" defer></script>
   <script src="aari/chat.js"></script>
   <script src="aari/scan.js"></script>
   <script src="aari/upload.js"></script>

--- a/bsvrb.ch/index.html
+++ b/bsvrb.ch/index.html
@@ -2,10 +2,16 @@
 <html lang="de">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>bsvrb.ch</title>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <style>
+    body { text-align: center; padding-top: 2em; }
+    #chat_entry { font-size: 2em; margin: 1em 0; display: inline-block; }
+  </style>
 </head>
 <body>
-  <h1>Willkommen bei bsvrb.ch</h1>
-  <!-- TODO: Inhalt einfügen -->
+  <a id="chat_entry" href="aari.html">Aarulon.L</a>
+  <p>Chatbot im Aufbau – experimentelle Version.</p>
 </body>
 </html>

--- a/interface/bundle.js
+++ b/interface/bundle.js
@@ -2293,7 +2293,8 @@ function initLogoBackground() {
   const minScale = 0.5;
   const FADE_MS = 1000;
   const imgBase = window.location.pathname.includes('/interface/') ||
-                  window.location.pathname.includes('/wings/')
+                  window.location.pathname.includes('/wings/') ||
+                  window.location.pathname.includes('/bsvrb.ch/')
                     ? '../sources/images/op-logo/'
                     : 'sources/images/op-logo/';
   const images = levels.map(lvl => {

--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -122,7 +122,8 @@ function initLogoBackground() {
   const minScale = 0.5;
   const FADE_MS = 1000;
   const imgBase = window.location.pathname.includes('/interface/') ||
-                  window.location.pathname.includes('/wings/')
+                  window.location.pathname.includes('/wings/') ||
+                  window.location.pathname.includes('/bsvrb.ch/')
                     ? '../sources/images/op-logo/'
                     : 'sources/images/op-logo/';
   const images = levels.map(lvl => {


### PR DESCRIPTION
## Summary
- show big link to Aarulon chat on `bsvrb.ch/index.html`
- theme `bsvrb.ch/aari.html` with visible Tanna collision animation
- fix logo path detection for `bsvrb.ch` pages

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68478b04aeec832191e21ddc0252aedc