### PR TITLE
Add minimal ChatGPT helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Thumbs.db
 # Python bytecode
 __pycache__/
 *.py[cod]
+aari/config.json

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 5. For quick static hosting, deploy the interface on
    [Netsly](interface/deploy_netsly.md) or
    [Hostpoint](interface/deploy_hostpoint.md).
+6. For the minimal Python helper see [docs/how_to_use.md](docs/how_to_use.md).
 
 ```
     +-----------+

--- a/aari/chat.py
+++ b/aari/chat.py
@@ -1,0 +1,27 @@
+import openai
+import json
+
+CONFIG_PATH = "aari/config.json"
+
+def load_config(path=CONFIG_PATH):
+    """Load API configuration."""
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def frage_chatgpt(prompt: str) -> str:
+    """Send prompt to ChatGPT and return the response."""
+    config = load_config()
+    openai.api_key = config.get("api_key", "")
+    response = openai.ChatCompletion.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.5,
+    )
+    return response.choices[0].message.content
+
+
+if __name__ == "__main__":
+    prompt = input("Aarulon hört zu: ")
+    antwort = frage_chatgpt(prompt)
+    print("Antwort:", antwort)

--- a/aari/listen.py
+++ b/aari/listen.py
@@ -1,0 +1,17 @@
+"""Simple speech input using the speech_recognition package."""
+
+import speech_recognition as sr
+
+
+def hoere() -> str:
+    """Capture audio from the microphone and return recognized text."""
+    recognizer = sr.Recognizer()
+    with sr.Microphone() as source:
+        print("Sprechen...")
+        audio = recognizer.listen(source)
+    try:
+        return recognizer.recognize_google(audio, language="de-DE")
+    except sr.UnknownValueError:
+        return ""
+    except sr.RequestError as exc:
+        raise RuntimeError(f"Recognition request failed: {exc}")

--- a/aari/say.py
+++ b/aari/say.py
@@ -1,0 +1,8 @@
+import pyttsx3
+
+
+def spreche(text: str) -> None:
+    """Vocalize text using the default speech engine."""
+    engine = pyttsx3.init()
+    engine.say(text)
+    engine.runAndWait()

--- a/docs/how_to_use.md
+++ b/docs/how_to_use.md
@@ -1,0 +1,16 @@
+# How to Use Aarulon
+
+This short guide shows how to run the minimal ChatGPT helper.
+
+1. Install the Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Put your OpenAI key in `aari/config.json`.
+3. Run the script:
+   ```bash
+   python3 aari/chat.py
+   ```
+4. Optionally call `spreche()` from `aari/say.py` to read answers aloud.
+
+Use responsibly as described in [LICENSE.txt](LICENSE.txt).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2
 pyttsx3>=2
+openai>=1

--- a/web/aari.html
+++ b/web/aari.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Aarulon Interface</title>
+</head>
+<body>
+  <h1>Aarulon Interface</h1>
+  <input id="prompt" type="text" placeholder="Frag mich etwas!">
+  <button onclick="sendePrompt()">Fragen</button>
+  <pre id="antwort"></pre>
+
+  <script>
+    async function sendePrompt() {
+      const prompt = document.getElementById("prompt").value;
+      const response = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt })
+      });
+      const result = await response.json();
+      document.getElementById("antwort").textContent = result.antwort;
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a simple Python helper for ChatGPT interaction in `aari/`
- provide a speech output module
- add a speech input example
- ignore `aari/config.json`
- document how to run the helper
- link the guide from README
- include a small HTML demo page
- add the `openai` dependency

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_6849f4cbd6f08321bb0bd7738a673f5e