### PR TITLE
Remove bundled better-sqlite3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ app/data.db
 __pycache__/
 *.py[cod]
 aari/config.json
+downloads/better-sqlite3-*.tgz

--- a/README.md
+++ b/README.md
@@ -655,7 +655,8 @@ fetchers.
 ### Running Tests
 [⇧](#contents)
 
-Ensure Node.js 18 or later is installed and run `npm install` to install the dependencies (e.g., `better-sqlite3`), then run:
+Ensure Node.js 18 or later is installed and run `npm install` to install the dependencies. Run `tools/fetch-better-sqlite3.sh` to download the `better-sqlite3` archive from the npm registry for offline setups.
+Then run:
 
 ```bash
 node --test

--- a/docs/NEUE_BENUTZER_DE.md
+++ b/docs/NEUE_BENUTZER_DE.md
@@ -4,9 +4,9 @@ Diese kurze Anleitung zeigt, wie du die Struktur 4789 lokal starten kannst.
 
 1. [README.md](../README.md) lesen, um Zweck und Aufbau zu verstehen.
 2. Node.js ≥18 installieren und `npm install` ausführen.
-   Dabei werden die JavaScript-Abhängigkeiten wie `better-sqlite3`
-   für die lokale SQLite-Datenbank installiert. Alternativ kannst du
-   `tools/guided-install.sh` nutzen.
+   Falls du ein Offline-Archiv von `better-sqlite3` benötigst,
+   lädt `tools/fetch-better-sqlite3.sh` das Paket aus dem npm-Registry herunter.
+   Alternativ kannst du `tools/guided-install.sh` nutzen.
 3. Einmalig `node tools/migrate-json-to-db.js` ausführen, um vorhandene JSON-Daten in die SQLite-Datenbank zu übernehmen.
 4. Server mit `npm start` oder `node tools/start-server.js` starten.
    Optional kannst du einen Seitennamen anhängen, z.B. `npm start signup.html`.

--- a/tools/fetch-better-sqlite3.sh
+++ b/tools/fetch-better-sqlite3.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Download the better-sqlite3 archive for offline installation.
+set -e
+
+# Disclaimers
+echo "Diese Struktur wird ohne Gew\u00e4hrleistung bereitgestellt. Fehler oder Auslassungen sind m\u00f6glich."
+echo "Die Nutzung erfolgt auf eigene Verantwortung. Weder Signature 4789 noch die Maintainer haften f\u00fcr Folgen oder Anspr\u00fcche."
+echo "4789 ist ein Standard f\u00fcr Verantwortung, keine Person und kein Glaubenssystem."
+echo "Nutzung nur reflektiert und mit Konsequenz, niemals zur Manipulation oder unkontrollierten Automatisierung."
+
+# Always run from repository root
+cd "$(dirname "$0")/.."
+
+version=$(node -p "require('./package.json').dependencies['better-sqlite3']")
+# Strip leading ^ if present
+version=${version#^}
+
+npm pack "better-sqlite3@$version"
+mkdir -p downloads
+mv "better-sqlite3-$version.tgz" "downloads/better-sqlite3-$version.tgz"
+
+echo "Archive stored at downloads/better-sqlite3-$version.tgz"


### PR DESCRIPTION
## Summary
- stop bundling `better-sqlite3-11.10.0.tgz`
- add `tools/fetch-better-sqlite3.sh` to download the archive from npm
- note the helper script in docs
- ignore downloaded archives in `.gitignore`

## Testing
- `npm install`
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684c19d4c04883218ecb9f19f36cc4fe