### PR TITLE
Update docs for OP-0 settings

### DIFF
--- a/docs/NEUE_BENUTZER_DE.md
+++ b/docs/NEUE_BENUTZER_DE.md
@@ -10,7 +10,9 @@ Diese kurze Anleitung zeigt, wie du die Struktur 4789 lokal starten kannst.
    Optional kannst du einen Seitennamen anhängen, z.B. `npm start signup.html`.
 5. Im Browser `http://localhost:8080/index.html` öffnen.
 6. Für die Registrierung [signup.html](../signup.html) aufrufen.
-7. Zusätzliche Einstellungen mit `python3 install.py` vornehmen.
+7. Zusätzliche Einstellungen mit `python3 install.py` vornehmen. In
+   `app/app_settings.yaml` kannst du den Startlevel `startup_op_level`
+   festlegen (Standard `0` für OP-0).
 
 Nutze die Struktur reflektiert. Keine Manipulation, keine Simulation.
 Ausführliche Erläuterungen stehen in [ANLEITUNG_EINFACH_DE.md](../ANLEITUNG_EINFACH_DE.md).


### PR DESCRIPTION
## Summary
- mention `startup_op_level` in the German new user guide

## Testing
- `node --test` *(fails: 9 failed)*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684b43b703848321990a08f453ae137c