### PR TITLE
Enable offline fallback with Tanna animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,11 @@
   <link rel="stylesheet" href="interface/ethicom-style.css">
   <script src="interface/bundle.js" defer></script>
   <script src="utils/op-level.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('./service-worker.js');
+    }
+  </script>
   <link rel="icon" href="sources/images/institutions/logo-bsvrb.svg" sizes="32x32">
 </head>
 <body class="home">
@@ -15,6 +20,9 @@
   <header>
     <a href="index.html"><img src="sources/images/institutions/logo-bsvrb.png" alt="BSVRB" class="title-logo"></a>
   </header>
+  <div id="offline_fallback" style="display:none;text-align:center;">
+    <img id="tanna_animation" src="sources/images/op-logo/tanna_op0.png" alt="Tanna animation" style="max-width:80%;height:auto;">
+  </div>
   <nav aria-label="Main">
     <a aria-current="page" class="icon-only" aria-label="Home">🏠</a>
     <a href="signup.html" class="icon-only" aria-label="Signup or Login">🔑</a>
@@ -22,5 +30,23 @@
   </nav>
   <main id="main_content"></main>
   <footer id="version_footer" class="text-xs text-center my-4"></footer>
+  <script>
+    async function serverOnline() {
+      try {
+        const r = await fetch('config.json', {method:'HEAD', cache:'no-cache'});
+        return r.ok;
+      } catch {
+        return false;
+      }
+    }
+    window.addEventListener('load', async () => {
+      if (!await serverOnline()) {
+        const el = document.getElementById('offline_fallback');
+        if (el) el.style.display = 'block';
+        if (typeof startTannaAnimation === 'function')
+          startTannaAnimation('tanna_animation');
+      }
+    });
+  </script>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,22 @@
+const CACHE_NAME = 'bsvrb-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/interface/ethicom-style.css',
+  '/interface/bundle.js',
+  '/utils/op-level.js',
+  '/sources/images/op-logo/tanna_op0.png',
+  '/sources/images/op-logo/tanna_op1.png',
+  '/sources/images/op-logo/tanna_op2.png',
+  '/sources/images/op-logo/tanna_op3.png',
+  '/sources/images/op-logo/tanna_op4.png',
+  '/sources/images/op-logo/tanna_op5.png',
+  '/sources/images/op-logo/tanna_op6.png',
+  '/sources/images/op-logo/tanna_op7.png'
+];
+self.addEventListener('install', evt => {
+  evt.waitUntil(caches.open(CACHE_NAME).then(c => c.addAll(ASSETS)));
+});
+self.addEventListener('fetch', evt => {
+  evt.respondWith(caches.match(evt.request).then(res => res || fetch(evt.request)));
+});


### PR DESCRIPTION
## Summary
- add service worker for offline resources
- show Tanna logo animation when server unavailable
- register service worker from the main page

## Testing
- `node --test` *(fails: 9 failing tests)*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684c195a6bf483219aab3a845cf76b5b