### PR TITLE
Add cross links for OP logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 | `test/` | Node.js test suite |
 | `tools/` | Utility scripts (e.g., trust-demotion engine, reliability monitor, correction engine, Python API example, `text_to_speech.py`) |
 | `use_cases/` | Example scenarios and dissemination ideas |
-| `sources/images/op-logo/` | Stages of the Tanna symbol |
+| [sources/images/op-logo/](sources/images/op-logo/README_TANNA_OP0-OP7.md) | Stages of the Tanna symbol |
 | `wings/` | Minimal mobile interface |
 | `evidence/` | Datasets such as `person-ratings.json` |
 | `interface_OLD/` | Legacy version of the first interface |

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,7 +107,7 @@ README.md -> GET_STARTED.md -> index.html
 | `test/` | Node.js test suite |
 | `tools/` | Utility scripts (e.g., trust-demotion engine, reliability monitor, correction engine, Python API example) |
 | `use_cases/` | Example scenarios and dissemination ideas |
-| `sources/images/op-logo/` | Stages of the Tanna symbol |
+| [sources/images/op-logo/](../sources/images/op-logo/README_TANNA_OP0-OP7.md) | Stages of the Tanna symbol |
 | `wings/` | Minimal mobile interface |
 | `evidence/` | Datasets such as `person-ratings.json` |
 | `interface_OLD/` | Legacy version of the first interface |

--- a/sources/images/op-logo/README_TANNA_OP0-OP7.md
+++ b/sources/images/op-logo/README_TANNA_OP0-OP7.md
@@ -6,6 +6,9 @@ This folder contains PNG files representing the geometrically and visually refin
 of the TANNA symbol from OP-0 to OP-7. Each stage represents an abstract layer or growth level
 in a logical, graphical, or systemic tree schema. For OP-8 and higher the design reuses the OP-7 logo,
 repeating it horizontally and shifting the hue to indicate progression.
+These PNGs are used by [`interface/module-logo.js`](../../../interface/module-logo.js) to show the current OP badge in the page header. The badge is positioned in the top-left corner via the `.op-status-link` rule in [`interface/css/nav.css`](../../../interface/css/nav.css).
+
+
 
 ---
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -95,7 +95,7 @@ README.md -> GET_STARTED.md -> index.html
 | `test/` | Node.js test suite |
 | `tools/` | Utility scripts (e.g., trust-demotion engine, reliability monitor, correction engine, Python API example) |
 | `use_cases/` | Example scenarios and dissemination ideas |
-| `sources/images/op-logo/` | Stages of the Tanna symbol |
+| [sources/images/op-logo/](../sources/images/op-logo/README_TANNA_OP0-OP7.md) | Stages of the Tanna symbol |
 | `wings/` | Minimal mobile interface |
 | `evidence/` | Datasets such as `person-ratings.json` |
 | `interface_OLD/` | Legacy version of the first interface |


### PR DESCRIPTION
## Summary
- link OP logo folder across docs
- clarify in OP logo README how the images are used for the user badge

## Testing
- `node --test`
- `node tools/check-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_6848432ce4f48321944f2fb40b29f296