### PR TITLE
Add Telegram bot script

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 | `sources/images/` | Pictures for institutions (`institutions/`), persons (`persons/`), and fish (`fish/`) |
 | `sources/fish/ch/` | Text placeholders for Swiss fish images (e.g., `esox_ch.png`) |
 | `test/` | Node.js test suite |
-| `tools/` | Utility scripts (e.g., trust-demotion engine, reliability monitor, correction engine, Python API example, `text_to_speech.py`) |
-| `use_cases/` | Example scenarios and dissemination ideas |
+| `tools/` | Utility scripts (e.g., trust-demotion engine, reliability monitor, correction engine, Python API example, `text_to_speech.py`, `telegram-bot.js`) |
+| `use_cases/` | Example scenarios and dissemination ideas (e.g., `telegram_bot.md`) |
 | [sources/images/op-logo/](sources/images/op-logo/README_TANNA_OP0-OP7.md) | Stages of the Tanna symbol |
 | `wings/` | Minimal mobile interface |
 | `evidence/` | Datasets such as `person-ratings.json` |

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "tools/serve-interface.js",
   "dependencies": {
     "canvas": "^2.11.2",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "node-telegram-bot-api": "^0.66.0"
   },
   "engines": {
     "node": ">=18"
@@ -17,6 +18,7 @@
     "serve-gh": "BASE_URL=https://4789-alpha.github.io node tools/serve-interface.js",
     "bundle-interface": "node tools/bundle-interface.js",
     "generate-wiki": "node tools/generate-wiki.js",
-    "test": "node --test && node tools/check-translations.js && node tools/check-file-integrity.js"
+    "test": "node --test && node tools/check-translations.js && node tools/check-file-integrity.js",
+    "telegram-bot": "node tools/telegram-bot.js"
   }
 }

--- a/tools/telegram-bot.js
+++ b/tools/telegram-bot.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * Minimal Telegram bot for 4789ethics.
+ *
+ * Requires TELEGRAM_TOKEN and TELEGRAM_CHAT_ID environment variables.
+ * The bot echoes messages from the configured chat.
+ */
+const TelegramBot = require('node-telegram-bot-api');
+
+function startBot() {
+  const token = process.env.TELEGRAM_TOKEN;
+  const chatId = process.env.TELEGRAM_CHAT_ID;
+  if (!token || !chatId) {
+    console.error('TELEGRAM_TOKEN and TELEGRAM_CHAT_ID must be set');
+    return;
+  }
+  const bot = new TelegramBot(token, { polling: true });
+  console.log('Telegram bot running');
+  bot.on('message', msg => {
+    if (String(msg.chat.id) !== String(chatId)) return;
+    if (msg.text) {
+      bot.sendMessage(chatId, `Echo: ${msg.text}`);
+    }
+  });
+}
+
+if (require.main === module) {
+  startBot();
+} else {
+  module.exports = startBot;
+}

--- a/use_cases/telegram_bot.md
+++ b/use_cases/telegram_bot.md
@@ -1,0 +1,10 @@
+# Telegram Bot Integration
+
+`tools/telegram-bot.js` provides a minimal echo bot for Telegram.
+
+1. Install dependencies with `npm install`.
+2. Set `TELEGRAM_TOKEN` and `TELEGRAM_CHAT_ID` as environment variables.
+3. Run `npm run telegram-bot` to start polling.
+
+The bot echoes any message sent in the configured chat. Adjust the code to add
+further logic. Network access is required for Telegram API calls.


### PR DESCRIPTION
## Summary
- add Telegram bot script and usage notes
- document in README and add a new use case
- expose script via npm run script in package.json

## Testing
- `npm test`
- `node tools/check-translations.js && node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_6849f95e76648321aa77eca4fb3e7c3a