### PR TITLE
Add zoomable Swiss waters map

### DIFF
--- a/interface/fish-interface/README.md
+++ b/interface/fish-interface/README.md
@@ -27,6 +27,10 @@ The page `fischeSchweiz.html` renders the national list for convenient browsing.
 The page `gewaesserBern.html` shows a simplified map of the canton Bern with
 lakes and the river Aare based on `sources/maps/bern-waters.json`.
 
+The page `gewaesserCH.html` displays a zoomable Leaflet map with
+regal and pacht waters for all Swiss cantons using
+`sources/maps/swiss-waters.json`.
+
 The goal is to promote respectful and transparent handling of fish populations
 worldwide. Contributions should follow the 4789 principles and the
 Open-Ethics License.

--- a/interface/fish-interface/gewaesserCH.html
+++ b/interface/fish-interface/gewaesserCH.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Gewässer Schweiz</title>
+  <link rel="stylesheet" href="../ethicom-style.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
+  <script src="../../utils/op-level.js"></script>
+  <script src="../ethicom-utils.js"></script>
+  <script src="../color-utils.js"></script>
+  <script src="../accessibility.js"></script>
+  <script src="../auto-outline.js"></script>
+  <script src="../theme-manager.js"></script>
+  <script src="../logo-background.js"></script>
+  <script src="../side-drop.js"></script>
+  <script src="../op-side-nav.js"></script>
+  <script src="gewaesserCH.js"></script>
+  <script src="../module-logo.js"></script>
+  <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main_content">Skip to main content</a>
+  <div id="op_background"></div>
+  <header>
+    <h1>Gewässer Schweiz</h1>
+    <nav>
+      <a href="../../index.html">Home</a>
+      <a href="../../bewertung.html">Bewertung</a>
+      <a href="../settings.html" class="icon-only">⚙</a>
+      <a href="../login.html">Login</a>
+      <a href="../wings/ratings.html">Ratings</a>
+      <a href="../signup.html">Signup</a>
+      <a href="../../README.html" class="readme-link">README</a>
+    </nav>
+  </header>
+  <main id="main_content">
+    <div id="ch_map" style="height:400px;width:100%;"></div>
+  </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      initSideDrop('../op-navigation.html');
+      const menu = document.getElementById('side_menu');
+      if (menu) menu.addEventListener('click', e => { e.preventDefault(); toggleSideDrop(); });
+    });
+  </script>
+  <div id="side_drop"></div>
+</body>
+</html>

--- a/interface/fish-interface/gewaesserCH.js
+++ b/interface/fish-interface/gewaesserCH.js
@@ -1,0 +1,28 @@
+async function initGewaesserCH() {
+  const mapElem = document.getElementById('ch_map');
+  if (!mapElem) return;
+
+  const map = L.map(mapElem).setView([46.8, 8.2], 8);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 18,
+    attribution: '© OpenStreetMap contributors'
+  }).addTo(map);
+
+  try {
+    const data = await fetch('../../sources/maps/swiss-waters.json').then(r => r.json());
+    const colors = { regal: '#4da6ff', pacht: '#ff9900', frei: '#66cc66' };
+    (data.cantons || []).forEach(c => {
+      const marker = L.circleMarker([c.lat, c.lng], {
+        radius: 8,
+        color: colors[c.type] || '#666',
+        fillColor: colors[c.type] || '#666',
+        fillOpacity: 0.8
+      }).addTo(map);
+      marker.bindPopup(`${c.name} (${c.type})`);
+    });
+  } catch (e) {
+    mapElem.textContent = 'Karte konnte nicht geladen werden.';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', initGewaesserCH);

--- a/sources/maps/swiss-waters.json
+++ b/sources/maps/swiss-waters.json
@@ -1,0 +1,30 @@
+{
+  "cantons": [
+    {"abbr":"ZH","name":"Zürich","type":"regal","lat":47.38,"lng":8.54},
+    {"abbr":"BE","name":"Bern","type":"pacht","lat":46.95,"lng":7.45},
+    {"abbr":"LU","name":"Luzern","type":"pacht","lat":47.05,"lng":8.30},
+    {"abbr":"UR","name":"Uri","type":"regal","lat":46.88,"lng":8.65},
+    {"abbr":"SZ","name":"Schwyz","type":"pacht","lat":47.02,"lng":8.65},
+    {"abbr":"OW","name":"Obwalden","type":"pacht","lat":46.87,"lng":8.28},
+    {"abbr":"NW","name":"Nidwalden","type":"regal","lat":46.95,"lng":8.38},
+    {"abbr":"GL","name":"Glarus","type":"pacht","lat":46.98,"lng":9.05},
+    {"abbr":"ZG","name":"Zug","type":"pacht","lat":47.17,"lng":8.52},
+    {"abbr":"FR","name":"Fribourg","type":"regal","lat":46.80,"lng":7.15},
+    {"abbr":"SO","name":"Solothurn","type":"pacht","lat":47.21,"lng":7.53},
+    {"abbr":"BS","name":"Basel-Stadt","type":"regal","lat":47.56,"lng":7.59},
+    {"abbr":"BL","name":"Basel-Landschaft","type":"pacht","lat":47.46,"lng":7.62},
+    {"abbr":"SH","name":"Schaffhausen","type":"regal","lat":47.70,"lng":8.62},
+    {"abbr":"AR","name":"Appenzell Ausserrhoden","type":"pacht","lat":47.37,"lng":9.30},
+    {"abbr":"AI","name":"Appenzell Innerrhoden","type":"pacht","lat":47.33,"lng":9.42},
+    {"abbr":"SG","name":"St. Gallen","type":"regal","lat":47.23,"lng":9.37},
+    {"abbr":"GR","name":"Graubünden","type":"regal","lat":46.77,"lng":9.53},
+    {"abbr":"TG","name":"Thurgau","type":"pacht","lat":47.57,"lng":8.90},
+    {"abbr":"AG","name":"Aargau","type":"regal","lat":47.39,"lng":8.05},
+    {"abbr":"TI","name":"Ticino","type":"pacht","lat":46.20,"lng":8.80},
+    {"abbr":"VD","name":"Vaud","type":"regal","lat":46.62,"lng":6.65},
+    {"abbr":"VS","name":"Valais","type":"regal","lat":46.23,"lng":7.35},
+    {"abbr":"NE","name":"Neuchâtel","type":"regal","lat":46.99,"lng":6.93},
+    {"abbr":"GE","name":"Genève","type":"regal","lat":46.20,"lng":6.14},
+    {"abbr":"JU","name":"Jura","type":"pacht","lat":47.36,"lng":7.24}
+  ]
+}

--- a/verax/map/leaflet.html
+++ b/verax/map/leaflet.html
@@ -24,6 +24,7 @@
   <div id="map"></div>
   <script>
     const map = L.map('map').setView([46.8345, 7.4953], 14);
+    L.control.zoom({ position: 'topright' }).addTo(map);
 
     // Tile-Layer (OSM international)
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {


### PR DESCRIPTION
## Summary
- mention new CH map in fish README
- add zoom control in Verax leaflet map
- include new Leaflet page showing regal and pacht waters for all cantons
- add JSON data for Swiss water categories

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6847918c16b4832180c775f9b44fdc36