### PR TITLE
Add visible OP status badge

### DIFF
--- a/interface/css/nav.css
+++ b/interface/css/nav.css
@@ -49,14 +49,19 @@ header .op-status-link {
   position: absolute;
   top: 0;
   left: 0;
-  right: auto;
+  display: flex;
+  align-items: center;
   line-height: 1;
-  display: block;
   height: 100%;
+  padding-left: 0.4em;
 }
 
 header .op-status-link img {
   display: none;
+}
+
+header .op-status-link .badge {
+  margin: 0;
 }
 
 header .title-logo {

--- a/interface/module-logo.js
+++ b/interface/module-logo.js
@@ -40,6 +40,11 @@ function insertModuleLogo() {
   link.setAttribute('aria-label', 'OP Status');
   link.style.width = `calc(${size} * 1.5 + 1em)`;
   link.style.height = '100%';
+
+  const badge = document.createElement('span');
+  badge.className = `badge op-${level.replace('OP-', '').replace('.', '')}`;
+  badge.textContent = level;
+  link.appendChild(badge);
   header.appendChild(link);
 
   if (!h1) return;


### PR DESCRIPTION
## Summary
- display current OP level next to header title
- style status link to show badge

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68478f839a748321949af9e4438e0b1f