### PR TITLE
Implement basic memory distribution

### DIFF
--- a/app/memory_config.json
+++ b/app/memory_config.json
@@ -1,0 +1,11 @@
+{
+  "total_units": 100,
+  "users": {
+    "userA": { "active": true, "units": 0 },
+    "userB": { "active": true, "units": 0 }
+  },
+  "gatekeepers": {
+    "gateA": { "active": true, "active_since": "2025-06-01T12:00:00Z" },
+    "gateB": { "active": true, "active_since": "2025-06-10T12:00:00Z" }
+  }
+}

--- a/test/memory-distributor.test.js
+++ b/test/memory-distributor.test.js
@@ -1,0 +1,35 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { distributeMemory } = require('../tools/memory-distributor');
+
+test('allocates units among active users', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mem-'));
+  const file = path.join(dir, 'mem.json');
+  const cfg = {
+    total_units: 90,
+    users: { A: { active: true, units: 0 }, B: { active: true, units: 0 } },
+    gatekeepers: { G: { active: true, active_since: '2024-01-01T00:00:00Z' } }
+  };
+  fs.writeFileSync(file, JSON.stringify(cfg));
+  assert.ok(distributeMemory(file));
+  const out = JSON.parse(fs.readFileSync(file, 'utf8'));
+  assert.strictEqual(out.users.A.units, 45);
+  assert.strictEqual(out.users.B.units, 45);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('skips when no active users', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mem-'));
+  const file = path.join(dir, 'mem.json');
+  const cfg = {
+    total_units: 50,
+    users: { A: { active: false, units: 0 } },
+    gatekeepers: { G: { active: true, active_since: '2024-01-01T00:00:00Z' } }
+  };
+  fs.writeFileSync(file, JSON.stringify(cfg));
+  assert.strictEqual(distributeMemory(file), false);
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/tools/memory-distributor.js
+++ b/tools/memory-distributor.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+
+function readConfig(filePath) {
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeConfig(cfg, filePath) {
+  fs.writeFileSync(filePath, JSON.stringify(cfg, null, 2));
+}
+
+function oldestGatekeeper(gatekeepers) {
+  if (!gatekeepers) return null;
+  return Object.entries(gatekeepers)
+    .filter(([, g]) => g.active)
+    .sort((a, b) => new Date(a[1].active_since) - new Date(b[1].active_since))[0];
+}
+
+function distributeMemory(filePath) {
+  const cfg = readConfig(filePath);
+  if (!cfg) return false;
+  const gk = oldestGatekeeper(cfg.gatekeepers);
+  if (!gk) return false;
+  const activeUsers = Object.entries(cfg.users || {}).filter(([, u]) => u.active);
+  if (activeUsers.length === 0) return false;
+  const per = Math.floor(cfg.total_units / activeUsers.length);
+  for (const [id, u] of Object.entries(cfg.users)) {
+    cfg.users[id].units = u.active ? per : 0;
+  }
+  writeConfig(cfg, filePath);
+  return true;
+}
+
+if (require.main === module) {
+  const cfgPath = process.argv[2] || path.join(__dirname, '..', 'app', 'memory_config.json');
+  if (distributeMemory(cfgPath)) {
+    console.log('Memory distributed.');
+  } else {
+    console.log('Distribution skipped.');
+  }
+}
+
+module.exports = { distributeMemory };

--- a/use_cases/memory_distributor.md
+++ b/use_cases/memory_distributor.md
@@ -1,0 +1,11 @@
+# Memory Distributor
+
+`tools/memory-distributor.js` assigns memory units to all active users. The oldest active gatekeeper triggers the distribution.
+
+Run the script with:
+
+```bash
+node tools/memory-distributor.js
+```
+
+The configuration lives in `app/memory_config.json` and updates after each run.


### PR DESCRIPTION
## Summary
- add `memory-distributor.js` tool to assign units to active users
- store configuration in `app/memory_config.json`
- document the feature in `use_cases/memory_distributor.md`
- cover distribution logic with `memory-distributor.test.js`

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_684849ad1e94832191a13ff71e8c6287