### PR TITLE
Update signup workflow docs and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ README.md -> GET_STARTED.md -> index.html
 | [interface/settings.html](interface/settings.html) | Language, theme, Tanna logo, and low motion settings |
 | [interface/signup.html](interface/signup.html) | Registration form |
 | [interface/offline-signup.html](interface/offline-signup.html) | Offline local signup |
+
+Signup requires the local server started via `node tools/serve-interface.js`.
 | [interface_OLD/tanna-template.html](interface_OLD/tanna-template.html) | Legacy base template |
 | [interface_OLD/tanna-template-dark.html](interface_OLD/tanna-template-dark.html) | Legacy dark template |
 | [interface_OLD/tanna-template-light.html](interface_OLD/tanna-template-light.html) | Legacy light template |

--- a/docs/README.md
+++ b/docs/README.md
@@ -129,6 +129,8 @@ README.md -> GET_STARTED.md -> index.html
 | [docs/tanna-collisions.md](docs/tanna-collisions.md) | How to enable Tanna background collisions |
 | [interface/signup.html](interface/signup.html) | Registration form |
 | [interface/offline-signup.html](interface/offline-signup.html) | Offline local signup |
+
+Signup requires the local server started via `node tools/serve-interface.js`.
 | [interface_OLD/tanna-template.html](interface_OLD/tanna-template.html) | Legacy base template |
 | [interface_OLD/tanna-template-dark.html](interface_OLD/tanna-template-dark.html) | Legacy dark template |
 | [interface_OLD/tanna-template-light.html](interface_OLD/tanna-template-light.html) | Legacy light template |

--- a/i18n/ui-text.json
+++ b/i18n/ui-text.json
@@ -111,7 +111,8 @@
     "connect_request_sent": "Request sent.",
     "connect_error": "Request failed.",
     "nav_navigator": "Navigator Menu",
-    "nav_story": "Story"
+    "nav_story": "Story",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "de": {
     "title": "Ethicom: Bewertung durch Menschen",
@@ -225,7 +226,8 @@
     "connect_request_sent": "Anfrage gesendet.",
     "connect_error": "Anfrage fehlgeschlagen. Bitte Verbindung prüfen.",
     "nav_navigator": "Navigator",
-    "nav_story": "Geschichte"
+    "nav_story": "Geschichte",
+    "signup_server_notice": "Nur mit lokalem Server nutzbar. Offline-signup.html verwenden, falls nötig."
   },
   "de-ch": {
     "title": "Ethicom: Bewertung durch Menschen",
@@ -339,7 +341,8 @@
     "connect_request_sent": "Anfrage gesendet.",
     "connect_error": "Anfrage fehlgeschlagen. Bitte Verbindung prüfen.",
     "nav_navigator": "Navigator",
-    "nav_story": "Geschichte"
+    "nav_story": "Geschichte",
+    "signup_server_notice": "Nur mit lokalem Server nutzbar. Offline-signup.html verwenden, falls nötig."
   },
   "fr": {
     "title": "Ethicom : Évaluation humaine",
@@ -453,7 +456,8 @@
     "connect_request_sent": "Request sent.",
     "connect_error": "Request failed.",
     "nav_story": "Story",
-    "nav_navigator": "Navigator Menu"
+    "nav_navigator": "Navigator Menu",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "es": {
     "title": "Ethicom: Evaluación Humana",
@@ -567,7 +571,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "pt": {
     "title": "Ethicom: Avaliação Humana",
@@ -680,7 +685,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "zh": {
     "title": "Ethicom：人工评估",
@@ -794,7 +800,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "hi": {
     "title": "Ethicom: मानवीय मूल्यांकन",
@@ -907,7 +914,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "ar": {
     "title": "إيثيكوم: التقييم البشري",
@@ -1020,7 +1028,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "ja": {
     "title": "Ethicom：人間による評価",
@@ -1133,7 +1142,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "sw": {
     "title": "Ethicom: Tathmini ya Kibinadamu",
@@ -1246,7 +1256,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "ru": {
     "title": "Ethicom: Оценка человеком",
@@ -1359,7 +1370,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "it": {
     "title": "Ethicom: Valutazione Umana",
@@ -1473,7 +1485,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "ko": {
     "title": "Ethicom: 인간 평가",
@@ -1586,7 +1599,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "fa": {
     "title": "ایتیکام: ارزیابی انسانی",
@@ -1699,7 +1713,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "pl": {
     "title": "Ethicom: Ocena Ludzka",
@@ -1812,7 +1827,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "am": {
     "title": "Ethicom: Human Evaluation",
@@ -1925,7 +1941,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "af": {
     "title": "Ethicom: Human Evaluation",
@@ -2038,7 +2055,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "bn": {
     "title": "Ethicom: Human Evaluation",
@@ -2151,7 +2169,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "ha": {
     "title": "Ethicom: Human Evaluation",
@@ -2264,7 +2283,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "id": {
     "title": "Ethicom: Human Evaluation",
@@ -2377,7 +2397,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "ig": {
     "title": "Ethicom: Human Evaluation",
@@ -2490,7 +2511,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "om": {
     "title": "Ethicom: Human Evaluation",
@@ -2603,7 +2625,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "rm": {
     "title": "Ethicom: Human Evaluation",
@@ -2716,7 +2739,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "ta": {
     "title": "Ethicom: Human Evaluation",
@@ -2829,7 +2853,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "te": {
     "title": "Ethicom: Human Evaluation",
@@ -2942,7 +2967,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "th": {
     "title": "Ethicom: Human Evaluation",
@@ -3055,7 +3081,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "tr": {
     "title": "Ethicom: Human Evaluation",
@@ -3168,7 +3195,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "ur": {
     "title": "Ethicom: Human Evaluation",
@@ -3282,7 +3310,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "vi": {
     "title": "Ethicom: Human Evaluation",
@@ -3395,7 +3424,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "xh": {
     "title": "Ethicom: Human Evaluation",
@@ -3508,7 +3538,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "yo": {
     "title": "Ethicom: Human Evaluation",
@@ -3621,7 +3652,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "zu": {
     "title": "Ethicom: Human Evaluation",
@@ -3734,7 +3766,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   },
   "nl": {
     "title": "Ethicom: Menselijke Evaluatie",
@@ -3847,6 +3880,7 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_country": "Country/Region:",
-    "signup_placeholder_country": "US"
+    "signup_placeholder_country": "US",
+    "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable."
   }
 }

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -33,6 +33,7 @@
       <select id="lang_select"></select>
     </div>
     <h2 data-ui="signup_title">Sign up</h2>
+    <p id="server_notice" class="card" data-ui="signup_server_notice" style="margin-bottom:1em;"></p>
     <label for="email_input" data-ui="signup_email">Email:</label>
     <input type="email" id="email_input" placeholder="name@provider.com" />
 

--- a/interface/signup.js
+++ b/interface/signup.js
@@ -56,6 +56,8 @@ function applySignupTexts() {
   if (phoneLabel) phoneLabel.textContent = t.signup_phone || phoneLabel.textContent;
   const phoneInput = document.getElementById('phone_input');
   if (phoneInput && t.signup_placeholder_phone) phoneInput.placeholder = t.signup_placeholder_phone;
+  const serverNotice = document.getElementById('server_notice');
+  if (serverNotice && t.signup_server_notice) serverNotice.textContent = t.signup_server_notice;
   updatePhonePlaceholder();
 }
 


### PR DESCRIPTION
## Summary
- display a server requirement notice on `signup.html`
- apply translation key for this notice in all languages
- mention the required local server in both READMEs

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68482f0a84688321b28666ddda068876