### PR TITLE
Unify stylesheet and bundle usage

### DIFF
--- a/README.html
+++ b/README.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>README – Ethics Structure 4789</title>
   <link rel="stylesheet" href="interface/ethicom-style.css">
-<script src="interface/bundle.js" defer></script>
+  <script src="interface/bundle.js" defer></script>
+  <script src="utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/aari.html
+++ b/aari.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Aarulon.L</title>
+  <link rel="stylesheet" href="interface/ethicom-style.css">
+  <script src="interface/bundle.js" defer></script>
+  <script src="utils/op-level.js"></script>
   <meta http-equiv="refresh" content="0; url=aari/index.html">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <title>Admin – BSVRB</title>
+  <link rel="stylesheet" href="interface/ethicom-style.css">
+  <script src="interface/bundle.js" defer></script>
+  <script src="utils/op-level.js"></script>
 </head>
 <body>
   <h2>👋 Willkommen im Adminbereich</h2>

--- a/auth/github/index.html
+++ b/auth/github/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>GitHub Login Info</title>
   <link rel="stylesheet" href="../../interface/ethicom-style.css">
+  <script src="../../interface/bundle.js" defer></script>
+  <script src="../../utils/op-level.js"></script>
 </head>
 <body>
   <main class="card" style="margin:2em auto;max-width:600px;">

--- a/auth/google/index.html
+++ b/auth/google/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Google Login Info</title>
   <link rel="stylesheet" href="../../interface/ethicom-style.css">
+  <script src="../../interface/bundle.js" defer></script>
+  <script src="../../utils/op-level.js"></script>
 </head>
 <body>
   <main class="card" style="margin:2em auto;max-width:600px;">

--- a/beatclub-basel.html
+++ b/beatclub-basel.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>BSVRB – Beatclub Basel</title>
   <link rel="stylesheet" href="interface/ethicom-style.css">
-<script src="interface/bundle.js" defer></script>
+  <script src="interface/bundle.js" defer></script>
   <script src="utils/op-level.js"></script>
 </head>
 <body>

--- a/bewertung.html
+++ b/bewertung.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Bewertung</title>
   <link rel="stylesheet" href="interface/ethicom-style.css">
-<script src="interface/bundle.js" defer></script>
+  <script src="interface/bundle.js" defer></script>
   <script src="utils/op-level.js"></script>
 </head>
 <body>

--- a/bsvrb-dept-1.html
+++ b/bsvrb-dept-1.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>BSVRB – Gesellschaft / Bewegung / Plattform</title>
   <link rel="stylesheet" href="interface/ethicom-style.css">
-<script src="interface/bundle.js" defer></script>
+  <script src="interface/bundle.js" defer></script>
+  <script src="utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/bsvrb-dept-2.html
+++ b/bsvrb-dept-2.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>BSVRB – Bildung / Zukunft / Ethik</title>
   <link rel="stylesheet" href="interface/ethicom-style.css">
-<script src="interface/bundle.js" defer></script>
+  <script src="interface/bundle.js" defer></script>
+  <script src="utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/bsvrb-dept-3.html
+++ b/bsvrb-dept-3.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>BSVRB – Technik / Innovation / Forschung</title>
   <link rel="stylesheet" href="interface/ethicom-style.css">
-<script src="interface/bundle.js" defer></script>
+  <script src="interface/bundle.js" defer></script>
+  <script src="utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/bsvrb-dept-4.html
+++ b/bsvrb-dept-4.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>BSVRB – Gesellschaft + Genuss</title>
   <link rel="stylesheet" href="interface/ethicom-style.css">
-<script src="interface/bundle.js" defer></script>
+  <script src="interface/bundle.js" defer></script>
+  <script src="utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/bsvrb-dept-5.html
+++ b/bsvrb-dept-5.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>BSVRB – Für Kultur, Natur, Mensch &amp; Region</title>
   <link rel="stylesheet" href="interface/ethicom-style.css">
-<script src="interface/bundle.js" defer></script>
+  <script src="interface/bundle.js" defer></script>
+  <script src="utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/bsvrb-fischerabteilung.html
+++ b/bsvrb-fischerabteilung.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>PPB – Ökologische Fischerabteilung BSVRB</title>
   <link rel="stylesheet" href="interface/ethicom-style.css">
