### PR TITLE
Fix interface path resolution

### DIFF
--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -893,7 +893,8 @@ const server = http.createServer((req, res) => {
     });
     return;
   }
-  const filePath = path.join(root, urlPath);
+  const safePath = urlPath.replace(/^\/+/, '');
+  const filePath = path.join(root, safePath);
   fs.stat(filePath, (err, stats) => {
     if (!err && stats.isFile()) {
       serveFile(filePath, res);


### PR DESCRIPTION
## Summary
- ensure serve-interface removes leading slashes before joining paths

## Testing
- `node --test` *(fails: Cannot find module 'better-sqlite3')*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684c359d50948321b0d80471304d4413