### PR TITLE
Allow 'yes' variations when running scripts

### DIFF
--- a/tools/auto-data-setup.sh
+++ b/tools/auto-data-setup.sh
@@ -8,7 +8,11 @@ echo "4789 ist ein Standard für Verantwortung, keine Person und kein Glaubenssy
 echo "Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung."
 printf "Fortfahren? (yes/no) "
 read answer
-[ "$answer" = "yes" ] || { echo "Abbruch."; exit 1; }
+answer=$(printf "%s" "$answer" | tr '[:upper:]' '[:lower:]')
+case "$answer" in
+  yes|y|ja|j|si|sí|sim|oui|da|hai|ok|okay) ;;
+  *) echo "Abbruch."; exit 1;;
+esac
 
 need_node() {
   echo "Node.js 18+ wird benötigt."

--- a/tools/auto-gatekeeper-setup.sh
+++ b/tools/auto-gatekeeper-setup.sh
@@ -8,7 +8,11 @@ echo "4789 ist ein Standard für Verantwortung, keine Person und kein Glaubenssy
 echo "Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung."
 printf "Fortfahren? (yes/no) "
 read answer
-[ "$answer" = "yes" ] || { echo "Abbruch."; exit 1; }
+answer=$(printf "%s" "$answer" | tr '[:upper:]' '[:lower:]')
+case "$answer" in
+  yes|y|ja|j|si|sí|sim|oui|da|hai|ok|okay) ;;
+  *) echo "Abbruch."; exit 1;;
+esac
 
 need_node() {
   echo "Node.js 18+ wird benötigt."

--- a/tools/auto-server-setup.sh
+++ b/tools/auto-server-setup.sh
@@ -8,7 +8,11 @@ echo "4789 ist ein Standard für Verantwortung, keine Person und kein Glaubenssy
 echo "Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung."
 printf "Fortfahren? (yes/no) "
 read answer
-[ "$answer" = "yes" ] || { echo "Abbruch."; exit 1; }
+answer=$(printf "%s" "$answer" | tr '[:upper:]' '[:lower:]')
+case "$answer" in
+  yes|y|ja|j|si|sí|sim|oui|da|hai|ok|okay) ;;
+  *) echo "Abbruch."; exit 1;;
+esac
 
 need_node() {
   echo "Node.js 18+ wird benötigt."

--- a/tools/easy-start.js
+++ b/tools/easy-start.js
@@ -13,7 +13,8 @@ disclaimers.forEach(l => console.log(l));
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 rl.question('Fortfahren? (yes/no) ', answer => {
   rl.close();
-  if (answer.trim() !== 'yes') {
+  const ok = ['yes', 'y', 'ja', 'j', 'si', 'sí', 'sim', 'oui', 'da', 'hai', 'ok', 'okay'];
+  if (!ok.includes(answer.trim().toLowerCase())) {
     console.log('Abbruch.');
     process.exit(1);
   }

--- a/tools/guided-install.sh
+++ b/tools/guided-install.sh
@@ -10,7 +10,11 @@ echo "Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder 
 
 printf "Fortfahren? (yes/no) "
 read answer
-[ "$answer" = "yes" ] || { echo "Abbruch."; exit 1; }
+answer=$(printf "%s" "$answer" | tr '[:upper:]' '[:lower:]')
+case "$answer" in
+  yes|y|ja|j|si|sí|sim|oui|da|hai|ok|okay) ;;
+  *) echo "Abbruch."; exit 1;;
+esac
 
 need_node() {
   echo "Node.js 18+ wird ben\u00f6tigt."

--- a/tools/start-server.js
+++ b/tools/start-server.js
@@ -23,7 +23,8 @@ const page = args[0] || 'index.html';
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 rl.question('Fortfahren? (yes/no) ', answer => {
   rl.close();
-  if (answer.trim() !== 'yes') {
+  const ok = ['yes', 'y', 'ja', 'j', 'si', 'sí', 'sim', 'oui', 'da', 'hai', 'ok', 'okay'];
+  if (!ok.includes(answer.trim().toLowerCase())) {
     console.log('Abbruch.');
     process.exit(1);
   }

--- a/tools/time-gui.js
+++ b/tools/time-gui.js
@@ -14,7 +14,8 @@ disclaimers.forEach(l => console.log(l));
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 rl.question('Fortfahren? (yes/no) ', answer => {
   rl.close();
-  if (answer.trim() !== 'yes') {
+  const ok = ['yes', 'y', 'ja', 'j', 'si', 'sí', 'sim', 'oui', 'da', 'hai', 'ok', 'okay'];
+  if (!ok.includes(answer.trim().toLowerCase())) {
     console.log('Abbruch.');
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- extend confirmation checks to accept common variations of "yes" in node and shell scripts

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684ac7335f9083219cfc9e68a9a1ba67