-<script src="interface/bundle.js" defer></script>
+  <script src="interface/bundle.js" defer></script>
+  <script src="utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/bsvrb-kulturabteilung.html
+++ b/bsvrb-kulturabteilung.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>PKB – Kunst- und Kulturabteilung BSVRB</title>
   <link rel="stylesheet" href="interface/ethicom-style.css">
-<script src="interface/bundle.js" defer></script>
+  <script src="interface/bundle.js" defer></script>
+  <script src="utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/bsvrb-quality.html
+++ b/bsvrb-quality.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>BSVRB – Qualitätskontrolle</title>
   <link rel="stylesheet" href="interface/ethicom-style.css">
-<script src="interface/bundle.js" defer></script>
+  <script src="interface/bundle.js" defer></script>
+  <script src="utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/bsvrb.ch/index.html
+++ b/bsvrb.ch/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>bsvrb.ch</title>
   <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
   <style>
     body { text-align: center; padding-top: 2em; }
     #chat_entry { font-size: 2em; margin: 1em 0; display: inline-block; }

--- a/bsvrb.ch/settings.html
+++ b/bsvrb.ch/settings.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Einstellungen</title>
   <link rel="stylesheet" href="../interface/ethicom-style.css">
-<script src="../interface/bundle.js" defer></script>
+  <script src="../interface/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
 </head>
 <body>

--- a/docs/README.html
+++ b/docs/README.html
@@ -4,8 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>README – Ethics Structure 4789</title>
-  <link rel="stylesheet" href="interface/ethicom-style.css">
-<script src="interface/bundle.js" defer></script>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>BSVRB</title>
-  <link rel="icon" href="sources/images/institutions/logo-bsvrb.svg" sizes="32x32">
   <link rel="stylesheet" href="interface/ethicom-style.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css">
   <script src="interface/bundle.js" defer></script>
   <script src="utils/op-level.js"></script>
+  <link rel="icon" href="sources/images/institutions/logo-bsvrb.svg" sizes="32x32">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css">
   <style>
     #departments_fallback.hidden { display: none; }
   </style>

--- a/interface/apple-hig.html
+++ b/interface/apple-hig.html
@@ -4,8 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Apple Human Interface Guidelines</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface/connect.html
+++ b/interface/connect.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Connect</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
 </head>
 <body>

--- a/interface/designregeln.html
+++ b/interface/designregeln.html
@@ -4,8 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Designregeln</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface/donate.html
+++ b/interface/donate.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Spenden</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
 </head>
 <body>

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -4,10 +4,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ethicom</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
-<script src="session.js"></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
+<script src="session.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface/fish-interface/fischEditor.html
+++ b/interface/fish-interface/fischEditor.html
@@ -5,17 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fische Editor</title>
   <link rel="stylesheet" href="../ethicom-style.css">
+  <script src="../bundle.js" defer></script>
   <script src="../../utils/op-level.js"></script>
-  <script src="../ethicom-utils.js"></script>
-  <script src="../color-utils.js"></script>
-  <script src="../accessibility.js"></script>
-  <script src="../auto-outline.js"></script>
-  <script src="../theme-manager.js"></script>
-  <script src="../logo-background.js"></script>
-  <script src="../side-drop.js"></script>
-  <script src="../op-side-nav.js"></script>
   <script src="fischEditor.js"></script>
-  <script src="../module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface/fish-interface/fischeBern.html
+++ b/interface/fish-interface/fischeBern.html
@@ -5,17 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fische Bern</title>
   <link rel="stylesheet" href="../ethicom-style.css">
+  <script src="../bundle.js" defer></script>
   <script src="../../utils/op-level.js"></script>
-  <script src="../ethicom-utils.js"></script>
-  <script src="../color-utils.js"></script>
-  <script src="../accessibility.js"></script>
-  <script src="../auto-outline.js"></script>
-  <script src="../theme-manager.js"></script>
-  <script src="../logo-background.js"></script>
-  <script src="../side-drop.js"></script>
-  <script src="../op-side-nav.js"></script>
   <script src="fischeBern.js"></script>
-  <script src="../module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface/fish-interface/fischeSchweiz.html
+++ b/interface/fish-interface/fischeSchweiz.html
@@ -5,17 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fische Schweiz</title>
   <link rel="stylesheet" href="../ethicom-style.css">
