### PR TITLE
Fix test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev librsvg2-dev build-essential
       - run: npm install
-      - run: rm -rf node_modules
       - run: node --test
       - run: node tools/check-translations.js
       - run: node tools/check-file-integrity.js


### PR DESCRIPTION
## Summary
- keep `node_modules` in the GitHub Actions workflow so dependencies like `better-sqlite3` remain available

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684c1b6124c48321a1520714b5db0f9b