### PR TITLE
Add automatic language selector

### DIFF
--- a/interface/bundle.js
+++ b/interface/bundle.js
@@ -2223,6 +2223,23 @@ function checkLanguageSetup() {
   if (typeof updateReadmeLinks === "function") updateReadmeLinks(lang);
 }
 
+function ensureLanguageDropdown() {
+  var select = document.getElementById("lang_select");
+  if (!select) {
+    var box = document.createElement("div");
+    box.id = "lang_selection";
+    box.style.position = "fixed";
+    box.style.top = "0.5em";
+    box.style.right = "0.5em";
+    box.innerHTML =
+      '<label for="lang_select" data-ui="choose_language_label">Language:</label> <select id="lang_select"></select>';
+    document.body.prepend(box);
+    select = box.querySelector("#lang_select");
+  }
+  checkLanguageSetup();
+  initLanguageDropdown("lang_select");
+}
+
 
 
 //----- login.js -----
@@ -4665,6 +4682,9 @@ function displayVersionInfo() {
 }
 
 if (typeof window !== 'undefined') {
-  window.addEventListener('DOMContentLoaded', displayVersionInfo);
+  window.addEventListener('DOMContentLoaded', function() {
+    displayVersionInfo();
+    ensureLanguageDropdown();
+  });
 }
 

--- a/interface/language-selector.js
+++ b/interface/language-selector.js
@@ -284,3 +284,24 @@ function checkLanguageSetup() {
   if (typeof updateReadmeLinks === "function") updateReadmeLinks(lang);
 }
 
+function ensureLanguageDropdown() {
+  let select = document.getElementById("lang_select");
+  if (!select) {
+    const box = document.createElement("div");
+    box.id = "lang_selection";
+    box.style.position = "fixed";
+    box.style.top = "0.5em";
+    box.style.right = "0.5em";
+    box.innerHTML =
+      '<label for="lang_select" data-ui="choose_language_label">Language:</label> <select id="lang_select"></select>';
+    document.body.prepend(box);
+    select = box.querySelector("#lang_select");
+  }
+  checkLanguageSetup();
+  initLanguageDropdown("lang_select");
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("DOMContentLoaded", ensureLanguageDropdown);
+}
+


### PR DESCRIPTION
## Summary
- add `ensureLanguageDropdown` to automatically inject a language selector
- include this logic in bundled JS to work across pages

## Testing
- `node --test` *(fails: 9 tests failed)*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684b3b80d94483218c498dccedc49a43