### PR TITLE
Fix absolute path resolution in serve-interface

### DIFF
--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -893,7 +893,8 @@ const server = http.createServer((req, res) => {
     });
     return;
   }
-  const filePath = path.join(root, urlPath);
+  const safePath = urlPath.replace(/^\/+/, '');
+  const filePath = path.join(root, safePath);
   fs.stat(filePath, (err, stats) => {
     if (!err && stats.isFile()) {
       serveFile(filePath, res);


### PR DESCRIPTION
## Summary
- adjust path joining logic in `serve-interface.js` to handle leading slashes

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684c2ecf4adc8321ba61d2f99fa065d3