### PR TITLE
Fix z-index for OP background

### DIFF
--- a/interface/css/content.css
+++ b/interface/css/content.css
@@ -275,7 +275,7 @@ button:hover {
 #op_background {
   position: fixed;
   inset: 0;
-  z-index: -1;
+  z-index: 0;
   overflow: hidden;
   opacity: 1;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- raise `#op_background` z-index to 0 so it sits above the page background

## Testing
- `node --test` *(fails: Cannot find module 'better-sqlite3')*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684b34fbb20c8321aac4e071c035b197