### PR TITLE
Implement OPauth helper and simplify login check

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,12 @@ To retrieve an installation token for a GitHub App run:
 node tools/github-app-token.js
 ```
 The script reads `app/github_app_config.yaml` and prints a short-lived token.
+For OPauth verification run:
+
+```bash
+node tools/github-opauth-token.js <email> <TOTP>
+```
+It validates your stored OPauth credentials before printing the same token.
 
 
 ### Optional Setup Helper

--- a/interface/bundle.js
+++ b/interface/bundle.js
@@ -1921,6 +1921,123 @@ function loadInterfaceForOP(op_level) {
 //----- language-selector.js -----
 // language-selector.js – 4789: bewusste Sprachwahl ohne Priorisierung
 
+// Minimal English texts for offline OP-0 use
+const offlineUiText = {
+  "en": {
+    "title": "Ethicom: Human Evaluation",
+    "label_source": "Source (URL or Title)",
+    "label_srclvl": "Ethical Level (SRC)",
+    "label_aspects": "Optional Aspects",
+    "label_comment": "Comment",
+    "btn_generate": "Show My Evaluation",
+    "btn_download": "Download as File",
+    "aspects": [
+      "Transparency",
+      "Repairability",
+      "System Reflection",
+      "Error Handling",
+      "Purpose Clarity"
+    ],
+    "signup_title": "Sign up",
+    "signup_email": "Email:",
+    "signup_password": "Password:",
+    "signup_btn": "Create Account",
+    "signup_placeholder_email": "name@provider.com",
+    "signup_placeholder_pw": "At least 8 characters",
+    "signup_address": "Address:",
+    "signup_phone": "Phone:",
+    "signup_nick": "Nickname:",
+    "signup_placeholder_nick": "Optional nickname",
+    "signup_alias": "Alias (public): {alias}",
+    "signup_placeholder_address": "Optional address",
+    "signup_placeholder_phone": "+12025550123",
+    "signup_country": "Country/Region:",
+    "signup_placeholder_country": "US",
+    "signup_invalid_email": "Invalid email format.",
+    "signup_unsupported": "Email provider not supported. Use a secure host.",
+    "signup_insecure_warn": "Insecure email host. Allowed only until OP-5.",
+    "signup_pw_short": "Password must be at least 8 characters.",
+    "signup_saved": "Signup complete. ID stored.",
+    "signup_secret": "Authenticator secret: {secret}",
+    "help_title": "Help – Operator Conduct",
+    "help_items": [
+      "Always check if your actions meet the ethics of responsibility.",
+      "Use only the tools assigned to your OP level.",
+      "Document decisions in the manifest for verification.",
+      "Nominations and feedback are structured and without personal pressure.",
+      "Consult a higher structure (from OP-7) if unsure.",
+      "Responsibility outweighs convenience.",
+      "Create signatures locally and confirm them structurally.",
+      "Withdrawals or corrections are part of the process, not weakness.",
+      "Maintain transparency at every step, even with anonymous use."
+    ],
+    "access_title": "Accessibility Setup",
+    "access_label_vision": "Can you see the screen?",
+    "access_label_hearing": "Can you hear from this device?",
+    "access_label_speech": "Can you speak?",
+    "access_label_simple": "Simplified interface?",
+    "access_opt_yes": "Yes",
+    "access_save_btn": "Save Setup",
+    "access_opt_no": "No",
+    "access_opt_yes_nospeech": "Yes, but cannot speak",
+    "access_saved": "Accessibility preferences saved.",
+    "nav_start": "Start",
+    "nav_ratings": "Ratings",
+    "nav_signup": "Signup",
+    "nav_readme": "README",
+    "nav_tools": "Tools",
+    "nav_settings": "Settings",
+    "label_choose_language": "Choose your language (ISO 639-1):",
+    "status_verifying_sig": "Verifying signature...",
+    "status_sig_missing": "Signature not found or incomplete.",
+    "status_sig_invalid": "Signature invalid or password incorrect.",
+    "status_sig_valid": "Signature valid: {level}",
+    "status_loading_op0": "Loading OP-0...",
+    "rating_yes": "Yes",
+    "rating_partial": "Partly",
+    "rating_no": "No",
+    "simple_toggle_label": "Toggle Simple Mode",
+    "simple_mode_on": "Simple mode is active.",
+    "simple_mode_off": "Simple mode is off.",
+    "disclaimer_title": "Disclaimers",
+    "disclaimer_items": [
+      "This structure is provided without warranty.",
+      "Use is at your own risk.",
+      "The operators and contributors accept no liability; BSVRB is an association under Swiss law (Swiss Civil Code art. 60 ff.: https://www.fedlex.admin.ch/eli/cc/24/233_245_233/en).",
+      "4789 is a standard for responsibility, not a person or belief system.",
+      "Use only with reflection and consequence; no manipulation or uncontrolled automation.",
+      "If a contradiction arises, apply self-reflection (structure_9874).",
+      "Humor is allowed if responsibility and clarity remain.",
+      "Each user’s TOTP secret is stored encrypted."
+    ],
+    "btn_disclaimer_accept": "I understand",
+    "attention_toggle_wiggle": "Wiggle when idle",
+    "attention_toggle_beep": "Beep when idle",
+    "side_close": "Close",
+    "side_menu_need_op6": "OP-6 required.",
+    "rating_saved": "Rating saved.",
+    "login_title": "Login",
+    "login_email": "Email:",
+    "login_password": "Password:",
+    "login_time_hint": "Current time: {time}",
+    "login_auth": "Authenticator code:",
+    "login_btn": "Log in",
+    "login_github": "Login with GitHub",
+    "login_google": "Login with Google",
+    "login_invalid": "Login failed.",
+    "login_saved": "Login successful. ID stored.",
+    "connect_title": "Connect",
+    "connect_request": "Request connection",
+    "connect_enter_sig": "Target signature:",
+    "connect_pending": "Pending requests",
+    "connect_connections": "Your connections",
+    "connect_approve": "Approve",
+    "connect_request_sent": "Request sent.",
+    "connect_error": "Request failed.",
+    "nav_navigator": "Navigator Menu",
+    "nav_story": "Story"
+  }
+};
 
 function askLanguageChoice() {
   const lang = prompt(
@@ -2046,17 +2163,32 @@ function initLanguageDropdown(selectId = "lang_select", textPath = getUiTextPath
       });
     })
     .catch(() => {
-      displayLangNotice(
-        'Start the interface with `node tools/serve-interface.js`. Then open `http://localhost:8080/ethicom.html` in your browser. Opening the HTML file directly (e.g. via `file://`) bypasses the local server and causes the language list to remain empty. Always access the interface through the provided `localhost` address so that translation files load correctly.'
-      );
-      const select = document.getElementById(selectId);
-      if (select) {
-        select.innerHTML = '<option value="en">en</option>';
-        select.value = 'en';
+      const texts = typeof offlineUiText !== 'undefined' ? offlineUiText : null;
+      if (texts) {
+        const select = document.getElementById(selectId);
+        if (select) {
+          select.innerHTML = Object.keys(texts)
+            .sort()
+            .map(c => `<option value="${c}">${c}</option>`)
+            .join('');
+          select.value = 'en';
+        }
+        localStorage.setItem('ethicom_lang', 'en');
+        if (typeof applyTexts === 'function') applyTexts(texts.en || {});
+        if (typeof updateReadmeLinks === 'function') updateReadmeLinks('en');
+      } else {
+        displayLangNotice(
+          'Start the interface with `node tools/serve-interface.js`. Then open `http://localhost:8080/ethicom.html` in your browser. Opening the HTML file directly (e.g. via `file://`) bypasses the local server and causes the language list to remain empty. Always access the interface through the provided `localhost` address so that translation files load correctly.'
+        );
+        const select = document.getElementById(selectId);
+        if (select) {
+          select.innerHTML = '<option value="en">en</option>';
+          select.value = 'en';
+        }
+        localStorage.setItem('ethicom_lang', 'en');
+        if (typeof applyTexts === 'function') applyTexts({});
+        if (typeof updateReadmeLinks === 'function') updateReadmeLinks('en');
       }
-      localStorage.setItem('ethicom_lang', 'en');
-      if (typeof applyTexts === 'function') applyTexts({});
-      if (typeof updateReadmeLinks === 'function') updateReadmeLinks('en');
     });
 }
 
