### PR TITLE
Add Hostpoint deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 3. Optionally compile the Flutter launcher in `launcher/` to start the server
    without the terminal (`flutter run launcher`).
 4. The interface opens at `http://localhost:8080/index.html`.
+5. For quick static hosting, deploy the interface on
+   [Netsly](interface/deploy_netsly.md) or
+   [Hostpoint](interface/deploy_hostpoint.md).
 
 ```
 README.md -> GET_STARTED.md -> index.html

--- a/interface/deploy_hostpoint.md
+++ b/interface/deploy_hostpoint.md
@@ -1,0 +1,10 @@
+# Deploying the Interface on Hostpoint
+
+Hostpoint offers simple static site hosting similar to Netlify. You can upload the built interface files and run them directly.
+
+1. Create a new static site in your Hostpoint control panel.
+2. Upload the repository files or link your fork via Git if available.
+3. Ensure `index.html` is in the root so the main page loads automatically.
+4. Save and deploy.
+
+This is one of several ways to host the interface. Adjust to your environment.


### PR DESCRIPTION
## Summary
- add `interface/deploy_hostpoint.md`
- document Hostpoint static hosting in Quick Start

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6848326198008321a1778eadf4a7c571