### PR TITLE
Allow commit history rewriting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,6 @@ If a command fails due to missing network access, note this in the PR descriptio
 
 ## 4. Commits and Pull Requests
 - Use clear, succinct commit messages.
-- Do not rewrite history or amend prior commits.
+- Rewriting history or amending commits is allowed when commit messages require improvement.
 - Summaries must reference changed files and mention test results.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,6 @@ static site generated with Jekyll. Name it after your user, for example
 ## Commits and Pull Requests
 
 - Use clear, succinct commit messages.
-- Do not rewrite history or amend prior commits.
+- Rewriting history or amending commits is allowed when commit messages require improvement.
 - Summaries must reference changed files and mention test results.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -26,6 +26,6 @@ If a command fails due to missing network access, note this in the PR descriptio
 
 ## 4. Commits and Pull Requests
 - Use clear, succinct commit messages.
-- Do not rewrite history or amend prior commits.
+- Rewriting history or amending commits is allowed when commit messages require improvement.
 - Summaries must reference changed files and mention test results.
 


### PR DESCRIPTION
## Summary
- permit rewriting commit messages by updating `AGENTS.md` and `docs/AGENTS.md`
- adjust `CONTRIBUTING.md` accordingly

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684b4595b61c832181083efeb87d948e