### PR TITLE
Implement nested rating structure

### DIFF
--- a/docs/signaturdesign.md
+++ b/docs/signaturdesign.md
@@ -21,6 +21,8 @@ Beispiel: Für OP-9 (Signatur 4789) sind zehn verschachtelte Arrays erforderlich
 4789[x][y][z][a][b][c][d][e][f][g]
 ```
 
+Eine Referenzimplementierung findet sich in `utils/nested-rating.js`.
+
 Jede zusätzliche Ebene (x, y, z, …) entspricht einer weiteren Array-Schicht bis die Ziel-OP-Stufe erreicht ist. Danach folgt eine abschliessende Ebene zur Sicherung der Bewertung.
 
 ## Nickname pro Signatur

--- a/test/nested-rating.test.js
+++ b/test/nested-rating.test.js
@@ -1,0 +1,13 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { buildNestedRatings } = require('../utils/nested-rating.js');
+
+test('buildNestedRatings stores entries based on OP level', () => {
+  const list = [
+    { op_level: 'OP-0', rating: 'yes' },
+    { op_level: 'OP-2', rating: 'no' }
+  ];
+  const nested = buildNestedRatings(list);
+  assert.deepStrictEqual(nested[0][0], { op_level: 'OP-0', rating: 'yes' });
+  assert.deepStrictEqual(nested[0][1][2][0], { op_level: 'OP-2', rating: 'no' });
+});

--- a/utils/nested-rating.js
+++ b/utils/nested-rating.js
@@ -1,0 +1,29 @@
+const { opLevelToNumber } = require('./op-level.js');
+
+function storeRating(storage, rating) {
+  const level = opLevelToNumber(rating.op_level);
+  let arr = storage;
+  for (let i = 0; i < level; i++) {
+    if (!Array.isArray(arr[i])) arr[i] = [];
+    arr = arr[i];
+  }
+  if (!Array.isArray(arr[level])) arr[level] = [];
+  arr[level].push(rating);
+}
+
+function buildNestedRatings(list) {
+  const root = [];
+  list.forEach(r => storeRating(root, r));
+  return root;
+}
+
+if (require.main === module) {
+  const fs = require('fs');
+  const path = require('path');
+  const p = path.join(__dirname, '..', 'evidence', 'person-ratings.json');
+  const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+  const nested = buildNestedRatings(data);
+  console.log(JSON.stringify(nested, null, 2));
+}
+
+module.exports = { storeRating, buildNestedRatings };


### PR DESCRIPTION
## Summary
- implement example storage structure for ratings based on OP level
- document the reference in the signaturdesign docs
- test nested rating logic

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_684834f13ac88321baafb0a1e2cd8c4c