### PR TITLE
Implement OP logo collision highlight

### DIFF
--- a/improvements.md
+++ b/improvements.md
@@ -34,7 +34,7 @@ Diese Liste enthält konkrete Vorschläge zur Verbesserung der Benutzerfreundlic
 - [ ] Codecov oder Coveralls für Testabdeckung.
 - [ ] Snyk oder GitHub Advanced Security für Sicherheits-Scans.
 - [ ] DNA-Daten aus PDF extrahieren und in `gatekeeper/` integrieren.
-- [ ] OP-Logo-Kollisionen im Hintergrund stets sichtbar halten; Logo-Farbe vom Hintergrund abheben und davor platzieren.
+- [x] OP-Logo-Kollisionen im Hintergrund stets sichtbar halten; Logo-Farbe vom Hintergrund abheben und davor platzieren.
 
 ---
 

--- a/interface/bundle.js
+++ b/interface/bundle.js
@@ -2639,6 +2639,8 @@ function initLogoBackground() {
 
   function step() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const style = getComputedStyle(document.documentElement);
+    const collisionColor = style.getPropertyValue('--collision-color').trim() || '#ffff00';
 
     for (let i = 0; i < symbols.length; i++) {
       const s = symbols[i];
@@ -2808,6 +2810,16 @@ function initLogoBackground() {
         }
         ctx.filter = 'none';
         ctx.restore();
+
+        if (s.highlightUntil > performance.now()) {
+          ctx.save();
+          ctx.lineWidth = 2;
+          ctx.strokeStyle = collisionColor;
+          ctx.beginPath();
+          ctx.arc(s.x, s.y, s.radius * s.scale + 4, 0, Math.PI * 2);
+          ctx.stroke();
+          ctx.restore();
+        }
       }
 
     requestAnimationFrame(step);

--- a/interface/css/content.css
+++ b/interface/css/content.css
@@ -293,6 +293,7 @@ body.home #op_background {
   width: 100%;
   height: 100%;
   display: block;
+  filter: drop-shadow(0 0 2px var(--bg-color));
 }
 
 @keyframes backgroundSway {

--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -211,6 +211,8 @@ function initLogoBackground() {
 
   function step() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const style = getComputedStyle(document.documentElement);
+    const collisionColor = style.getPropertyValue('--collision-color').trim() || '#ffff00';
 
     for (let i = 0; i < symbols.length; i++) {
       const s = symbols[i];
@@ -380,6 +382,16 @@ function initLogoBackground() {
         }
         ctx.filter = 'none';
         ctx.restore();
+
+        if (s.highlightUntil > performance.now()) {
+          ctx.save();
+          ctx.lineWidth = 2;
+          ctx.strokeStyle = collisionColor;
+          ctx.beginPath();
+          ctx.arc(s.x, s.y, s.radius * s.scale + 4, 0, Math.PI * 2);
+          ctx.stroke();
+          ctx.restore();
+        }
       }
 
     requestAnimationFrame(step);


### PR DESCRIPTION
## Summary
- mark OP logo collision item as complete
- add drop shadow and highlight circle for OP logo collisions
- compute theme collision color in animation

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684c3288403c8321bcdc701cd3175cf2