### PR TITLE
Add auto-module setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 - [Automated Server Setup](#automated-server-setup)
 - [Automated Gatekeeper Setup](#automated-gatekeeper-setup)
 - [Automated Data Setup](#automated-data-setup)
+- [Automated Module Setup](#automated-module-setup)
 - [Guided Installation](#guided-installation)
 - [Running Tests](#running-tests)
 - [Contributing](#contributing)
@@ -589,6 +590,13 @@ Install `clang make pkg-config libjpeg-turbo cairo pango freetype libpng librsvg
 Run `tools/auto-data-setup.sh` to install Node.js 18 if needed and fetch optional
 offline data. The script installs Python and JavaScript dependencies, downloads
 currency rates and pulls candidate images from Wikipedia.
+
+### Automated Module Setup
+[⇧](#contents)
+
+Run `tools/auto-module-setup.sh` to bundle all interface scripts and update the
+HTML pages. The helper ensures new modules are automatically integrated after a
+single command.
 
 ### Guided Installation
 [⇧](#contents)

--- a/tools/auto-module-setup.sh
+++ b/tools/auto-module-setup.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Automatic module integration for the 4789 project.
+set -e
+
+# Key disclaimers
+echo "Diese Struktur wird ohne Gew\u00e4hrleistung bereitgestellt. Fehler oder Auslassungen sind m\u00f6glich."
+echo "Die Nutzung erfolgt auf eigene Verantwortung. Weder Signature 4789 noch die Maintainer haften f\u00fcr Folgen oder Anspr\u00fcche."
+echo "4789 ist ein Standard f\u00fcr Verantwortung, keine Person und kein Glaubenssystem."
+echo "Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung."
+printf "Fortfahren? (yes/no) "
+read answer
+answer=$(printf "%s" "$answer" | tr '[:upper:]' '[:lower:]')
+case "$answer" in
+  yes|y|ja|j|si|sí|sim|oui|da|hai|ok|okay) ;;
+  *) echo "Abbruch."; exit 1;;
+esac
+
+need_node() {
+  echo "Node.js 18+ wird ben\u00f6tigt."
+  if [ "$(uname)" = "Darwin" ]; then
+    if command -v brew >/dev/null 2>&1; then
+      echo "Installing Node.js via Homebrew..."
+      brew install node@18
+      brew link --force --overwrite node@18
+    else
+      echo "Homebrew fehlt. Bitte Node.js manuell installieren."
+      exit 1
+    fi
+  elif [ -f /etc/debian_version ]; then
+    echo "Installing Node.js via apt..."
+    curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+    sudo apt-get install -y nodejs
+  else
+    echo "Automatic Node.js installation nicht unterst\u00fctzt."
+    exit 1
+  fi
+}
+
+if command -v node >/dev/null 2>&1; then
+  ver=$(node -v | cut -c2- | cut -d. -f1)
+  if [ "$ver" -lt 18 ]; then
+    need_node
+  fi
+else
+  need_node
+fi
+
+echo "Installing npm dependencies..."
+npm install
+
+echo "Bundling interface modules..."
+npm run bundle-interface
+
+echo "Updating HTML references..."
+node tools/unify-html.js
+
+echo "Module setup complete."


### PR DESCRIPTION
## Summary
- add `auto-module-setup.sh` to bundle interface modules and update HTML
- document the new script in the README

## Testing
- `node --test` *(fails: 8 failing tests)*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684ac845c8048321b61eeff8d757e6ce