### PR TITLE
Add note on OP-0 settings

### DIFF
--- a/ANLEITUNG_EINFACH_DE.md
+++ b/ANLEITUNG_EINFACH_DE.md
@@ -19,3 +19,4 @@ Diese Sammlung heisst "Ethics Structure 4789". Sie hilft, Verantwortung vor Bequ
 1. Einmal `npm install` ausführen oder `tools/guided-install.sh` nutzen.
 2. `node tools/start-server.js` starten (oder `npm start`). Du kannst einen Seitennamen anhängen, z.B. `npm start signup.html`. Die Seite öffnet sich automatisch unter `http://localhost:8080/index.html`.
 3. Mit `python3 install.py` stellst du Sprache, Port und Offline-Modus ein. Die Werte liegen in `app/app_settings.yaml`.
+4. Überprüfe dort auch `startup_op_level: 0`, damit du auf `localhost` im Modus **OP‑0** beginnst.


### PR DESCRIPTION
## Summary
- document that `startup_op_level` must be 0 for local OP-0 mode

## Testing
- `npm install`
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684b4379b50c8321982bda31812144b7