### PR TITLE
Implement basic chat interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 - [Generating Interface README](#generating-interface-readme)
 - [Gatekeeper Control](#gatekeeper-control)
 - [API Access Control](#api-access-control)
+- [Chat Interface](#chat-interface)
 - [Mechatronic Control](#mechatronic-control)
 - [OP Function Bundles](#op-function-bundles)
 - [Currency Synchronization](#currency-synchronization)
@@ -370,6 +371,13 @@ Copy that folder to another device and run `node gatekeeper.js <token>` for dele
 the operator level and confirmation flags from `app/user_state.yaml` and grants
 access only when the specified OP level is met and the user has confirmed
 ethical intent.
+
+### Chat Interface
+[⇧](#contents)
+
+Connected users may exchange short messages via `chat.html`. Only approved
+connections can send or receive texts. The interface lists your connections and
+allows sending short notes.
 
 ### Mechatronic Control
 [⇧](#contents)

--- a/docs/chat-usage.md
+++ b/docs/chat-usage.md
@@ -1,0 +1,10 @@
+# Chat Interface
+
+The chat module allows connected users to exchange short messages.
+
+1. Create a connection under `connect.html` and wait for approval.
+2. Open `chat.html` from the navigation menu.
+3. Select a connection, type your message and press **Send**.
+
+Only approved connections may send and read messages. Operators below OP‑1
+cannot access the chat.

--- a/interface/chat-interface.js
+++ b/interface/chat-interface.js
@@ -1,0 +1,55 @@
+let chatTexts = {};
+
+function sig(){
+  try{ return JSON.parse(localStorage.getItem('ethicom_signature')||'{}'); }catch{return {};}}
+
+function loadConnections(){
+  const sel = document.getElementById('chat_target');
+  if(!sel) return;
+  const id = sig().id;
+  if(!id) return;
+  fetch('/api/connect/list?id='+encodeURIComponent(id))
+    .then(r=>r.json())
+    .then(data=>{
+      sel.innerHTML = data.connections.map(c=>`<option value="${c.id}">${c.id} (${c.op_level})</option>`).join('');
+    });
+}
+
+function loadMessages(){
+  const hist = document.getElementById('chat_history');
+  const target = document.getElementById('chat_target').value;
+  const id = sig().id;
+  if(!hist || !target || !id) return;
+  fetch(`/api/chat/list?user=${encodeURIComponent(id)}&target=${encodeURIComponent(target)}`)
+    .then(r=>r.json())
+    .then(data=>{
+      hist.innerHTML = data.messages.map(m=>`<div><strong>${m.from===id?'You':m.from}:</strong> ${m.text}</div>`).join('');
+      hist.scrollTop = hist.scrollHeight;
+    });
+}
+
+function sendMessage(){
+  const msgEl = document.getElementById('chat_message');
+  const target = document.getElementById('chat_target').value;
+  const id = sig().id;
+  const text = msgEl.value.trim();
+  if(!text || !id || !target) return;
+  fetch('/api/chat/send', {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({ from:id, to:target, text })
+  }).then(()=>{
+    msgEl.value='';
+    loadMessages();
+  });
+}
+
+function initChatInterface(){
+  loadConnections();
+  document.getElementById('chat_send').addEventListener('click', sendMessage);
+  document.getElementById('chat_target').addEventListener('change', loadMessages);
+  setInterval(loadMessages, 5000);
+  loadMessages();
+}
+
+if(typeof window!=='undefined') window.initChatInterface=initChatInterface;

--- a/interface/chat.html
+++ b/interface/chat.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Chat</title>
+  <link rel="stylesheet" href="/ethicom-style.css">
+  <script src="/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main_content">Skip to main content</a>
+  <div id="op_background"></div>
+  <header>
+    <h1>Chat</h1>
+  </header>
+  <nav aria-label="Main navigation">
+    <a href="../index.html">Home</a>
+    <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="login.html">Login</a>
+    <a href="signup.html">Signup</a>
+    <a href="../README.html" class="readme-link">README</a>
+    <button id="side_menu" type="button" class="icon-only" aria-label="Menu" data-min-op="OP-6">☰</button>
+  </nav>
+  <main id="main_content">
+    <section class="card">
+      <div id="chat_history" class="chat-history"></div>
+      <div class="chat-input-row">
+        <select id="chat_target"></select>
+        <input id="chat_message" placeholder="Message" />
+        <button id="chat_send" class="accent-button">Send</button>
+      </div>
+    </section>
+  </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      initSideDrop('nav-menu.html');
+      const menu=document.getElementById('side_menu');
+      if(menu) menu.addEventListener('click',e=>{e.preventDefault();toggleSideDrop();});
+      if (typeof initChatInterface === 'function') initChatInterface();
+    });
+  </script>
+  <div id="side_drop"></div>
+</body>
+</html>

--- a/interface/nav-menu.html
+++ b/interface/nav-menu.html
@@ -13,6 +13,7 @@
     <li><a href="settings.html">⚙ Einstellungen</a></li>
     <li><a href="login.html">🔑 Login</a></li>
     <li><a href="signup.html">Signup</a></li>
+    <li><a href="chat.html">Chat</a></li>
     <li><a href="../README.html">?</a></li>
   </ul>
 </div>

--- a/interface/op-side-nav.js
+++ b/interface/op-side-nav.js
@@ -1,7 +1,7 @@
 function setupOpSideNav(container){
   const list = container.querySelector('#op_side_nav');
   if(!list) return;
-  const levels=['OP-0','OP-1','OP-2','OP-3','OP-4','OP-5','OP-5.U','OP-6','OP-7','OP-7.U','OP-8','OP-8.M','OP-9','OP-9.M','OP-9.A','OP-10','OP-11','OP-12'];
+  const levels=['OP-0','OP-1','OP-2','OP-3','OP-4','OP-5','OP-5.U','OP-6','OP-7','OP-7.U','OP-8','OP-8.M','OP-9','OP-9.M','OP-9.A','OP-10','OP-11','OP-12','chat'];
   list.innerHTML = levels.map(l => `<li><button class="accent-button" data-level="${l}">${l}</button></li>`).join('');
   list.querySelectorAll('button').forEach(btn => {
     btn.addEventListener('click', () => {

--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -149,6 +149,7 @@ const paths = cfg.paths || {};
 const usersFile = path.join(repoRoot, paths.users || 'app/users.json');
 const evalFile = path.join(repoRoot, paths.evaluations || 'app/evaluations.json');
 const connFile = path.join(repoRoot, paths.connections || 'app/connections.json');
+const messagesFile = path.join(repoRoot, paths.messages || 'app/messages.json');
 const profileFile = path.join(repoRoot, paths.userprofile || 'app/userprofile.json');
 const oauthCfg = parseOAuthConfig(paths.oauthConfig ? path.join(repoRoot, paths.oauthConfig) : undefined);
 const oauthStates = new Set();
@@ -655,6 +656,42 @@ function handleConnectList(req, res) {
   res.end(JSON.stringify({ pending: pending, connections: conns }));
 }
 
+function handleChatSend(req, res) {
+  let body = '';
+  req.on('data', c => { body += c; });
+  req.on('end', () => {
+    try {
+      const { from, to, text } = JSON.parse(body);
+      if (!from || !to || !text) { res.writeHead(400); res.end('Invalid'); return; }
+      const cons = readJson(connFile);
+      const ok = cons.some(c => c.approved && ((c.requester === from && c.target === to) || (c.requester === to && c.target === from)));
+      if (!ok) { res.writeHead(403); res.end('Not connected'); return; }
+      const msgs = readJson(messagesFile);
+      msgs.push({ from, to, text, timestamp: new Date().toISOString() });
+      writeJson(messagesFile, msgs);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ success: true }));
+    } catch (err) {
+      res.writeHead(400);
+      res.end('Bad Request');
+    }
+  });
+}
+
+function handleChatList(req, res) {
+  const url = new URL(req.url, 'http://localhost');
+  const user = url.searchParams.get('user');
+  const target = url.searchParams.get('target');
+  if (!user || !target) { res.writeHead(400); res.end('Invalid'); return; }
+  const cons = readJson(connFile);
+  const ok = cons.some(c => c.approved && ((c.requester === user && c.target === target) || (c.requester === target && c.target === user)));
+  if (!ok) { res.writeHead(403); res.end('Not connected'); return; }
+  const msgs = readJson(messagesFile);
+  const list = msgs.filter(m => (m.from === user && m.to === target) || (m.from === target && m.to === user));
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ messages: list }));
+}
+
 function handleProfile(req, res) {
   if (req.method === 'GET') {
     const data = readProfile();
@@ -781,6 +818,12 @@ const server = http.createServer((req, res) => {
   if (req.method === 'GET' && urlPath === '/api/connect/list') {
     return handleConnectList(req, res);
   }
+  if (req.method === 'POST' && urlPath === '/api/chat/send') {
+    return handleChatSend(req, res);
+  }
+  if (req.method === 'GET' && urlPath === '/api/chat/list') {
+    return handleChatList(req, res);
+  }
   if (req.method === 'GET' && urlPath === '/api/gatekeeper/token') {
     return handleTempToken(req, res);
   }
@@ -855,6 +898,8 @@ if (require.main === module) {
     handleConnectRequest,
     handleConnectApprove,
     handleConnectList,
+    handleChatSend,
+    handleChatList,
     handleTempToken,
     handleProfile,
     handleData,


### PR DESCRIPTION
## Summary
- add a minimal chat module with HTML and JS
- store and fetch chat messages in `serve-interface.js`
- include Chat entry in navigation and side nav
- document chat usage

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684ac8036a688321ab8de74bb0e8df01