### PR TITLE
Limit settings access to OP‑2

### DIFF
--- a/README.html
+++ b/README.html
@@ -17,7 +17,7 @@
   </header>
   <nav>
     <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a aria-current="page" class="icon-only readme-link" aria-label="Help">?</a>

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ See [docs/FOLDER_STRUCTURE.md](docs/FOLDER_STRUCTURE.md) for a concise directory
 | [bewertung.html](bewertung.html) | Entry page for rating modules |
 | [personenbewertung.html](personenbewertung.html) | Swipe-based person rating |
 | [org-bewertung.html](org-bewertung.html) | Preview for organisation ratings |
-| [interface/settings_OLD.html](interface/settings_OLD.html) | Language, theme, Tanna logo, and low motion settings |
+| [interface/settings_OLD.html](interface/settings_OLD.html) | Language, theme, Tanna logo, and low motion settings (visible from OP-2) |
 | [interface/signup.html](interface/signup.html) | Registration form |
 | [interface/offline-signup.html](interface/offline-signup.html) | Offline local signup |
 
@@ -284,7 +284,7 @@ Use the `image_url` field in `sources/persons/human-op0-candidates.json` to reco
 [⇧](#contents)
 
 **ethicom.html**
-SHA-256: 38ebbdd1d3363432e9e9cda982e7aca6391786d779ff52e4566a8f0c8a0754d7
+SHA-256: 334ba96685c105f4037866fcb54ce604671cad4e5cc0665da06b844ee418cc1a
 Verified 2025-05-21 by Signature 4789
 
 **ethicom-consensus.js**

--- a/beatclub-basel.html
+++ b/beatclub-basel.html
@@ -20,7 +20,7 @@
   </div>
   <nav>
     <a href="beatclub-basel.html" class="icon-only" aria-label="Home" aria-current="page">🏠</a>
-    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bewertung.html
+++ b/bewertung.html
@@ -16,7 +16,7 @@
     <p class="tagline">Modul-Auswahl</p>
     <nav>
       <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-      <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="interface/settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
       <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bsvrb-dept-1.html
+++ b/bsvrb-dept-1.html
@@ -17,7 +17,7 @@
   </header>
   <nav>
     <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bsvrb-dept-2.html
+++ b/bsvrb-dept-2.html
@@ -17,7 +17,7 @@
   </header>
   <nav>
     <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bsvrb-dept-3.html
+++ b/bsvrb-dept-3.html
@@ -17,7 +17,7 @@
   </header>
   <nav>
     <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bsvrb-dept-4.html
+++ b/bsvrb-dept-4.html
@@ -17,7 +17,7 @@
   </header>
   <nav>
     <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bsvrb-dept-5.html
+++ b/bsvrb-dept-5.html
@@ -17,7 +17,7 @@
   </header>
   <nav>
     <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bsvrb-fischerabteilung.html
+++ b/bsvrb-fischerabteilung.html
@@ -19,7 +19,7 @@
   </div>
   <nav>
       <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-      <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="interface/settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
       <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
       <a href="interface/signup.html">Signup</a>
       <a href="interface/fish.html">Fish Interface</a>

--- a/bsvrb-kulturabteilung.html
+++ b/bsvrb-kulturabteilung.html
@@ -19,7 +19,7 @@
   </div>
   <nav>
       <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-      <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="interface/settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
       <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/bsvrb-quality.html
+++ b/bsvrb-quality.html
@@ -19,7 +19,7 @@
   </div>
   <nav>
       <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-      <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="interface/settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
       <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/docs/README.html
+++ b/docs/README.html
@@ -17,7 +17,7 @@
   </header>
   <nav>
     <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a aria-current="page" class="icon-only readme-link" aria-label="Help">?</a>

--- a/grimmhorn.html
+++ b/grimmhorn.html
@@ -20,7 +20,7 @@
   </div>
   <nav>
     <a href="grimmhorn.html" class="icon-only" aria-label="Home" aria-current="page">🏠</a>
-    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/interface/apple-hig.html
+++ b/interface/apple-hig.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/bundle.js
+++ b/interface/bundle.js
@@ -3071,7 +3071,7 @@ window.addEventListener('DOMContentLoaded', () => {
     const navHtml =
       '<nav class="op0-nav">'+
       `<a href="${base}index.html" class="icon-only" aria-label="Home">\u{1F3E0}</a>`+
-      `<a href="${base}interface/settings_OLD.html" class="icon-only" aria-label="Settings">\u2699</a>`+
+      `<a href="${base}interface/settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">\u2699</a>`+
       `<a href="${base}interface/login.html" class="icon-only" aria-label="Login">\u{1F511}</a>`+
       `<a href="${base}interface/signup.html">Signup</a>`+
       `<a href="${base}README.html" class="icon-only readme-link" aria-label="Help">?</a>`+

--- a/interface/chat.html
+++ b/interface/chat.html
@@ -16,7 +16,7 @@
   </header>
   <nav aria-label="Main navigation">
     <a href="../index.html">Home</a>
-    <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
     <a href="login.html">Login</a>
     <a href="signup.html">Signup</a>
     <a href="../README.html" class="readme-link">README</a>

--- a/interface/designregeln.html
+++ b/interface/designregeln.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/donate.html
+++ b/interface/donate.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/ethicom.html
+++ b/interface/ethicom.html
@@ -21,7 +21,7 @@
   <nav aria-label="Main navigation">
     <a href="../index.html">Home</a>
     <a href="../bewertung.html">Bewertung</a>
-    <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
     <a href="login.html">Login</a>
     <a href="../wings/ratings.html">Ratings</a>
     <a href="signup.html">Signup</a>

--- a/interface/fish-interface/fischEditor.html
+++ b/interface/fish-interface/fischEditor.html
@@ -17,7 +17,7 @@
     <nav>
       <a href="../../index.html">Home</a>
       <a href="../../bewertung.html">Bewertung</a>
-      <a href="../settings_OLD.html" class="icon-only">⚙</a>
+      <a href="../settings_OLD.html" data-min-op="OP-2" class="icon-only">⚙</a>
       <a href="../login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="../signup.html">Signup</a>

--- a/interface/fish-interface/fischeBern.html
+++ b/interface/fish-interface/fischeBern.html
@@ -17,7 +17,7 @@
     <nav>
       <a href="../../index.html">Home</a>
       <a href="../../bewertung.html">Bewertung</a>
-      <a href="../settings_OLD.html" class="icon-only">⚙</a>
+      <a href="../settings_OLD.html" data-min-op="OP-2" class="icon-only">⚙</a>
       <a href="../login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="../signup.html">Signup</a>

--- a/interface/fish-interface/fischeSchweiz.html
+++ b/interface/fish-interface/fischeSchweiz.html
@@ -17,7 +17,7 @@
     <nav>
       <a href="../../index.html">Home</a>
       <a href="../../bewertung.html">Bewertung</a>
-      <a href="../settings_OLD.html" class="icon-only">⚙</a>
+      <a href="../settings_OLD.html" data-min-op="OP-2" class="icon-only">⚙</a>
       <a href="../login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="../signup.html">Signup</a>

--- a/interface/fish-interface/gewaesserBern.html
+++ b/interface/fish-interface/gewaesserBern.html
@@ -17,7 +17,7 @@
     <nav>
       <a href="../../index.html">Home</a>
       <a href="../../bewertung.html">Bewertung</a>
-      <a href="../settings_OLD.html" class="icon-only">⚙</a>
+      <a href="../settings_OLD.html" data-min-op="OP-2" class="icon-only">⚙</a>
       <a href="../login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="../signup.html">Signup</a>

--- a/interface/fish-interface/gewaesserCH.html
+++ b/interface/fish-interface/gewaesserCH.html
@@ -19,7 +19,7 @@
     <nav>
       <a href="../../index.html">Home</a>
       <a href="../../bewertung.html">Bewertung</a>
-      <a href="../settings_OLD.html" class="icon-only">⚙</a>
+      <a href="../settings_OLD.html" data-min-op="OP-2" class="icon-only">⚙</a>
       <a href="../login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="../signup.html">Signup</a>

--- a/interface/fish.html
+++ b/interface/fish.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/hermes.html
+++ b/interface/hermes.html
@@ -17,7 +17,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/login.html
+++ b/interface/login.html
@@ -21,7 +21,7 @@
   <nav aria-label="Main navigation">
     <a href="../index.html">Home</a>
     <a href="../bewertung.html">Bewertung</a>
-    <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
     <a href="login.html" aria-current="page">Login</a>
     <a href="../wings/ratings.html">Ratings</a>
     <a href="signup.html">Signup</a>

--- a/interface/material.html
+++ b/interface/material.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/nav-menu.html
+++ b/interface/nav-menu.html
@@ -11,7 +11,7 @@
     <li><a href="../bsvrb-dept-5.html">Abteilung 5</a></li>
     <li><a href="../beatclub-basel.html">Beatclub Basel</a></li>
     <li><a href="../grimmhorn.html">Grimmhorn</a></li>
-    <li><a href="settings_OLD.html">⚙ Einstellungen</a></li>
+    <li><a href="settings_OLD.html" data-min-op="OP-2">⚙ Einstellungen</a></li>
     <li><a href="login.html">🔑 Login</a></li>
     <li><a href="signup.html">Signup</a></li>
     <li><a href="chat.html">Chat</a></li>

--- a/interface/navigator.html
+++ b/interface/navigator.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/nielsen.html
+++ b/interface/nielsen.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/norman.html
+++ b/interface/norman.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/op0-navigation.js
+++ b/interface/op0-navigation.js
@@ -18,7 +18,7 @@
     const navHtml =
       '<nav class="op0-nav">'+
       `<a href="${base}index.html" class="icon-only" aria-label="Home">\u{1F3E0}</a>`+
-      `<a href="${base}interface/settings_OLD.html" class="icon-only" aria-label="Settings">\u2699</a>`+
+      `<a href="${base}interface/settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">\u2699</a>`+
       `<a href="${base}interface/login.html" class="icon-only" aria-label="Login">\u{1F511}</a>`+
       `<a href="${base}interface/signup.html">Signup</a>`+
       `<a href="${base}README.html" class="icon-only readme-link" aria-label="Help">?</a>`+

--- a/interface/settings_OLD.html
+++ b/interface/settings_OLD.html
@@ -21,7 +21,7 @@
   <nav aria-label="Main navigation">
     <a href="../index.html">Home</a>
     <a href="../bewertung.html">Bewertung</a>
-    <a href="settings_OLD.html" aria-current="page" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="settings_OLD.html" data-min-op="OP-2" aria-current="page" class="icon-only" aria-label="Settings">⚙</a>
     <a href="../wings/ratings.html">Ratings</a>
     <a href="signup.html">Signup</a>
       <a href="hermes.html">Hermes</a>

--- a/interface/shneiderman.html
+++ b/interface/shneiderman.html
@@ -16,7 +16,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="signup.html">Signup</a>

--- a/interface/signup.html
+++ b/interface/signup.html
@@ -20,7 +20,7 @@
   <nav aria-label="Main navigation">
     <a href="../index.html">Home</a>
     <a href="../bewertung.html">Bewertung</a>
-    <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
     <a href="../wings/ratings.html">Ratings</a>
     <a href="signup.html" aria-current="page">Signup</a>
       <a href="hermes.html">Hermes</a>

--- a/interface/start.html
+++ b/interface/start.html
@@ -22,7 +22,7 @@
     <nav aria-label="Main navigation">
       <a href="../index.html">Home</a>
       <a href="../bewertung.html">Bewertung</a>
-      <a href="settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+      <a href="settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
       <a href="login.html">Login</a>
       <a href="../wings/ratings.html">Ratings</a>
       <a href="connect.html">Connect</a>

--- a/org-bewertung.html
+++ b/org-bewertung.html
@@ -16,7 +16,7 @@
     <nav>
       <a href="index.html">Home</a>
       <a href="bewertung.html" aria-current="page">Bewertung</a>
-      <a href="interface/settings_OLD.html" class="icon-only">⚙</a>
+      <a href="interface/settings_OLD.html" data-min-op="OP-2" class="icon-only">⚙</a>
       <a href="wings/ratings.html">Ratings</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="readme-link">README</a>

--- a/personenbewertung.html
+++ b/personenbewertung.html
@@ -17,7 +17,7 @@
     <nav>
       <a href="index.html">Home</a>
       <a href="bewertung.html" aria-current="page">Bewertung</a>
-      <a href="interface/settings_OLD.html" class="icon-only">⚙</a>
+      <a href="interface/settings_OLD.html" data-min-op="OP-2" class="icon-only">⚙</a>
       <a href="wings/ratings.html">Ratings</a>
       <a href="interface/signup.html">Signup</a>
       <a href="README.html" class="readme-link">README</a>

--- a/template.html
+++ b/template.html
@@ -17,7 +17,7 @@
   </header>
   <nav>
     <a href="index.html" class="icon-only" aria-label="Home">🏠</a>
-    <a href="interface/settings_OLD.html" class="icon-only" aria-label="Settings">⚙</a>
+    <a href="interface/settings_OLD.html" data-min-op="OP-2" class="icon-only" aria-label="Settings">⚙</a>
     <a href="interface/login.html" class="icon-only" aria-label="Login">🔑</a>
     <a href="interface/signup.html">Signup</a>
     <a href="README.html" class="icon-only readme-link" aria-label="Help">?</a>

--- a/wings/index.html
+++ b/wings/index.html
@@ -25,7 +25,7 @@
     <a href="../interface/login.html" data-ui="nav_login">Login</a>
     <a href="../interface/signup.html" data-ui="nav_signup">Signup</a>
     <a href="../interface/tools.html" data-ui="nav_tools">Tools</a>
-    <a href="../interface/settings_OLD.html" data-ui="nav_settings" class="icon-only" title="Settings" aria-label="Settings">⚙</a>
+    <a href="../interface/settings_OLD.html" data-min-op="OP-2" data-ui="nav_settings" class="icon-only" title="Settings" aria-label="Settings">⚙</a>
     <a href="index.html" aria-current="page">Wings</a>
     <a href="../README.md" target="_blank" data-ui="nav_readme" class="readme-link">README</a>
     <button id="side_menu" type="button" class="icon-only" aria-label="Menu" data-min-op="OP-6">☰</button>


### PR DESCRIPTION
## Summary
- restrict settings menu to OP-2 or higher
- update README to mention OP-2 requirement and refresh file hash
- adjust bundle and navigation scripts to hide settings link before OP-2

## Testing
- `node --test` *(fails: Cannot find module 'better-sqlite3')*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684c3157dd0083218cb6977055f840fb