### PR TITLE
Improve nav visibility by OP level

### DIFF
--- a/README.html
+++ b/README.html
@@ -20,7 +20,7 @@
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a aria-current="page" class="icon-only readme-link" aria-label="Help">?</a>
-    <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
+    <button id="side_menu" type="button" class="icon-only" aria-label="Menu" data-min-op="OP-6">☰</button>
   </nav>
   <section id="user_info" class="card" aria-live="polite"></section>
   <main id="main_content">

--- a/bewertung.html
+++ b/bewertung.html
@@ -20,7 +20,7 @@
       <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>
-      <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
+      <button id="side_menu" type="button" class="icon-only" aria-label="Menu" data-min-op="OP-6">☰</button>
     </nav>
   </header>
   <main id="main_content">

--- a/docs/README.html
+++ b/docs/README.html
@@ -20,7 +20,7 @@
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a aria-current="page" class="icon-only readme-link" aria-label="Help">?</a>
-    <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
+    <button id="side_menu" type="button" class="icon-only" aria-label="Menu" data-min-op="OP-6">☰</button>
   </nav>
   <section id="user_info" class="card" aria-live="polite"></section>
   <main id="main_content" class="cards-grid">

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
       <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>
-      <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
+      <button id="side_menu" type="button" class="icon-only" aria-label="Menu" data-min-op="OP-6">☰</button>
   </nav>
   <main id="main_content" class="cards-grid">
     <div id="lang_selection" class="card" style="margin-bottom:1em;">

--- a/interface/bundle.js
+++ b/interface/bundle.js
@@ -1721,20 +1721,38 @@ function hideLoadingBadge() {
 
 window.getStoredOpLevel = getStoredOpLevel;
 window.opLevelToNumber = opLevelToNumber;
-window.getReadmePath = getReadmePath;
-window.showLoadingBadge = showLoadingBadge;
-window.hideLoadingBadge = hideLoadingBadge;
+  window.getReadmePath = getReadmePath;
+  window.showLoadingBadge = showLoadingBadge;
+  window.hideLoadingBadge = hideLoadingBadge;
 
-// Check if user confirmed responsibility via "Sana"
-function getSanaConfirmed() {
-  try {
-    return localStorage.getItem('sana_confirmed') === 'true';
-  } catch (err) {
-    return false;
+  // Check if user confirmed responsibility via "Sana"
+  function getSanaConfirmed() {
+    try {
+      return localStorage.getItem('sana_confirmed') === 'true';
+    } catch (err) {
+      return false;
+    }
   }
-}
 
-window.getSanaConfirmed = getSanaConfirmed;
+  window.getSanaConfirmed = getSanaConfirmed;
+
+  // Show or hide navigation links based on the required OP level
+  function applyOpLevelVisibility(root = document) {
+    const currentLevel =
+      typeof opLevelToNumber === 'function' &&
+      typeof getStoredOpLevel === 'function'
+        ? opLevelToNumber(getStoredOpLevel())
+        : 0;
+    root.querySelectorAll('[data-min-op]').forEach(el => {
+      const required = opLevelToNumber(el.dataset.minOp);
+      if (currentLevel < required) {
+        el.style.display = 'none';
+      }
+    });
+  }
+
+  window.applyOpLevelVisibility = applyOpLevelVisibility;
+  document.addEventListener('DOMContentLoaded', () => applyOpLevelVisibility());
 
 
 

--- a/interface/ethicom-utils.js
+++ b/interface/ethicom-utils.js
@@ -261,3 +261,21 @@ function getSanaConfirmed() {
 
 window.getSanaConfirmed = getSanaConfirmed;
 
+// Show or hide navigation links based on the required OP level
+function applyOpLevelVisibility(root = document) {
+  const currentLevel =
+    typeof opLevelToNumber === 'function' &&
+    typeof getStoredOpLevel === 'function'
+      ? opLevelToNumber(getStoredOpLevel())
+      : 0;
+  root.querySelectorAll('[data-min-op]').forEach(el => {
+    const required = opLevelToNumber(el.dataset.minOp);
+    if (currentLevel < required) {
+      el.style.display = 'none';
+    }
+  });
+}
+
+window.applyOpLevelVisibility = applyOpLevelVisibility;
+document.addEventListener('DOMContentLoaded', () => applyOpLevelVisibility());
+

--- a/interface/features_de.md
+++ b/interface/features_de.md
@@ -63,6 +63,8 @@ if (user.op_level >= 5) {
 ```
 
 - Das Side-Drop-Menü steht erst ab OP-6 zur Verfügung.
+- Alternativ kann ein Element das Attribut `data-min-op="OP-x"` erhalten.
+  Das Skript `applyOpLevelVisibility()` blendet solche Links automatisch aus.
 
 ## 5. Fortschrittsanzeige
 

--- a/interface/login.html
+++ b/interface/login.html
@@ -27,7 +27,7 @@
     <a href="signup.html">Signup</a>
       <a href="hermes.html">Hermes</a>
     <a href="../README.html" class="readme-link">README</a>
-    <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
+    <button id="side_menu" type="button" class="icon-only" aria-label="Menu" data-min-op="OP-6">☰</button>
   </nav>
   <main id="main_content">
     <div id="lang_selection" class="card" style="margin-bottom:1em;">

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -25,7 +25,7 @@
     <a href="signup.html">Signup</a>
       <a href="hermes.html">Hermes</a>
     <a href="../README.html" class="readme-link">README</a>
-    <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
+    <button id="side_menu" type="button" class="icon-only" aria-label="Menu" data-min-op="OP-6">☰</button>
   </nav>
   <main id="main_content">
     <p class="note">Settings are saved locally. Some options apply after reload.</p>

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -25,7 +25,7 @@
     <a href="signup.html" aria-current="page">Signup</a>
       <a href="hermes.html">Hermes</a>
     <a href="../README.html" class="readme-link">README</a>
-    <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
+    <button id="side_menu" type="button" class="icon-only" aria-label="Menu" data-min-op="OP-6">☰</button>
   </nav>
   <main id="main_content">
     <div id="lang_selection" class="card" style="margin-bottom:1em;">

--- a/wings/index.html
+++ b/wings/index.html
@@ -28,7 +28,7 @@
     <a href="../interface/settings.html" data-ui="nav_settings" class="icon-only" title="Settings" aria-label="Settings">⚙</a>
     <a href="index.html" aria-current="page">Wings</a>
     <a href="../README.md" target="_blank" data-ui="nav_readme" class="readme-link">README</a>
-    <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
+    <button id="side_menu" type="button" class="icon-only" aria-label="Menu" data-min-op="OP-6">☰</button>
   </nav>
   <main id="main_content">
     <div id="lang_selection" class="card" style="margin-bottom:1em;">

--- a/wings/ratings.html
+++ b/wings/ratings.html
@@ -22,7 +22,7 @@
     <a href="../index.html">Home</a>
     <a href="index.html">Wings</a>
     <a href="../bewertung.html" data-ui="nav_ratings">Full View</a>
-    <button id="side_menu" type="button" class="icon-only" aria-label="Menu">☰</button>
+    <button id="side_menu" type="button" class="icon-only" aria-label="Menu" data-min-op="OP-6">☰</button>
   </nav>
   <main id="main_content">
     <div id="lang_selection" class="card" style="margin-bottom:1em;">


### PR DESCRIPTION
## Summary
- hide menu links unless the user has the required OP level
- document the `data-min-op` attribute for menu items

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_68483ec077a883218b60da62aec45fe7