@@ -2078,15 +2210,6 @@ function checkLanguageSetup() {
 //----- login.js -----
 let uiText = {};
 
-function currentSuffix() {
-  const now = new Date();
-  now.setHours(now.getHours() + 4);
-  now.setMinutes(now.getMinutes() + 44);
-  const h = String(now.getHours() % 24).padStart(2, '0');
-  const m = String(now.getMinutes()).padStart(2, '0');
-  return h + m;
-}
-
 function applyLoginTexts() {
   document.documentElement.lang = localStorage.getItem('ethicom_lang') || 'de';
   const t = uiText;
@@ -2100,13 +2223,6 @@ function applyLoginTexts() {
   if (authLabel) authLabel.textContent = t.login_auth || authLabel.textContent;
   const loginBtn = document.getElementById('login_btn');
   if (loginBtn) loginBtn.textContent = t.login_btn || loginBtn.textContent;
-  const hint = document.getElementById('time_hint');
-  if (hint && t.login_time_hint) {
-    const now = new Date();
-    const h = String(now.getHours()).padStart(2, '0');
-    const m = String(now.getMinutes()).padStart(2, '0');
-    hint.textContent = t.login_time_hint.replace('{time}', `${h}:${m}`);
-  }
 }
 
 function initLogin() {
@@ -2129,8 +2245,10 @@ function handleLogin() {
   const auth = authInput.value.trim();
   statusEl.textContent = '';
 
-  const suffix = currentSuffix();
-  if (!password.endsWith(suffix)) password += suffix;
+  if (password.length < 8) {
+    statusEl.textContent = 'Password must be at least 8 characters.';
+    return;
+  }
 
   if (!/^[^@]+@[^@]+\.[^@]+$/.test(email)) {
     statusEl.textContent = uiText.login_invalid || 'Login failed. Please check your credentials.';
@@ -2153,7 +2271,9 @@ function handleLogin() {
       setTimeout(() => { window.location.href = 'ethicom.html'; }, 500);
     })
     .catch(() => {
-      statusEl.textContent = uiText.login_invalid || 'Login failed. Please check your credentials.';
+      statusEl.textContent =
+        uiText.login_invalid ||
+        'Login failed. Check email, password and authenticator code.';
     });
 }
 
@@ -2260,7 +2380,7 @@ function initLogoBackground() {
   overlay.style.position = 'fixed';
   overlay.style.inset = '0';
   overlay.style.pointerEvents = 'none';
-  overlay.style.zIndex = '1';
+  overlay.style.zIndex = '0';
   overlay.style.width = '100%';
   overlay.style.height = '100%';
   document.body.appendChild(overlay);
@@ -2536,7 +2656,8 @@ function initLogoBackground() {
           octx.save();
           octx.translate(s.x, s.y);
           const style = getComputedStyle(document.documentElement);
-          octx.strokeStyle = style.getPropertyValue('--collision-color') ||
+          octx.strokeStyle =
+            style.getPropertyValue('--collision-color') ||
             style.getPropertyValue('--accent-color') || '#ff0';
           octx.lineWidth = 2;
           octx.beginPath();
@@ -2628,6 +2749,11 @@ function insertModuleLogo() {
   link.setAttribute('aria-label', 'OP Status');
   link.style.width = `calc(${size} * 1.5 + 1em)`;
   link.style.height = '100%';
+
+  const badge = document.createElement('span');
+  badge.className = `badge op-${level.replace('OP-', '').replace('.', '')}`;
+  badge.textContent = level;
+  link.appendChild(badge);
   header.appendChild(link);
 
   if (!h1) return;
@@ -3083,6 +3209,25 @@ function renderMarkdown(md) {
 }
 
 
+//----- session.js -----
+// Simple session timeout logic
+(function() {
+  const SESSION_MINUTES = 30;
+  let lastAction = Date.now();
+  function reset() { lastAction = Date.now(); }
+  function check() {
+    if (Date.now() - lastAction > SESSION_MINUTES * 60 * 1000) {
+      localStorage.removeItem('ethicom_signature');
+      window.location.href = 'login.html';
+    }
+  }
+  document.addEventListener('mousemove', reset);
+  document.addEventListener('keydown', reset);
+  setInterval(check, 60 * 1000);
+})();
+
+
+
 //----- side-drop.js -----
 // side-drop.js – simple slide-out menu for OP badge
 let sideDropUrl = null;
@@ -3319,6 +3464,8 @@ function applySignupTexts() {
   if (phoneLabel) phoneLabel.textContent = t.signup_phone || phoneLabel.textContent;
   const phoneInput = document.getElementById('phone_input');
   if (phoneInput && t.signup_placeholder_phone) phoneInput.placeholder = t.signup_placeholder_phone;
+  const serverNotice = document.getElementById('server_notice');
+  if (serverNotice && t.signup_server_notice) serverNotice.textContent = t.signup_server_notice;
   updatePhonePlaceholder();
 }
 
@@ -3521,6 +3668,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
 //----- theme-manager.js -----
+
+function getOpLevel() {
+  return typeof window !== 'undefined' &&
+    typeof window.opLevelToNumber === 'function' &&
+    typeof window.getStoredOpLevel === 'function'
+      ? window.opLevelToNumber(window.getStoredOpLevel())
+      : 0;
+}
+
 function applyTheme(theme) {
   const body = document.body;
   body.classList.remove(
@@ -3570,53 +3726,73 @@ function initThemeSelection() {
   const labels = ['Dark Tanna','Tanna','Transparent','Sea Blue','Desert','Accessible','Custom'];
 
   let theme = localStorage.getItem('ethicom_theme') || 'tanna-dark';
+  if (getOpLevel() === 0) {
+    theme = 'tanna-dark';
+  }
   applyTheme(theme);
   if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
   if (select) {
     select.value = theme;
-    if (opLevel >= 3) {
-      select.addEventListener('change', e => {
-        theme = e.target.value;
-        localStorage.setItem('ethicom_theme', theme);
-        applyTheme(theme);
-        resetSlidersFromTheme();
-        if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
-        const idx = themes.indexOf(theme);
-        if (slider && idx >= 0) {
-          slider.value = idx;
-          if (label) label.textContent = labels[idx];
-        }
-      });
-    } else {
-      select.disabled = true;
-    }
+    select.addEventListener('change', e => {
+      if (getOpLevel() < 3) return;
+      theme = e.target.value;
+      localStorage.setItem('ethicom_theme', theme);
+      applyTheme(theme);
+      resetSlidersFromTheme();
+      if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
+      const idx = themes.indexOf(theme);
+      if (slider && idx >= 0) {
+        slider.value = idx;
+        if (label) label.textContent = labels[idx];
+      }
+    });
   }
   if (slider) {
     slider.max = themes.length - 1;
     const cur = themes.indexOf(theme);
     slider.value = cur >= 0 ? cur : 0;
     if (label) label.textContent = labels[slider.value];
-    if (opLevel >= 3) {
-      slider.addEventListener('input', e => {
-        const idx = parseInt(e.target.value, 10);
-        theme = themes[idx] || themes[0];
-        if (label) label.textContent = labels[idx] || labels[0];
-        localStorage.setItem('ethicom_theme', theme);
-        applyTheme(theme);
-        resetSlidersFromTheme();
-        if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
-        if (select) select.value = theme;
-      });
-    } else {
-      slider.disabled = true;
-    }
+    slider.addEventListener('input', e => {
+      if (getOpLevel() < 3) return;
+      const idx = parseInt(e.target.value, 10);
+      theme = themes[idx] || themes[0];
+      if (label) label.textContent = labels[idx] || labels[0];
+      localStorage.setItem('ethicom_theme', theme);
+      applyTheme(theme);
+      resetSlidersFromTheme();
+      if (tannaCard) tannaCard.style.display = theme === 'tanna' ? 'block' : 'none';
+      if (select) select.value = theme;
+    });
   }
   if (customBtn) {
-    if (opLevel >= 4) {
-      customBtn.style.display = 'block';
-      customBtn.addEventListener('click', createCustomTheme);
+    customBtn.addEventListener('click', e => {
+      if (getOpLevel() >= 4) createCustomTheme(e);
+    });
+  }
+
+  function updateAccess() {
+    const level = getOpLevel();
+    if (select) select.disabled = level < 3;
+    if (slider) slider.disabled = level < 3;
+    if (customBtn) customBtn.style.display = level >= 4 ? 'block' : 'none';
+    if (level === 0) {
+      theme = 'tanna-dark';
+      applyTheme(theme);
+      resetSlidersFromTheme();
+      if (select) select.value = theme;
+      if (slider) {
+        const idx = themes.indexOf(theme);
+        slider.value = idx >= 0 ? idx : 0;
+        if (label) label.textContent = labels[slider.value];
+      }
+      if (tannaCard) tannaCard.style.display = 'none';
     }
   }
+
+  updateAccess();
+  window.addEventListener('storage', e => {
+    if (e.key === 'ethicom_signature') updateAccess();
+  });
 }
 
 
@@ -4434,7 +4610,8 @@ window.addEventListener('DOMContentLoaded', () => {
   const modules = [
     { name: 'Bewertung', href: 'bewertung.html' },
     { name: 'Ethicom', href: 'interface/ethicom.html' },
-    { name: 'Fish', href: 'interface/fish.html' }
+    { name: 'Fish', href: 'interface/fish.html' },
+    { name: 'BSVRB', href: 'index.html' }
   ];
 
   const aside = document.createElement('nav');

--- a/interface/login.html
+++ b/interface/login.html
@@ -40,7 +40,6 @@
 
     <label for="pw_input" data-ui="login_password">Password:</label>
     <input type="password" id="pw_input" placeholder="At least 8 characters" />
-    <p id="time_hint" data-ui="login_time_hint"></p>
 
     <label for="auth_input" data-ui="login_auth">Authenticator code:</label>
     <input type="text" id="auth_input" placeholder="123456" inputmode="numeric" />

--- a/interface/login.js
+++ b/interface/login.js
@@ -1,14 +1,5 @@
 let uiText = {};
 
-function currentSuffix() {
-  const now = new Date();
-  now.setHours(now.getHours() + 4);
-  now.setMinutes(now.getMinutes() + 44);
-  const h = String(now.getHours() % 24).padStart(2, '0');
-  const m = String(now.getMinutes()).padStart(2, '0');
-  return h + m;
-}
-
 function applyLoginTexts() {
   document.documentElement.lang = localStorage.getItem('ethicom_lang') || 'de';
   const t = uiText;
@@ -22,13 +13,6 @@ function applyLoginTexts() {
   if (authLabel) authLabel.textContent = t.login_auth || authLabel.textContent;
   const loginBtn = document.getElementById('login_btn');
   if (loginBtn) loginBtn.textContent = t.login_btn || loginBtn.textContent;
-  const hint = document.getElementById('time_hint');
-  if (hint && t.login_time_hint) {
-    const now = new Date();
-    const h = String(now.getHours()).padStart(2, '0');
-    const m = String(now.getMinutes()).padStart(2, '0');
-    hint.textContent = t.login_time_hint.replace('{time}', `${h}:${m}`);
-  }
 }
 
 function initLogin() {
@@ -55,9 +39,6 @@ function handleLogin() {
     statusEl.textContent = 'Password must be at least 8 characters.';
     return;
   }
-
-  const suffix = currentSuffix();
-  if (!password.endsWith(suffix)) password += suffix;
 
   if (!/^[^@]+@[^@]+\.[^@]+$/.test(email)) {
     statusEl.textContent = uiText.login_invalid || 'Login failed. Please check your credentials.';

--- a/tools/github-opauth-token.js
+++ b/tools/github-opauth-token.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const crypto = require('crypto');
+const { parseAppConfig, createJwt } = require('./github-app-token.js');
+
+const githubAppCfg = parseAppConfig();
+
+function base32Decode(str) {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  const clean = str.toUpperCase().replace(/[^A-Z2-7]/g, '');
+  let bits = 0, value = 0, idx = 0;
+  const out = [];
+  for (const ch of clean) {
+    value = (value << 5) | alphabet.indexOf(ch);
+    bits += 5;
+    if (bits >= 8) {
+      out[idx++] = (value >>> (bits - 8)) & 0xff;
+      bits -= 8;
+    }
+  }
+  return Buffer.from(out.slice(0, idx));
+}
+
+function totpCode(secret, step) {
+  const key = base32Decode(secret);
+  const buf = Buffer.alloc(8);
+  buf.writeUInt32BE(0, 0);
+  buf.writeUInt32BE(step, 4);
+  const hmac = crypto.createHmac('sha1', key).update(buf).digest();
+  const offset = hmac[19] & 0xf;
+  const num = (hmac.readUInt32BE(offset) & 0x7fffffff) % 1000000;
+  return String(num).padStart(6, '0');
+}
+
+function verifyTotp(secret, code) {
+  const t = Math.floor(Date.now() / 30000);
+  const c = String(code).padStart(6, '0');
+  return [t - 1, t, t + 1].some(step => totpCode(secret, step) === c);
+}
+
+function decryptTotpSecret(data) {
+  const key = crypto
+    .createHash('sha256')
+    .update(process.env.TOTP_SECRET_KEY || 'default_totp_key')
+    .digest();
+  const buf = Buffer.from(data, 'base64');
+  const iv = buf.slice(0, 12);
+  const tag = buf.slice(12, 28);
+  const enc = buf.slice(28);
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+  const dec = Buffer.concat([decipher.update(enc), decipher.final()]);
+  return dec.toString('utf8');
+}
+
+function loadUsers() {
+  const file = path.join(__dirname, '..', 'app', 'users.json');
+  if (!fs.existsSync(file)) return [];
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+function findUser(email) {
+  const emailHash = crypto.createHash('sha256').update(email).digest('hex');
+  return loadUsers().find(u => u.emailHash === emailHash);
+}
+
+async function requestToken(jwt, installation) {
+  return new Promise((resolve, reject) => {
+    const opts = {
+      hostname: 'api.github.com',
+      path: `/app/installations/${installation}/access_tokens`,
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': '4789ethics-opauth'
+      }
+    };
+    const req = https.request(opts, res => {
+      let body = '';
+      res.on('data', c => { body += c; });
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          try { resolve(JSON.parse(body).token); } catch (e) { reject(e); }
+        } else {
+          reject(new Error(`HTTP ${res.statusCode}`));
+        }
+      });
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+async function main() {
+  const [email, totp] = process.argv.slice(2);
+  if (!email || !totp) {
+    console.log('Usage: node tools/github-opauth-token.js <email> <TOTP>');
+    process.exit(0);
+  }
+  const user = findUser(email);
+  if (!user || !user.totpSecretEnc || !verifyTotp(decryptTotpSecret(user.totpSecretEnc), totp)) {
+    console.error('OPauth verification failed');
+    process.exit(1);
+  }
+  const cfg = githubAppCfg;
+  if (!cfg || !cfg.app_id || !cfg.private_key || !cfg.installation_id) {
+    console.error('GitHub app config missing in app/github_app_config.yaml');
+    process.exit(1);
+  }
+  const jwt = createJwt(cfg.app_id, cfg.private_key);
+  try {
+    const token = await requestToken(jwt, cfg.installation_id);
+    console.log('Installation token:', token);
+  } catch (err) {
+    console.error('GitHub app auth failed:', err.message);
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -298,16 +298,10 @@ function handleLogin(req, res) {
       const emailHash = crypto.createHash('sha256').update(email).digest('hex');
       const user = users.find(u => u.emailHash === emailHash);
       if (!user) { res.writeHead(403); res.end('Invalid credentials'); return; }
-      const now = new Date();
-      now.setHours(now.getHours() + 4);
-      now.setMinutes(now.getMinutes() + 44);
-      const suffix = String(now.getHours() % 24).padStart(2, '0') +
-        String(now.getMinutes()).padStart(2, '0');
-      if (password.length < 4 || !password.endsWith(suffix)) {
+      if (password.length < 8) {
         res.writeHead(403); res.end('Invalid credentials'); return;
       }
-      const basePw = password.slice(0, -4);
-      const pwHash = crypto.createHash('sha256').update(basePw + user.salt).digest('hex');
+      const pwHash = crypto.createHash('sha256').update(password + user.salt).digest('hex');
       if (pwHash !== user.pwHash) { res.writeHead(403); res.end('Invalid credentials'); return; }
       if (user.totpSecretEnc &&
           !verifyTotp(decryptTotpSecret(user.totpSecretEnc), auth_code)) {


### PR DESCRIPTION
## Summary
- clean up login HTML and JS to remove time-based password suffix
- regenerate interface bundle
- parse GitHub app config in the OPauth helper
- drop obsolete suffix check in the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684835503ee88321a42deffbabf0444b