### PR TITLE
Add GitHub App helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,13 @@ node tools/github-device-login.js
 ```
 Follow the printed instructions to authorize and store your ID locally.
 
+To retrieve an installation token for a GitHub App run:
+
+```bash
+node tools/github-app-token.js
+```
+The script reads `app/github_app_config.yaml` and prints a short-lived token.
+
 
 ### Optional Setup Helper
 [⇧](#contents)

--- a/app/github_app_config.yaml
+++ b/app/github_app_config.yaml
@@ -1,0 +1,3 @@
+app_id: "YOUR_GITHUB_APP_ID"
+installation_id: "YOUR_INSTALLATION_ID"
+private_key: "PATH_TO_PRIVATE_KEY_PEM"

--- a/docs/README.md
+++ b/docs/README.md
@@ -489,6 +489,13 @@ node tools/github-device-login.js
 ```
 Follow the printed instructions to authorize and store your ID locally.
 
+To retrieve an installation token for a GitHub App run:
+
+```bash
+node tools/github-app-token.js
+```
+The script reads `app/github_app_config.yaml` and prints a short-lived token.
+
 
 ### Optional Setup Helper
 [⇧](#contents)

--- a/test/github-app-token.test.js
+++ b/test/github-app-token.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const { parseAppConfig, createJwt } = require('../tools/github-app-token.js');
+
+test('parses app config', () => {
+  const dir = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'appcfg-'));
+  const pemPath = path.join(dir, 'key.pem');
+  fs.writeFileSync(pemPath, 'KEY');
+  const cfgPath = path.join(dir, 'cfg.yaml');
+  fs.writeFileSync(cfgPath, `app_id: 1\ninstallation_id: 2\nprivate_key: ${pemPath}\n`);
+  const cfg = parseAppConfig(cfgPath);
+  assert.strictEqual(cfg.app_id, '1');
+  assert.strictEqual(cfg.installation_id, '2');
+  assert.strictEqual(cfg.private_key, 'KEY');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('creates jwt', () => {
+  const { privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const pem = privateKey.export({ type: 'pkcs1', format: 'pem' });
+  const jwt = createJwt('42', pem);
+  assert.strictEqual(typeof jwt, 'string');
+  assert.strictEqual(jwt.split('.').length, 3);
+});

--- a/tools/github-app-token.js
+++ b/tools/github-app-token.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const crypto = require('crypto');
+
+function parseAppConfig(filePath) {
+  const cfgPath = filePath || path.join(__dirname, '..', 'app', 'github_app_config.yaml');
+  if (!fs.existsSync(cfgPath)) return null;
+  const cfg = {};
+  fs.readFileSync(cfgPath, 'utf8').split(/\r?\n/).forEach(line => {
+    const m = line.match(/^(app_id|installation_id|private_key):\s*(.*)$/);
+    if (m) cfg[m[1]] = m[2].replace(/['"]/g, '');
+  });
+  if (cfg.private_key && fs.existsSync(cfg.private_key)) {
+    cfg.private_key = fs.readFileSync(cfg.private_key, 'utf8');
+  }
+  return cfg;
+}
+
+function base64url(input) {
+  return Buffer.from(input).toString('base64').replace(/=+$/,'').replace(/\+/g,'-').replace(/\//g,'_');
+}
+
+function createJwt(appId, key) {
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const payload = base64url(JSON.stringify({ iat: now - 60, exp: now + 600, iss: appId }));
+  const data = `${header}.${payload}`;
+  const sign = crypto.createSign('RSA-SHA256');
+  sign.update(data);
+  const sig = base64url(sign.sign(key));
+  return `${data}.${sig}`;
+}
+
+function requestToken(jwt, installation) {
+  return new Promise((resolve, reject) => {
+    const opts = {
+      hostname: 'api.github.com',
+      path: `/app/installations/${installation}/access_tokens`,
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': '4789ethics'
+      }
+    };
+    const req = https.request(opts, res => {
+      let body = '';
+      res.on('data', c => { body += c; });
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          try { resolve(JSON.parse(body).token); } catch (e) { reject(e); }
+        } else {
+          reject(new Error(`HTTP ${res.statusCode}`));
+        }
+      });
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+async function main() {
+  const cfg = parseAppConfig();
+  if (!cfg || !cfg.app_id || !cfg.private_key || !cfg.installation_id) {
+    console.error('GitHub app config missing in app/github_app_config.yaml');
+    process.exit(1);
+  }
+  const jwt = createJwt(cfg.app_id, cfg.private_key);
+  const token = await requestToken(jwt, cfg.installation_id);
+  console.log('Installation token:', token);
+}
+
+if (require.main === module) {
+  main().catch(err => console.error('GitHub app auth failed:', err.message));
+}
+
+module.exports = { parseAppConfig, createJwt };


### PR DESCRIPTION
## Summary
- add `github-app-token.js` script for generating installation tokens
- document script usage in README and docs
- provide sample `github_app_config.yaml`
- test GitHub App helper functions

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68482fedd4e083218d0e04c2b013f1f4