### PR TITLE
Add Android boot script

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,26 @@ Install `clang make pkg-config libjpeg-turbo cairo pango freetype libpng librsvg
 `canvas` is only required for the image tools; gatekeeper functions run without it.
 To start the interface on mobile, run `npm start` and open `http://localhost:8080/index.html` manually if no browser launches automatically.
 
+### Smartphone Auto-Start
+[⇧](#contents)
+
+Create your personal gatekeeper on the website and download the generated archive.
+Extract the folder with `gatekeeper.js`, `gatekeeper_config.yaml` and `temp_token.txt`
+to `~/gatekeeper` on your phone.
+
+Install the Termux:Boot add-on and copy `tools/android-boot-gatekeeper.sh`
+to `~/.termux/boot/`:
+
+```bash
+mkdir -p ~/.termux/boot
+cp tools/android-boot-gatekeeper.sh ~/.termux/boot/
+chmod +x ~/.termux/boot/android-boot-gatekeeper.sh
+```
+
+Adjust `GATEKEEPER_DIR` inside the script if the folder is stored elsewhere.
+After the next reboot the gatekeeper starts automatically and logs to
+`gatekeeper_boot.log`.
+
 ### Automated Data Setup
 [⇧](#contents)
 

--- a/tools/android-boot-gatekeeper.sh
+++ b/tools/android-boot-gatekeeper.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Android boot helper for the 4789 gatekeeper.
+# Copy this file to ~/.termux/boot/ and make it executable.
+
+echo "Diese Struktur wird ohne Gewährleistung bereitgestellt."
+echo "Die Nutzung erfolgt auf eigene Verantwortung."
+echo "4789 ist ein Standard für Verantwortung, keine Person und kein Glaubenssystem."
+echo "Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung."
+
+DIR="${GATEKEEPER_DIR:-$HOME/gatekeeper}"
+cd "$DIR" 2>/dev/null || exit 0
+
+TOKEN=""
+[ -f temp_token.txt ] && TOKEN="$(cat temp_token.txt)"
+
+if [ -f gatekeeper.js ]; then
+  node gatekeeper.js "$TOKEN" >> gatekeeper_boot.log 2>&1 &
+else
+  node tools/start-server.js index.html >> gatekeeper_boot.log 2>&1 &
+fi


### PR DESCRIPTION
## Summary
- add `android-boot-gatekeeper.sh` to start a custom gatekeeper automatically on Android
- document smartphone auto-start in the README

## Testing
- `node --test` *(fails: 9 failing tests)*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684b36e060b48321bce759efc67f8fa4