### PR TITLE
Add mechatronic control script

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 - [Generating Interface README](#generating-interface-readme)
 - [Gatekeeper Control](#gatekeeper-control)
 - [API Access Control](#api-access-control)
+- [Mechatronic Control](#mechatronic-control)
 - [OP Function Bundles](#op-function-bundles)
 - [Currency Synchronization](#currency-synchronization)
 - [Wiki Image Loader](#wiki-image-loader)
@@ -377,6 +378,19 @@ Copy that folder to another device and run `node gatekeeper.js <token>` for dele
 the operator level and confirmation flags from `app/user_state.yaml` and grants
 access only when the specified OP level is met and the user has confirmed
 ethical intent.
+
+### Mechatronic Control
+[⇧](#contents)
+
+`tools/mechatronic-control.js` verifies the operator level and gatekeeper
+status before allowing any automated action. Run
+
+```bash
+node tools/mechatronic-control.js OP-6 <token>
+```
+
+to attempt a mechatronic command. Replace `<token>` with a temporary gatekeeper
+token when required.
 
 ### OP Function Bundles
 [⇧](#contents)

--- a/operator/alphabetical_sublevels.md
+++ b/operator/alphabetical_sublevels.md
@@ -5,5 +5,8 @@ specialized tasks. Only **OP-9.A** is explicitly defined and reserved for the
 original developer with a veto right. New letters may describe further duties as
 the structure grows.
 
+- **OP-7.O** – may control mechatronic components when the gatekeeper and
+  ethics module confirm responsible use.
+
 If a signature exists but no sublevel is specified, permissions fall back to the
 base level—new registrations default to **OP-1**.

--- a/tools/mechatronic-control.js
+++ b/tools/mechatronic-control.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+const { gateCheck } = require('./gatekeeper.js');
+const { opLevelToNumber } = require('../utils/op-level.js');
+
+function parseUserState(filePath) {
+  const p = filePath || path.join(__dirname, '..', 'app', 'user_state.yaml');
+  if (!fs.existsSync(p)) return null;
+  const data = fs.readFileSync(p, 'utf8').split(/\r?\n/);
+  let op = null;
+  data.forEach(line => {
+    const m = line.match(/^\s*op_level:\s*(.*)$/);
+    if (m) op = m[1].replace(/['\"]/g, '');
+  });
+  return op;
+}
+
+function mechaAllowed(minLevel = 'OP-6', token) {
+  const level = parseUserState();
+  if (!level) return false;
+  const user = opLevelToNumber(level);
+  const req = opLevelToNumber(minLevel);
+  const cfg = path.join(__dirname, '..', 'app', 'gatekeeper_config.yaml');
+  const store = path.join(__dirname, '..', 'app', 'gatekeeper_devices.json');
+  const log = path.join(__dirname, '..', 'app', 'gatekeeper_log.json');
+  const gate = gateCheck(cfg, store, token, log);
+  return user >= req && gate;
+}
+
+if (require.main === module) {
+  const disclaimers = [
+    'Diese Struktur wird ohne Gew\u00e4hrleistung bereitgestellt.',
+    'Die Nutzung erfolgt auf eigene Verantwortung.',
+    '4789 ist ein Standard f\u00fcr Verantwortung, keine Person und kein Glaubenssystem.',
+    'Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung.'
+  ];
+  disclaimers.forEach(l => console.log(l));
+  const min = process.argv[2] || 'OP-6';
+  const token = process.argv[3];
+  if (mechaAllowed(min, token)) {
+    console.log('Mechatronic control allowed for', min);
+  } else {
+    console.log('Mechatronic control denied for', min);
+    process.exit(1);
+  }
+}
+
+module.exports = mechaAllowed;


### PR DESCRIPTION
## Summary
- add `tools/mechatronic-control.js` to gate mechatronic automation by OP level and gatekeeper
- document new helper in README
- note sublevel `OP-7.O` for mechatronic control

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6848bd44550c83218fb850106d26df40