### PR TITLE
Mark legacy settings page as deprecated

### DIFF
--- a/README.html
+++ b/README.html
@@ -17,7 +17,7 @@
   </header>
   <nav>
     <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-    <a href="interface/settings.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a aria-current="page" class="icon-only readme-link" aria-label="Help">?</a>

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
     +-------------+
       |         |
       v         v
- settings.html  ethicom.html
+ settings_OLD.html (deprecated)  ethicom.html
 ```
 
 ## Contents
@@ -154,7 +154,7 @@ See [DISCLAIMERS.md](DISCLAIMERS.md) for warranty and liability notes.
 | [bewertung.html](bewertung.html) | Entry page for rating modules |
 | [personenbewertung.html](personenbewertung.html) | Swipe-based person rating |
 | [org-bewertung.html](org-bewertung.html) | Preview for organisation ratings |
-| [interface/settings.html](interface/settings.html) | Language, theme, Tanna logo, and low motion settings |
+| [interface/settings_OLD.html](interface/settings_OLD.html) | Language, theme, Tanna logo, and low motion settings |
 | [interface/signup.html](interface/signup.html) | Registration form |
 | [interface/offline-signup.html](interface/offline-signup.html) | Offline local signup |
 
@@ -277,7 +277,7 @@ Use the `image_url` field in `sources/persons/human-op0-candidates.json` to reco
 [⇧](#contents)
 
 **ethicom.html**
-SHA-256: e562c07f46ff6714b7fd1b467b7bbaa059150a997e747bd429270802f108096a
+SHA-256: 38ebbdd1d3363432e9e9cda982e7aca6391786d779ff52e4566a8f0c8a0754d7
 Verified 2025-05-21 by Signature 4789
 
 **ethicom-consensus.js**

--- a/beatclub-basel.html
+++ b/beatclub-basel.html
@@ -20,7 +20,7 @@
   </div>
   <nav>
     <a href="beatclub-basel.html" class="icon-only" aria-label="Home" aria-current="page">🏠</a>
-    <a href="interface/settings.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bewertung.html
+++ b/bewertung.html
@@ -16,7 +16,7 @@
     <p class="tagline">Modul-Auswahl</p>
     <nav>
       <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-      <a href="interface/settings.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
       <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bsvrb-dept-1.html
+++ b/bsvrb-dept-1.html
@@ -17,7 +17,7 @@
   </header>
   <nav>
     <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-    <a href="interface/settings.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bsvrb-dept-2.html
+++ b/bsvrb-dept-2.html
@@ -17,7 +17,7 @@
   </header>
   <nav>
     <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-    <a href="interface/settings.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bsvrb-dept-3.html
+++ b/bsvrb-dept-3.html
@@ -17,7 +17,7 @@
   </header>
   <nav>
     <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-    <a href="interface/settings.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bsvrb-dept-4.html
+++ b/bsvrb-dept-4.html
@@ -17,7 +17,7 @@
   </header>
   <nav>
     <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-    <a href="interface/settings.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bsvrb-dept-5.html
+++ b/bsvrb-dept-5.html
@@ -17,7 +17,7 @@
   </header>
   <nav>
     <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-    <a href="interface/settings.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bsvrb-fischerabteilung.html
+++ b/bsvrb-fischerabteilung.html
@@ -19,7 +19,7 @@
   </div>
   <nav>
       <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-      <a href="interface/settings.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
       <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
       <a href="interface/signup.html">Signup</a>
       <a href="interface/fish.html">Fish Interface</a>

--- a/bsvrb-kulturabteilung.html
+++ b/bsvrb-kulturabteilung.html
@@ -19,7 +19,7 @@
   </div>
   <nav>
       <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-      <a href="interface/settings.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
       <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bsvrb-quality.html
+++ b/bsvrb-quality.html
@@ -19,7 +19,7 @@
   </div>
   <nav>
       <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-      <a href="interface/settings.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
       <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bsvrb.ch/settings_OLD.html
+++ b/bsvrb.ch/settings_OLD.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- DEPRECATED: This old settings interface is kept for reference. A new implementation will replace it. -->
 <html lang="de">
 <head>
   <meta charset="utf-8">

--- a/docs/README.html
+++ b/docs/README.html
@@ -17,7 +17,7 @@
   </header>
   <nav>
     <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-    <a href="interface/settings.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a aria-current="page" class="icon-only readme-link" aria-label="Help">?</a>

--- a/docs/tanna-collisions.md
+++ b/docs/tanna-collisions.md
@@ -7,9 +7,9 @@ To check that collisions work:
 1. **Page setup** – A page must contain a `<div id="op_background"></div>` and load `bundle.js`.
    See [`interface/tanna-animation.html`](../interface/tanna-animation.html) lines 7–18.
 2. **Local settings** – The low-motion option slows the animation.
-   Adjust via [`interface/settings.html`](../interface/settings.html) lines 284–289.
+   Adjust via [`interface/settings_OLD.html`](../interface/settings_OLD.html) lines 284–289.
 3. **Fill ratio and symbol size** – Increase these values if collisions are rare.
    They are stored as `ethicom_bg_fill` and `ethicom_bg_symbol_size`.
-   See [`interface/settings.html`](../interface/settings.html) lines 208–221 and 259–268.
+   See [`interface/settings_OLD.html`](../interface/settings_OLD.html) lines 208–221 and 259–268.
 
 When the settings are applied and collisions are enabled (`collisionsEnabled` in `logo-background.js`), the overlay draws a yellow circle around colliding symbols.

--- a/grimmhorn.html
+++ b/grimmhorn.html
@@ -20,7 +20,7 @@
   </div>
   <nav>
     <a href="grimmhorn.html" class="icon-only" aria-label="Home" aria-current="page">🏠</a>
-    <a href="interface/settings.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/interface/apple-hig.html
+++ b/interface/apple-hig.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/bundle.js
+++ b/interface/bundle.js
@@ -3071,7 +3071,7 @@ window.addEventListener('DOMContentLoaded', () => {
     const navHtml =
       '<nav class="op0-nav">'+
       `<a href="${base}index.html" class="icon-only" aria-label="Home">\u{1F3E0}</a>`+
-      `<a href="${base}interface/settings.html" class="icon-only" aria-label="Settings">\u2699</a>`+
+      `<a href="${base}interface/settings_OLD.html" class="icon-only" aria-label="Settings">\u2699</a>`+
       `<a href="${base}interface/login.html" class="icon-only" aria-label="Login">\u{1F511}</a>`+
       `<a href="${base}interface/signup.html">Signup</a>`+
       `<a href="${base}README.html" class="icon-only readme-link" aria-label="Help">?</a>`+

--- a/interface/chat.html
+++ b/interface/chat.html
@@ -16,7 +16,7 @@
   </header>
   <nav aria-label="Main navigation">
     <a href="../index.html">Home</a>
-    <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
     <a href="login.html">Login</a>
     <a href="signup.html">Signup</a>
     <a href="../README.html" class="readme-link">README</a>

--- a/interface/designregeln.html
+++ b/interface/designregeln.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/donate.html
+++ b/interface/donate.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -21,7 +21,7 @@
   <nav aria-label="Main navigation">
     <a href="../index.html">Home</a>
     <a href="../bewertung.html">Bewertung</a>
-    <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
     <a href="login.html">Login</a>
     <a href="../wings/ratings.html">Ratings</a>
     <a href="signup.html">Signup</a>

--- a/interface/fish-interface/fischEditor.html
+++ b/interface/fish-interface/fischEditor.html
@@ -17,7 +17,7 @@
     <nav>
       <a href="../../index.html">Home</a>
       <a href="../../bewertung.html">Bewertung</a>
-      <a href="../settings.html" class="icon-only">⚙</a>
+      <a href="../settings_OLD.html" class="icon-only">⚙</a>
       <a href="../login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="../signup.html">Signup</a>

--- a/interface/fish-interface/fischeBern.html
+++ b/interface/fish-interface/fischeBern.html
@@ -17,7 +17,7 @@
     <nav>
       <a href="../../index.html">Home</a>
       <a href="../../bewertung.html">Bewertung</a>
-      <a href="../settings.html" class="icon-only">⚙</a>
+      <a href="../settings_OLD.html" class="icon-only">⚙</a>
       <a href="../login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="../signup.html">Signup</a>

--- a/interface/fish-interface/fischeSchweiz.html
+++ b/interface/fish-interface/fischeSchweiz.html
@@ -17,7 +17,7 @@
     <nav>
       <a href="../../index.html">Home</a>
       <a href="../../bewertung.html">Bewertung</a>
-      <a href="../settings.html" class="icon-only">⚙</a>
+      <a href="../settings_OLD.html" class="icon-only">⚙</a>
       <a href="../login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="../signup.html">Signup</a>

--- a/interface/fish-interface/gewaesserBern.html
+++ b/interface/fish-interface/gewaesserBern.html
@@ -17,7 +17,7 @@
     <nav>
       <a href="../../index.html">Home</a>
       <a href="../../bewertung.html">Bewertung</a>
-      <a href="../settings.html" class="icon-only">⚙</a>
+      <a href="../settings_OLD.html" class="icon-only">⚙</a>
       <a href="../login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="../signup.html">Signup</a>

--- a/interface/fish-interface/gewaesserCH.html
+++ b/interface/fish-interface/gewaesserCH.html
@@ -19,7 +19,7 @@
     <nav>
       <a href="../../index.html">Home</a>
       <a href="../../bewertung.html">Bewertung</a>
-      <a href="../settings.html" class="icon-only">⚙</a>
+      <a href="../settings_OLD.html" class="icon-only">⚙</a>
       <a href="../login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="../signup.html">Signup</a>

--- a/interface/fish.html
+++ b/interface/fish.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/hermes.html
+++ b/interface/hermes.html
@@ -17,7 +17,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/login.html
+++ b/interface/login.html
@@ -21,7 +21,7 @@
   <nav aria-label="Main navigation">
     <a href="../index.html">Home</a>
     <a href="../bewertung.html">Bewertung</a>
-    <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
     <a href="login.html" aria-current="page">Login</a>
     <a href="../wings/ratings.html">Ratings</a>
     <a href="signup.html">Signup</a>

--- a/interface/material.html
+++ b/interface/material.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/nav-menu.html
+++ b/interface/nav-menu.html
@@ -11,7 +11,7 @@
     <li><a href="../bsvrb-dept-5.html">Abteilung 5</a></li>
     <li><a href="../beatclub-basel.html">Beatclub Basel</a></li>
     <li><a href="../grimmhorn.html">Grimmhorn</a></li>
-    <li><a href="settings.html">⚙ Einstellungen</a></li>
+    <li><a href="settings_OLD.html">⚙ Einstellungen</a></li>
     <li><a href="login.html">🔑 Login</a></li>
     <li><a href="signup.html">Signup</a></li>
     <li><a href="chat.html">Chat</a></li>

--- a/interface/navigator.html
+++ b/interface/navigator.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/nielsen.html
+++ b/interface/nielsen.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/norman.html
+++ b/interface/norman.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/op0-navigation.js
+++ b/interface/op0-navigation.js
@@ -18,7 +18,7 @@
     const navHtml =
       '<nav class="op0-nav">'+
       `<a href="${base}index.html" class="icon-only" aria-label="Home">\u{1F3E0}</a>`+
-      `<a href="${base}interface/settings.html" class="icon-only" aria-label="Settings">\u2699</a>`+
+      `<a href="${base}interface/settings_OLD.html" class="icon-only" aria-label="Settings">\u2699</a>`+
       `<a href="${base}interface/login.html" class="icon-only" aria-label="Login">\u{1F511}</a>`+
       `<a href="${base}interface/signup.html">Signup</a>`+
       `<a href="${base}README.html" class="icon-only readme-link" aria-label="Help">?</a>`+

--- a/interface/settings_OLD.html
+++ b/interface/settings_OLD.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- DEPRECATED: This old settings interface is kept for reference. A new implementation will replace it. -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -20,7 +21,7 @@
   <nav aria-label="Main navigation">
     <a href="../index.html">Home</a>
     <a href="../bewertung.html">Bewertung</a>
-    <a href="settings.html" aria-current="page" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="settings_OLD.html" aria-current="page" class="icon-only" aria-label="Settings">⚙</a>
     <a href="../wings/ratings.html">Ratings</a>
     <a href="signup.html">Signup</a>
       <a href="hermes.html">Hermes</a>

--- a/interface/shneiderman.html
+++ b/interface/shneiderman.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -20,7 +20,7 @@
   <nav aria-label="Main navigation">
     <a href="../index.html">Home</a>
     <a href="../bewertung.html">Bewertung</a>
-    <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
     <a href="../wings/ratings.html">Ratings</a>
     <a href="signup.html" aria-current="page">Signup</a>
       <a href="hermes.html">Hermes</a>

--- a/interface/start.html
+++ b/interface/start.html
@@ -22,7 +22,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="connect.html">Connect</a>

--- a/org-bewertung.html
+++ b/org-bewertung.html
@@ -16,7 +16,7 @@
     <nav>
       <a href="index.html">Home</a>
       <a href="bewertung.html" aria-current="page">Bewertung</a>
-      <a href="interface/settings.html" class="icon-only">⚙</a>
+      <a href="interface/settings_OLD.html" class="icon-only">⚙</a>
       <a href="wings/ratings.html">Ratings</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="readme-link">README</a>

--- a/personenbewertung.html
+++ b/personenbewertung.html
@@ -17,7 +17,7 @@
     <nav>
       <a href="index.html">Home</a>
       <a href="bewertung.html" aria-current="page">Bewertung</a>
-      <a href="interface/settings.html" class="icon-only">⚙</a>
+      <a href="interface/settings_OLD.html" class="icon-only">⚙</a>
       <a href="wings/ratings.html">Ratings</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="readme-link">README</a>

--- a/template.html
+++ b/template.html
@@ -17,7 +17,7 @@
   </header>
   <nav>
     <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-    <a href="interface/settings.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/wings/index.html
+++ b/wings/index.html
@@ -25,7 +25,7 @@
     <a href="../interface/login.html" data-ui="nav_login">Login</a>
     <a href="../interface/signup.html" data-ui="nav_signup">Signup</a>
     <a href="../interface/tools.html" data-ui="nav_tools">Tools</a>
-    <a href="../interface/settings.html" data-ui="nav_settings" class="icon-only" title="Settings" aria-label="Settings">⚙</a>
+    <a href="../interface/settings_OLD.html" data-ui="nav_settings" class="icon-only" title="Settings" aria-label="Settings">⚙</a>
     <a href="index.html" aria-current="page">Wings</a>
     <a href="../README.md" target="_blank" data-ui="nav_readme" class="readme-link">README</a>
     <button id="side_menu" type="button" class="icon-only" aria-label="Menu" data-min-op="OP-6">☰</button>


### PR DESCRIPTION
## Summary
- rename `settings.html` to `settings_OLD.html`
- note deprecation in the settings page
- update documentation links to the old settings page
- point site navigation and docs to `settings_OLD.html`
- update file integrity hash for `ethicom.html`

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684c1507ec088321aaf88f51bea8ce10