### PR TITLE
Implement anonymous input synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 | [sources/images/op-logo/](sources/images/op-logo/README_TANNA_OP0-OP7.md) | Stages of the Tanna symbol |
 | `wings/` | Minimal mobile interface |
 | `evidence/` | Datasets such as `person-ratings.json` |
+| `anon_inputs/` | Anonymized user inputs aggregated by `anon-input-sync.js` |
 | `references/` | Reference tables and scores |
 
 

--- a/anon_inputs/README.md
+++ b/anon_inputs/README.md
@@ -1,0 +1,3 @@
+# Anonymous Inputs
+
+This folder collects anonymized user inputs, organized as one JSON file per entry. Each input should contain a `question_id`, `answer`, `details`, `op_level` and `alias` field.

--- a/anon_inputs/sample1.json
+++ b/anon_inputs/sample1.json
@@ -1,0 +1,1 @@
+{"question_id":"q1","answer":"yes","details":"example answer","op_level":"OP-1","alias":"anon@OP-1"}

--- a/anon_inputs/sample2.json
+++ b/anon_inputs/sample2.json
@@ -1,0 +1,1 @@
+{"question_id":"q1","answer":"no","details":"longer example answer text","op_level":"OP-3","alias":"tester@OP-3"}

--- a/anon_inputs/sample3.json
+++ b/anon_inputs/sample3.json
@@ -1,0 +1,1 @@
+{"question_id":"q2","answer":"yes","details":"different question","op_level":"OP-2","alias":"user@OP-2"}

--- a/test/anon-input-sync.test.js
+++ b/test/anon-input-sync.test.js
@@ -1,0 +1,29 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { writeSummary } = require('../tools/anon-input-sync');
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'anon-'));
+}
+
+test('aggregates anonymous inputs', () => {
+  const dir = tmpDir();
+  const out = path.join(dir, 'summary.json');
+  const inputs = [
+    { question_id: 'q1', answer: 'yes', details: 'a', op_level: 'OP-1', alias: 'a@OP-1' },
+    { question_id: 'q1', answer: 'no', details: 'long text', op_level: 'OP-3', alias: 'b@OP-3' },
+    { question_id: 'q2', answer: 'yes', details: 'c', op_level: 'OP-2', alias: 'c@OP-2' }
+  ];
+  inputs.forEach((obj, i) => {
+    fs.writeFileSync(path.join(dir, `in${i}.json`), JSON.stringify(obj));
+  });
+  const summary = writeSummary(dir, out);
+  assert.strictEqual(summary.q1.count, 2);
+  assert.strictEqual(summary.q1.highest_op, 'OP-3');
+  assert.strictEqual(summary.q1.detailed_response, 'long text');
+  assert.strictEqual(summary.q2.count, 1);
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/tools/anon-input-sync.js
+++ b/tools/anon-input-sync.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+const { opLevelToNumber } = require('../utils/op-level.js');
+
+function loadInputs(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir)
+    .filter(f => f.endsWith('.json'))
+    .map(f => {
+      const data = fs.readFileSync(path.join(dir, f), 'utf8');
+      try {
+        return JSON.parse(data);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+function summarize(list) {
+  const summary = {};
+  list.forEach(entry => {
+    const q = entry.question_id;
+    if (!summary[q]) {
+      summary[q] = {
+        count: 0,
+        answers: {},
+        highest_op: 'OP-0',
+        detailed_response: ''
+      };
+    }
+    const info = summary[q];
+    info.count += 1;
+    info.answers[entry.answer] = (info.answers[entry.answer] || 0) + 1;
+    if (entry.details && entry.details.length > info.detailed_response.length) {
+      info.detailed_response = entry.details;
+    }
+    const lvl = opLevelToNumber(entry.op_level);
+    const cur = opLevelToNumber(info.highest_op);
+    if (lvl > cur) info.highest_op = entry.op_level;
+  });
+
+  for (const q of Object.keys(summary)) {
+    const info = summary[q];
+    const pct = {};
+    for (const [ans, num] of Object.entries(info.answers)) {
+      pct[ans] = +(num / info.count * 100).toFixed(2);
+    }
+    info.average = pct;
+  }
+  return summary;
+}
+
+function writeSummary(dir, outFile) {
+  const list = loadInputs(dir);
+  const summary = summarize(list);
+  fs.writeFileSync(outFile, JSON.stringify(summary, null, 2));
+  return summary;
+}
+
+if (require.main === module) {
+  const dir = path.join(__dirname, '..', 'anon_inputs');
+  const out = path.join(__dirname, '..', 'references', 'anon-input-summary.json');
+  const summary = writeSummary(dir, out);
+  console.log('Summary written for', Object.keys(summary).length, 'questions');
+}
+
+module.exports = { loadInputs, summarize, writeSummary };


### PR DESCRIPTION
## Summary
- add `anon_inputs/` folder with example entries
- implement `tools/anon-input-sync.js` to aggregate anonymous inputs
- cover the new script with `anon-input-sync.test.js`
- document the folder in `README.md`

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_68495041d2748321b47983b59b5b0387