### PR TITLE
Add page argument to npm start

### DIFF
--- a/ANLEITUNG_EINFACH_DE.md
+++ b/ANLEITUNG_EINFACH_DE.md
@@ -18,5 +18,5 @@ Diese Sammlung heisst "Ethics Structure 4789". Sie hilft, Verantwortung vor Bequ
 ## Lokaler Betrieb
 
 1. Einmal `npm install` ausführen oder `tools/guided-install.sh` nutzen.
-2. `node tools/start-server.js` starten (oder `npm start`). Die Seite öffnet sich automatisch unter `http://localhost:8080/index.html`.
+2. `node tools/start-server.js` starten (oder `npm start`). Du kannst einen Seitennamen anhängen, z.B. `npm start signup.html`. Die Seite öffnet sich automatisch unter `http://localhost:8080/index.html`.
 3. Mit `python3 install.py` stellst du Sprache, Port und Offline-Modus ein. Die Werte liegen in `app/app_settings.yaml`.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
    `node tools/serve-interface.js`. If you only have the website, download
    [`tools/easy-start.js`](https://www.bsvrb.ch/tools/easy-start.js) and run it
    with Node. For GitHub Pages deployments you can use
-   `npm run serve-gh`.
+   `npm run serve-gh`. Pass a page name to `npm start` to open it directly,
+   for example `npm start signup.html`.
    Opening an HTML file directly (via `file://`) disables translations and
    settings. See [Local Deployment](#local-deployment) for details.
 3. Optionally compile the Flutter launcher in `launcher/` to start the server

--- a/docs/NEUE_BENUTZER_DE.md
+++ b/docs/NEUE_BENUTZER_DE.md
@@ -6,6 +6,7 @@ Diese kurze Anleitung zeigt, wie du die Struktur 4789 lokal starten kannst.
 2. Node.js ≥18 installieren und `npm install` ausführen.
    Alternativ `tools/guided-install.sh` nutzen.
 3. Server mit `npm start` oder `node tools/start-server.js` starten.
+   Optional kannst du einen Seitennamen anhängen, z.B. `npm start signup.html`.
 4. Im Browser `http://localhost:8080/index.html` öffnen.
 5. Für die Registrierung [signup.html](../signup.html) aufrufen.
 6. Zusätzliche Einstellungen mit `python3 install.py` vornehmen.

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,8 @@ See [DISCLAIMERS.md](../DISCLAIMERS.md) for warranty and liability notes.
    `node tools/serve-interface.js`. If you only have the website, download
    [`tools/easy-start.js`](https://www.bsvrb.ch/tools/easy-start.js) and run it
    with Node. For GitHub Pages deployments you can use
-   `npm run serve-gh`.
+   `npm run serve-gh`. Pass a page name to `npm start` to open it directly,
+   for example `npm start signup.html`.
    Opening an HTML file directly (via `file://`) disables translations and
    settings. See [Local Deployment](#local-deployment) for details.
 3. Optionally compile the Flutter launcher in `launcher/` to start the server

--- a/tools/start-server.js
+++ b/tools/start-server.js
@@ -10,6 +10,16 @@ const disclaimers = [
 ];
 
 disclaimers.forEach(l => console.log(l));
+const args = process.argv.slice(2);
+let env = { ...process.env };
+if (args[0] && args[0].startsWith('http')) {
+  env.BASE_URL = args.shift();
+} else if (args[0] === 'gh') {
+  env.BASE_URL = 'https://4789-alpha.github.io';
+  args.shift();
+}
+const page = args[0] || 'index.html';
+
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 rl.question('Fortfahren? (yes/no) ', answer => {
   rl.close();
@@ -18,9 +28,9 @@ rl.question('Fortfahren? (yes/no) ', answer => {
     process.exit(1);
   }
 
-  const server = spawn('node', [path.join(__dirname, 'serve-interface.js')], { stdio: 'inherit' });
+  const server = spawn('node', [path.join(__dirname, 'serve-interface.js')], { stdio: 'inherit', env });
 
-  const url = 'http://localhost:8080/index.html';
+  const url = /^https?:\/\//.test(page) ? page : `http://localhost:8080/${page}`;
   let cmd, args;
   if (process.platform === 'win32') {
     cmd = 'cmd';


### PR DESCRIPTION
## Summary
- allow `npm start` to open a specific page and optional BASE_URL
- document optional argument in README, docs/README and NEUE_BENUTZER_DE
- mention argument in ANLEITUNG_EINFACH_DE
- update server script to read arguments and set BASE_URL

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68482d1d0b008321a9d4265ec03b772f