### PR TITLE
Add UTF-8 meta tags and cleanup CSS

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -173,7 +173,7 @@ body {
   margin: 0;
   padding: 0;
   font-family: system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
-  overflow-x: hidden;7
+  overflow-x: hidden;
   display: flex;
   flex-direction: column;
   min-height: 100vh;

--- a/interface/nav-menu.html
+++ b/interface/nav-menu.html
@@ -1,3 +1,4 @@
+<meta charset="UTF-8">
 <div class="card">
   <h3>Main Navigation</h3>
   <ul class="nav-menu">

--- a/interface/op-navigation.html
+++ b/interface/op-navigation.html
@@ -1,3 +1,4 @@
+<meta charset="UTF-8">
 <div class="card">
   <a href="op-story.html" data-ui="nav_story">OP Story</a>
   <ul id="op_side_nav" class="op-side-nav"></ul>

--- a/interface_OLD/op-navigation.html
+++ b/interface_OLD/op-navigation.html
@@ -1,3 +1,4 @@
+<meta charset="UTF-8">
 <div class="card">
   <ul id="op_side_nav" class="op-side-nav"></ul>
 </div>


### PR DESCRIPTION
## Summary
- ensure nav menu fragments specify UTF-8
- fix stray character in ethicom CSS

## Testing
- `npx --yes node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68481d5e0fb88321abbe73cef9624d2b