### PR TITLE
Add help flag for interface server

### DIFF
--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -136,6 +136,14 @@ try {
 
 const port = process.env.PORT || cfg.port || 8080;
 const baseUrl = process.env.BASE_URL || cfg.baseUrl || `http://localhost:${port}`;
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  console.log('Usage: node tools/serve-interface.js');
+  console.log('Starts a local server for the Ethicom interface.');
+  console.log(`Set PORT or cfg.port to change the port (default ${port}).`);
+  console.log('BASE_URL overrides the public origin for OAuth.');
+  process.exit(0);
+}
 const paths = cfg.paths || {};
 
 const usersFile = path.join(repoRoot, paths.users || 'app/users.json');


### PR DESCRIPTION
## Summary
- add `--help` output to `tools/serve-interface.js`

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_68489025e594832198de14123737fa48