+  <script src="../bundle.js" defer></script>
   <script src="../../utils/op-level.js"></script>
-  <script src="../ethicom-utils.js"></script>
-  <script src="../color-utils.js"></script>
-  <script src="../accessibility.js"></script>
-  <script src="../auto-outline.js"></script>
-  <script src="../theme-manager.js"></script>
-  <script src="../logo-background.js"></script>
-  <script src="../side-drop.js"></script>
-  <script src="../op-side-nav.js"></script>
   <script src="fischeSchweiz.js"></script>
-  <script src="../module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface/fish-interface/gewaesserBern.html
+++ b/interface/fish-interface/gewaesserBern.html
@@ -5,17 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Gewässer Bern</title>
   <link rel="stylesheet" href="../ethicom-style.css">
+  <script src="../bundle.js" defer></script>
   <script src="../../utils/op-level.js"></script>
-  <script src="../ethicom-utils.js"></script>
-  <script src="../color-utils.js"></script>
-  <script src="../accessibility.js"></script>
-  <script src="../auto-outline.js"></script>
-  <script src="../theme-manager.js"></script>
-  <script src="../logo-background.js"></script>
-  <script src="../side-drop.js"></script>
-  <script src="../op-side-nav.js"></script>
   <script src="gewaesserBern.js"></script>
-  <script src="../module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface/fish-interface/gewaesserCH.html
+++ b/interface/fish-interface/gewaesserCH.html
@@ -5,18 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Gewässer Schweiz</title>
   <link rel="stylesheet" href="../ethicom-style.css">
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
+  <script src="../bundle.js" defer></script>
   <script src="../../utils/op-level.js"></script>
-  <script src="../ethicom-utils.js"></script>
-  <script src="../color-utils.js"></script>
-  <script src="../accessibility.js"></script>
-  <script src="../auto-outline.js"></script>
-  <script src="../theme-manager.js"></script>
-  <script src="../logo-background.js"></script>
-  <script src="../side-drop.js"></script>
-  <script src="../op-side-nav.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
   <script src="gewaesserCH.js"></script>
-  <script src="../module-logo.js"></script>
   <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
 </head>
 <body>

--- a/interface/fish.html
+++ b/interface/fish.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fish Interface</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
 </head>
 <body>

--- a/interface/gatekeeper.html
+++ b/interface/gatekeeper.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Gatekeeper</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
-<script src="disclaimer.js"></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
 </head>
 <body>
   <div id="op_background"></div>

--- a/interface/hermes.html
+++ b/interface/hermes.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Hermes</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
 </head>
 <body>

--- a/interface/login.html
+++ b/interface/login.html
@@ -4,10 +4,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Login – BSVRB</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
-<script src="session.js"></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
+<script src="session.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface/material.html
+++ b/interface/material.html
@@ -4,8 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Material Design Prinzipien</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface/navigator.html
+++ b/interface/navigator.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Navigator</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
 </head>
 <body>

--- a/interface/nielsen.html
+++ b/interface/nielsen.html
@@ -4,8 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Nielsens Heuristiken</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface/norman.html
+++ b/interface/norman.html
@@ -4,8 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Normans Prinzipien</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface/offline-signup.html
+++ b/interface/offline-signup.html
@@ -4,8 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Offline Signup</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface/op-story.html
+++ b/interface/op-story.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>OP Story</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
 </head>
 <body>

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Settings</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
 </head>
 <body>

--- a/interface/shneiderman.html
+++ b/interface/shneiderman.html
@@ -4,8 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Shneidermans Regeln</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Registrierung – BSVRB</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
 </head>
 <body>

--- a/interface/start.html
+++ b/interface/start.html
@@ -4,10 +4,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>BSVRB Interface</title>
-  <link rel="icon" href="../sources/images/institutions/logo-bsvrb.svg" sizes="32x32">
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
+  <link rel="icon" href="../sources/images/institutions/logo-bsvrb.svg" sizes="32x32">
   <style>
     .op-list { list-style: none; padding: 0; }
     .op-list li { margin-bottom: 0.6em; display: flex; align-items: center; gap: 0.4em; }

--- a/interface/tanna-animation.html
+++ b/interface/tanna-animation.html
@@ -4,8 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Tanna Animation</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-<script src="bundle.js" defer></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface/time-tool.html
+++ b/interface/time-tool.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Time Tool</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-  <script src="bundle.js" defer></script>
-  <script src="disclaimer.js"></script>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
 </head>
 <body>
   <div id="op_background"></div>

