### PR TITLE
Add serve-bsvrb script

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 3. Run `node tools/migrate-json-to-db.js` once to import existing JSON data into the SQLite database.
    If you only have the HTML files, download
    [`tools/easy-start.js`](https://www.bsvrb.ch/tools/easy-start.js) and run it with Node.
-   For GitHub Pages use `npm run serve-gh`.
+  For GitHub Pages use `npm run serve-gh`.
+  For the official domain run `npm run serve-bsvrb`.
    Pass a page name to `npm start` to open it directly,
    for example `npm start signup.html`.
    Opening an HTML file directly (via `file://`) disables translations.
@@ -523,6 +524,7 @@ When deploying on another domain, set the environment variable `BASE_URL`
 to that public origin (e.g. `https://4789-alpha.github.io`) so that OAuth
 redirects work properly. Start the server with `npm run serve-gh` to
 apply this setting automatically.
+Use `npm run serve-bsvrb` for the official domain.
 Configure your GitHub OAuth application to use `${BASE_URL}/auth/github/callback`
 as the callback URL and put your credentials in `app/oauth_config.yaml`.
 

--- a/auth/google/index.html
+++ b/auth/google/index.html
@@ -13,6 +13,7 @@
     <h2>Google OAuth unavailable</h2>
     <p>This GitHub Pages demo cannot start the Google login flow.</p>
     <p>Run <code>npm run serve-gh</code> locally to enable OAuth callbacks.</p>
+    <p>Or use <code>npm run serve-bsvrb</code> for bsvrb.ch.</p>
   </main>
 </body>
 </html>

--- a/interface/bundle.js
+++ b/interface/bundle.js
@@ -3163,6 +3163,7 @@ async function initRatings() {
     library.innerHTML =
       'Bibliothek konnte nicht geladen werden. ' +
       'Bitte starten Sie die Seite mit <code>npm run serve-gh</code> ' +
+      'oder <code>npm run serve-bsvrb</code> ' +
       `und öffnen Sie <a href="${baseUrl}/ethicom.html">${baseUrl}</a>.`;
   }
 }

--- a/interface/ratings.js
+++ b/interface/ratings.js
@@ -141,6 +141,7 @@ async function initRatings() {
     library.innerHTML =
       'Bibliothek konnte nicht geladen werden. ' +
       'Bitte starten Sie die Seite mit <code>npm run serve-gh</code> ' +
+      'oder <code>npm run serve-bsvrb</code> ' +
       `und öffnen Sie <a href="${baseUrl}/ethicom.html">${baseUrl}</a>.`;
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "start": "node tools/start-server.js",
     "easy-start": "node tools/easy-start.js",
     "serve-gh": "BASE_URL=https://4789-alpha.github.io node tools/serve-interface.js",
+    "serve-bsvrb": "BASE_URL=https://bsvrb.ch node tools/serve-interface.js",
     "bundle-interface": "node tools/bundle-interface.js",
     "generate-wiki": "node tools/generate-wiki.js",
     "test": "node --test && node tools/check-translations.js && node tools/check-file-integrity.js",


### PR DESCRIPTION
## Summary
- add `serve-bsvrb` npm script
- mention script in quickstart instructions and OAuth setup section
- expand local setup hint in ratings interface
- note new script in Google OAuth placeholder page

## Testing
- `node --test` *(fails: 10 failing tests)*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684ac8a55e6c8321888eb5ba38ca9246