### PR TITLE
Make canvas optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,9 @@ npm install
 ```
 
 Some tools rely on the `canvas` package. On Linux, you may need system packages
-such as `libcairo2-dev` and `build-essential` to compile it.
+such as `libcairo2-dev` and `build-essential` to compile it. If `canvas`
+fails to build on your platform, you can skip installing it and those tools
+will remain disabled.
 
 For optional Python utilities run:
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "description": "Utility scripts for the Ethics Structure 4789 project",
   "main": "tools/serve-interface.js",
   "dependencies": {
-    "canvas": "^2.11.2",
     "express": "^4.19.2",
     "node-telegram-bot-api": "^0.66.0"
+  },
+  "optionalDependencies": {
+    "canvas": "^2.11.2"
   },
   "engines": {
     "node": ">=18"

--- a/tools/op8-logo-assembler.js
+++ b/tools/op8-logo-assembler.js
@@ -1,4 +1,11 @@
-const { createCanvas, loadImage } = require('canvas');
+let createCanvas, loadImage;
+try {
+  ({ createCanvas, loadImage } = require('canvas'));
+} catch {
+  console.error('The "canvas" package is required for op8-logo-assembler.');
+  console.error('Install it with "npm install canvas" and ensure native libs build.');
+  process.exit(1);
+}
 const fs = require('fs');
 const path = require('path');
 

--- a/tools/stereo-anaglyph.js
+++ b/tools/stereo-anaglyph.js
@@ -1,4 +1,11 @@
-const { createCanvas, loadImage } = require('canvas');
+let createCanvas, loadImage;
+try {
+  ({ createCanvas, loadImage } = require('canvas'));
+} catch {
+  console.error('The "canvas" package is required for stereo-anaglyph.');
+  console.error('Install it with "npm install canvas" and ensure native libs build.');
+  process.exit(1);
+}
 const fs = require('fs');
 
 async function stereoToAnaglyph(leftPath, rightPath, outputPath, options = {}) {


### PR DESCRIPTION
## Summary
- make `canvas` an optional dependency
- guard image tools when canvas is missing
- document that canvas can be skipped when it fails to build

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684aaeb59f048321b792f0e35d76c038