--- a/interface_OLD/README.html
+++ b/interface_OLD/README.html
@@ -4,11 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>README</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-  <script src="side-drop.js"></script>
-  <script src="op-side-nav.js"></script>
-  <script src="../interface/logo-background.js"></script>
-  <script src="../interface/module-logo.js"></script>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
   <style>body{white-space:pre-wrap;font-family:monospace;color:#fff;background:#000;padding:1em;}</style>
 </head>
 <body>
@@ -40,7 +38,6 @@ For OP-6 and above, the generator can optionally store a hashed passport or ID l
 ## Interface Overview
 
 - `ethicom.html` → loads modular interface per OP-level
-- `ethicom-style.css` → dark mode, badge colors, minimal energy
 - `signature-generator.js` → local signature creation (e.g. `SIG-XXXX-XXXX-XXXX`); for OP-6+ it can store a hashed passport/ID locally
 - `signature-verifier.js` → hash & password check before activation
 - `interface-loader.js` → loads correct module for OP-0 to OP-12 and extra tools
@@ -90,7 +87,6 @@ The range from OP-0 to OP-3 forms the editing stage (*Bearbeitungsstufe*) where 
 ```plaintext
 interface/
 ├── ethicom.html
-├── ethicom-style.css
 ├── signature-generator.js
 ├── signature-verifier.js
 ├── interface-loader.js

--- a/interface_OLD/about.html
+++ b/interface_OLD/about.html
@@ -4,21 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Über das Modul</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-  <script src="language-selector.js"></script>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
-  <script src="ethicom-utils.js"></script>
-  <script src="translation-manager.js"></script>
-  <script src="interface-loader.js"></script>
-  <script src="disclaimer.js"></script>
-  <script src="color-auth.js"></script>
-  <script src="theme-manager.js"></script>
-  <script src="../interface/logo-background.js"></script>
-  <script src="touch-features.js"></script>
-  <script src="module-arranger.js"></script>
-  <script src="side-drop.js"></script>
-  <script src="op-side-nav.js"></script>
-  <script src="../interface/module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/chat.html
+++ b/interface_OLD/chat.html
@@ -4,18 +4,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Chat</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-  <script src="interface-loader.js"></script>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
   <script src="signature-verifier.js"></script>
-  <script src="language-selector.js"></script>
-  <script src="color-auth.js"></script>
-  <script src="theme-manager.js"></script>
-  <script src="../interface/logo-background.js"></script>
-  <script src="touch-features.js"></script>
-  <script src="module-arranger.js"></script>
-  <script src="side-drop.js"></script>
-  <script src="op-side-nav.js"></script>
-  <script src="../interface/module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/erstkontakt.html
+++ b/interface_OLD/erstkontakt.html
@@ -4,23 +4,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Willkommen</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-  <script src="language-selector.js"></script>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
   <script src="signature-strength.js"></script>
   <script src="ratings.js"></script>
-  <script src="interface-loader.js"></script>
-  <script src="translation-manager.js"></script>
   <script src="dynamic-info.js"></script>
   <script src="op-overview.js"></script>
-  <script src="disclaimer.js"></script>
-  <script src="color-auth.js"></script>
-  <script src="theme-manager.js"></script>
-  <script src="../interface/logo-background.js"></script>
-  <script src="touch-features.js"></script>
-  <script src="module-arranger.js"></script>
-  <script src="side-drop.js"></script>
-  <script src="op-side-nav.js"></script>
-  <script src="../interface/module-logo.js"></script>
   <style>
     #op_interface { margin-top: 1em; }
   </style>

--- a/interface_OLD/ethicom.html
+++ b/interface_OLD/ethicom.html
@@ -4,30 +4,16 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ethik-Kompass</title>
-  <link rel="stylesheet" href="ethicom-style.css">
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
-  <script src="ethicom-utils.js"></script>
   <script src="evidence-recorder.js"></script>
   <script src="signature-verifier.js"></script>
-  <script src="interface-loader.js"></script>
-  <script src="language-selector.js"></script>
-  <script src="translation-manager.js"></script>
-  <script src="accessibility.js"></script>
-  <script src="auto-outline.js"></script>
   <script src="dynamic-help.js"></script>
   <script src="dynamic-info.js"></script>
-  <script src="theme-manager.js"></script>
-  <script src="disclaimer.js"></script>
   <script src="dev-mode.js"></script>
   <script src="op0-testmode.js"></script>
-  <script src="../interface/logo-background.js"></script>
   <script src="attention-seeker.js"></script>
-  <script src="touch-features.js"></script>
-  <script src="color-auth.js"></script>
-  <script src="module-arranger.js"></script>
-  <script src="side-drop.js"></script>
-  <script src="op-side-nav.js"></script>
-  <script src="../interface/module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/ethikom.html
+++ b/interface_OLD/ethikom.html
@@ -4,30 +4,16 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ethik-Kompass</title>
-  <link rel="stylesheet" href="ethicom-style.css">
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
-  <script src="ethicom-utils.js"></script>
   <script src="evidence-recorder.js"></script>
   <script src="signature-verifier.js"></script>
-  <script src="interface-loader.js"></script>
-  <script src="language-selector.js"></script>
-  <script src="translation-manager.js"></script>
-  <script src="accessibility.js"></script>
-  <script src="auto-outline.js"></script>
   <script src="dynamic-help.js"></script>
   <script src="dynamic-info.js"></script>
-  <script src="theme-manager.js"></script>
-  <script src="disclaimer.js"></script>
   <script src="dev-mode.js"></script>
   <script src="op0-testmode.js"></script>
-  <script src="../interface/logo-background.js"></script>
   <script src="attention-seeker.js"></script>
-  <script src="touch-features.js"></script>
-  <script src="color-auth.js"></script>
-  <script src="module-arranger.js"></script>
-  <script src="side-drop.js"></script>
-  <script src="op-side-nav.js"></script>
-  <script src="../interface/module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/page-flow-demo.html
+++ b/interface_OLD/page-flow-demo.html
@@ -4,14 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Page Flow Demo</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-  <script src="theme-manager.js"></script>
-  <script src="../interface/logo-background.js"></script>
-  <script src="touch-features.js"></script>
-  <script src="module-arranger.js"></script>
-  <script src="side-drop.js"></script>
-  <script src="op-side-nav.js"></script>
-  <script src="../interface/module-logo.js"></script>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
   <style>
     #flow {
       display: flex;

--- a/interface_OLD/ratings.html
+++ b/interface_OLD/ratings.html
@@ -4,18 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Bewertungen</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-  <script src="language-selector.js"></script>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
   <script src="signature-strength.js"></script>
   <script src="ratings.js"></script>
-  <script src="color-auth.js"></script>
-  <script src="theme-manager.js"></script>
-  <script src="../interface/logo-background.js"></script>
-  <script src="touch-features.js"></script>
-  <script src="module-arranger.js"></script>
-  <script src="side-drop.js"></script>
-  <script src="op-side-nav.js"></script>
-  <script src="../interface/module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/settings.html
+++ b/interface_OLD/settings.html
@@ -4,22 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Einstellungen</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-  <script src="language-selector.js"></script>
-  <script src="translation-manager.js"></script>
-  <script src="theme-manager.js"></script>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
   <script src="dev-mode.js"></script>
   <script src="op0-testmode.js"></script>
-  <script src="accessibility.js"></script>
-  <script src="auto-outline.js"></script>
-  <script src="color-auth.js"></script>
   <script src="attention-seeker.js"></script>
-  <script src="touch-features.js"></script>
-  <script src="../interface/logo-background.js"></script>
-  <script src="module-arranger.js"></script>
-  <script src="side-drop.js"></script>
-  <script src="op-side-nav.js"></script>
-  <script src="../interface/module-logo.js"></script>
 </head>
 <body class="left-layout">
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/signup.html
+++ b/interface_OLD/signup.html
@@ -4,19 +4,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Registrierung</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-  <script src="language-selector.js"></script>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
-  <script src="ethicom-utils.js"></script>
   <script src="signup.js"></script>
-  <script src="color-auth.js"></script>
-  <script src="theme-manager.js"></script>
-  <script src="../interface/logo-background.js"></script>
-  <script src="touch-features.js"></script>
-  <script src="module-arranger.js"></script>
-  <script src="side-drop.js"></script>
-  <script src="op-side-nav.js"></script>
-  <script src="../interface/module-logo.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/tanna-tabs.html
+++ b/interface_OLD/tanna-tabs.html
@@ -4,10 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Ethicom 4789</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-  <script src="theme-manager.js"></script>
-  <script src="../interface/logo-background.js"></script>
-  <script src="../interface/module-logo.js"></script>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
   <style>
     body {
       margin: 0;

--- a/interface_OLD/tanna-template-dark.html
+++ b/interface_OLD/tanna-template-dark.html
@@ -4,13 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Template</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-  <script src="theme-manager.js"></script>
-  <script src="../interface/logo-background.js"></script>
-  <script src="../interface/module-logo.js"></script>
-  <script src="module-arranger.js"></script>
-  <script src="side-drop.js"></script>
-  <script src="op-side-nav.js"></script>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/tanna-template-light.html
+++ b/interface_OLD/tanna-template-light.html
@@ -4,13 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Template</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-  <script src="theme-manager.js"></script>
-  <script src="../interface/logo-background.js"></script>
-  <script src="../interface/module-logo.js"></script>
-  <script src="module-arranger.js"></script>
-  <script src="side-drop.js"></script>
-  <script src="op-side-nav.js"></script>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/tanna-template.html
+++ b/interface_OLD/tanna-template.html
@@ -4,13 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Template</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-  <script src="theme-manager.js"></script>
-  <script src="../interface/logo-background.js"></script>
-  <script src="../interface/module-logo.js"></script>
-  <script src="module-arranger.js"></script>
-  <script src="side-drop.js"></script>
-  <script src="op-side-nav.js"></script>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/interface_OLD/tools.html
+++ b/interface_OLD/tools.html
@@ -4,19 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Tools</title>
-  <link rel="stylesheet" href="ethicom-style.css">
-  <script src="interface-loader.js"></script>
-  <script src="language-selector.js"></script>
-  <script src="translation-manager.js"></script>
-  <script src="color-auth.js"></script>
-  <script src="theme-manager.js"></script>
-  <script src="disclaimer.js"></script>
-  <script src="../interface/logo-background.js"></script>
-  <script src="touch-features.js"></script>
-  <script src="module-arranger.js"></script>
-  <script src="side-drop.js"></script>
-  <script src="op-side-nav.js"></script>
-  <script src="../interface/module-logo.js"></script>
+  <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/login.html
+++ b/login.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login – BSVRB</title>
+  <link rel="stylesheet" href="interface/ethicom-style.css">
+  <script src="interface/bundle.js" defer></script>
+  <script src="utils/op-level.js"></script>
 </head>
 <body>
   <h2>Login</h2>

--- a/org-bewertung.html
+++ b/org-bewertung.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Organisationsbewertung</title>
   <link rel="stylesheet" href="interface/ethicom-style.css">
-<script src="interface/bundle.js" defer></script>
+  <script src="interface/bundle.js" defer></script>
   <script src="utils/op-level.js"></script>
 </head>
 <body>

--- a/personenbewertung.html
+++ b/personenbewertung.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Personenbewertung</title>
   <link rel="stylesheet" href="interface/ethicom-style.css">
-<script src="interface/bundle.js" defer></script>
+  <script src="interface/bundle.js" defer></script>
   <script src="utils/op-level.js"></script>
 </head>
 <body>

--- a/signup.html
+++ b/signup.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="utf-8">
   <title>Signup</title>
+  <link rel="stylesheet" href="interface/ethicom-style.css">
+  <script src="interface/bundle.js" defer></script>
+  <script src="utils/op-level.js"></script>
 </head>
 <body>
   <p>Weiter zur <a href="interface/signup.html">Registrierung</a>.</p>

--- a/template.html
+++ b/template.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Seitenvorlage</title>
   <link rel="stylesheet" href="interface/ethicom-style.css">
-<script src="interface/bundle.js" defer></script>
+  <script src="interface/bundle.js" defer></script>
+  <script src="utils/op-level.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/tools/unify-html.js
+++ b/tools/unify-html.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+
+function listHtml(dir) {
+  let out = [];
+  for (const entry of fs.readdirSync(dir, {withFileTypes:true})) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) out = out.concat(listHtml(p));
+    else if (entry.isFile() && entry.name.endsWith('.html')) out.push(p);
+  }
+  return out;
+}
+
+function relPath(file, target) {
+  return path.relative(path.dirname(file), path.join(root, target)).replace(/\\/g,'/') + '/';
+}
+
+function process(file) {
+  const skip = ['interface/op-navigation.html','interface/nav-menu.html','interface_OLD/op-navigation.html','aari/index.html'];
+  const rel = path.relative(root, file).replace(/\\/g,'/');
+  if (skip.includes(rel)) return;
+  let text = fs.readFileSync(file, 'utf8');
+  if (!text.includes('<!DOCTYPE html>')) return;
+
+  const lines = text.split(/\n/);
+  const out = [];
+  const cssPath = relPath(file,'interface');
+  const utilsPath = relPath(file,'utils');
+  let inserted = false;
+
+  for (const line of lines) {
+    if (/ethicom-style\.css/.test(line)) continue;
+    if (/script.*interface\//.test(line) && !/bundle\.js/.test(line)) continue;
+    if (/script.*(ethicom-utils|color-utils|color-auth|disclaimer|accessibility|auto-outline|theme-manager|logo-background|side-drop|op-side-nav|module-logo|translation-manager|interface-loader|language-selector|touch-features|module-arranger|version)\.js/.test(line)) continue;
+    if (/script.*bundle\.js/.test(line)) continue;
+    if (/script.*op-level\.js/.test(line)) continue;
+    out.push(line);
+    if (!inserted && /<title/.test(line)) {
+      out.push(`  <link rel="stylesheet" href="${cssPath}ethicom-style.css">`);
+      out.push(`  <script src="${cssPath}bundle.js" defer></script>`);
+      out.push(`  <script src="${utilsPath}op-level.js"></script>`);
+      inserted = true;
+    }
+  }
+
+  if (!inserted) {
+    const idx = out.findIndex(l=>/<head>/.test(l));
+    if (idx >= 0) {
+      out.splice(idx+1,0,
+        `  <link rel="stylesheet" href="${cssPath}ethicom-style.css">`,
+        `  <script src="${cssPath}bundle.js" defer></script>`,
+        `  <script src="${utilsPath}op-level.js"></script>`);
+    }
+  }
+
+  fs.writeFileSync(file, out.join('\n'));
+}
+
+for (const f of listHtml(root)) {
+  process(f);
+}

--- a/verax/index.html
+++ b/verax/index.html
@@ -5,10 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Verax</title>
   <link rel="stylesheet" href="../interface/ethicom-style.css">
+  <script src="../interface/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
   <link rel="stylesheet" href="style.css">
-  <script src="../interface/theme-manager.js"></script>
-  <script src="../interface/logo-background.js"></script>
-  <script src="../interface/module-logo.js"></script>
 </head>
 <body>
   <div id="op_background" aria-hidden="true"></div>

--- a/verax/map/leaflet.html
+++ b/verax/map/leaflet.html
@@ -3,14 +3,13 @@
 <head>
   <meta charset="utf-8" />
   <title>VERAX Karte</title>
+  <link rel="stylesheet" href="../../interface/ethicom-style.css">
+  <script src="../../interface/bundle.js" defer></script>
+  <script src="../../utils/op-level.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="../../interface/ethicom-style.css" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
   <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-gpx/1.5.1/gpx.min.js"></script>
-  <script src="../../interface/theme-manager.js"></script>
-  <script src="../../interface/logo-background.js"></script>
-  <script src="../../interface/module-logo.js"></script>
   <style>
     body, html { margin: 0; padding: 0; }
     #map { height: 100vh; width: 100vw; }

--- a/wings/index.html
+++ b/wings/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <title>Wings</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="../interface/ethicom-style.css">
-<script src="../interface/bundle.js" defer></script>
-  <link rel="stylesheet" href="wings-style.css" />
+  <script src="../interface/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="wings-style.css" />
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>

--- a/wings/ratings.html
+++ b/wings/ratings.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Bewertungen</title>
   <link rel="stylesheet" href="../interface/ethicom-style.css">
-<script src="../interface/bundle.js" defer></script>
-  <link rel="stylesheet" href="wings-style.css" />
+  <script src="../interface/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
+  <link rel="stylesheet" href="wings-style.css" />
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>


### PR DESCRIPTION
## Summary
- add `unify-html.js` script for automatic cleanup
- reference `interface/ethicom-style.css` in every page
- load `bundle.js` with `op-level.js` to simplify headers

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6848bf49b4d48321a48d31bc2566c4ef