### PR TITLE
Ensure Tanna-Dark for OP-0 users

### DIFF
--- a/interface/theme-manager.js
+++ b/interface/theme-manager.js
@@ -56,6 +56,9 @@ function initThemeSelection() {
   const labels = ['Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Accessible','Custom'];
 
   let theme = localStorage.getItem('ethicom_theme') || 'tanna-dark';
+  if (getOpLevel() === 0) {
+    theme = 'tanna-dark';
+  }
   applyTheme(theme);
   if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
   if (select) {
@@ -102,6 +105,18 @@ function initThemeSelection() {
     if (select) select.disabled = level < 3;
     if (slider) slider.disabled = level < 3;
     if (customBtn) customBtn.style.display = level >= 4 ? 'block' : 'none';
+    if (level === 0) {
+      theme = 'tanna-dark';
+      applyTheme(theme);
+      resetSlidersFromTheme();
+      if (select) select.value = theme;
+      if (slider) {
+        const idx = themes.indexOf(theme);
+        slider.value = idx >= 0 ? idx : 0;
+        if (label) label.textContent = labels[slider.value];
+      }
+      if (tannaCard) tannaCard.style.display = 'none';
+    }
   }
 
   updateAccess();


### PR DESCRIPTION
## Summary
- force `tanna-dark` when OP level is `OP-0`
- update access routine to enforce theme on level change

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_6847a170d1d48321bd3a30ccae6e62c0