### PR TITLE
Add standalone Tanna demo page

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
         <li><a href="beatclub-basel.html">Beatclub Basel</a> – Bier, Solidarität, Vielfalt, Rave &amp; Beats.</li>
         <li><a href="grimmhorn.html">Grimmhorn</a> – Raum für laute Experimente.</li>
         <li><a href="wings/index.html">Wings</a> – Ethik-Kompass für technologische Projekte.</li>
+        <li><a href="interface/tanna-registers.html">Tanna Demo</a> – Hintergrundanimation.</li>
       </ul>
     </section>
 

--- a/interface/tanna-registers.html
+++ b/interface/tanna-registers.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tanna Background</title>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main_content">Skip to main content</a>
+  <div id="op_background"></div>
+  <main id="main_content"></main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `interface/tanna-registers.html` with only the animated background so logged-in users just see their registers
- link the new demo from the project list in `index.html`

## Testing
- `node --test`
- `node tools/check-translations.js`


------
https://chatgpt.com/codex/tasks/task_e_6848bdaf00448321bc461c6d7bb739a9