### PR TITLE
Add repository zip export without images

### DIFF
--- a/bsvrb.ch/settings.html
+++ b/bsvrb.ch/settings.html
@@ -127,7 +127,7 @@
     <details class="card">
       <summary>Repository</summary>
       <div id="repo_download">
-        <a href="/download.zip" class="accent-button">Download .zip</a>
+        <a href="/download.zip" class="accent-button">Download .zip (no images)</a>
         <a href="/tools/easy-start.js" class="accent-button">easy-start.js</a>
       </div>
     </details>

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -130,7 +130,7 @@
     <details class="card">
       <summary>Repository</summary>
       <div id="repo_download">
-        <a href="/download.zip" class="accent-button">Download .zip</a>
+        <a href="/download.zip" class="accent-button">Download .zip (no images)</a>
         <a href="/tools/easy-start.js" class="accent-button">easy-start.js</a>
       </div>
     </details>

--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -874,7 +874,18 @@ const server = http.createServer((req, res) => {
       'Content-Type': 'application/zip',
       'Content-Disposition': 'attachment; filename="ethics-structure.zip"'
     });
-    const git = spawn('git', ['-C', repoRoot, 'archive', '--format=zip', 'HEAD']);
+    const git = spawn('git', [
+      '-C', repoRoot,
+      'archive',
+      '--format=zip',
+      'HEAD',
+      ':!*.png',
+      ':!*.jpg',
+      ':!*.jpeg',
+      ':!*.gif',
+      ':!*.svg',
+      ':!*.webp'
+    ]);
     git.stdout.pipe(res);
     git.on('error', () => {
       res.statusCode = 500;


### PR DESCRIPTION
## Summary
- filter out image files when generating `/download.zip`
- mark the Download button as skipping images

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684c0ae6ed90832197dbaaae2f859e56