### PR TITLE
Update smartphone setup with canvas note

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,9 @@ tools/auto-gatekeeper-setup.sh
 node tools/gatekeeper-gui.js
 ```
 Open the printed URL in the mobile browser and follow the on‑screen steps.
+Termux lacks a pre‑built binary for the `canvas` package.
+Install `clang make pkg-config libjpeg-turbo cairo pango freetype libpng librsvg` to compile it.
+`canvas` is only required for the image tools; gatekeeper functions run without it.
 
 ### Automated Data Setup
 [⇧](#contents)


### PR DESCRIPTION
## Summary
- mention missing canvas binary on Termux in README
- list Termux packages needed to build canvas
- note that canvas is optional for gatekeeper functions

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684aaeb493548321bc8b0b65761cea28