### PR TITLE
Update index page with department overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,52 @@
         <li>Im entpackten Ordner <code>node tools/easy-start.js</code> ausführen.</li>
       </ol>
     </section>
+    <section class="card" style="max-width:40em;margin:2em auto;">
+      <h1>Abteilungen</h1>
+      <ul style="text-align:left;">
+        <li><a href="bsvrb-dept-1.html">Gesellschaft / Bewegung / Plattform / Genuss</a> (Abteilung Soziales)</li>
+        <li><a href="bsvrb-dept-2.html">Bildung / Zukunft / Ethik</a> (Abteilung Verantwortung)</li>
+        <li><a href="bsvrb-dept-3.html">Technik / Innovation / Forschung</a> (Abteilung Wissenschaft)</li>
+        <li><a href="bsvrb-dept-5.html">Für Kultur, Natur, Mensch &amp; Region</a> (Abteilung Kultur)</li>
+        <li><a href="bsvrb-quality.html">Qualitätskontrolle / Verantwortungssystem / Sicherheitsprüfungen</a> (Abteilung Sicherheit)</li>
+      </ul>
+    </section>
+    <section class="card" style="max-width:40em;margin:2em auto;">
+      <h1>Begonnene Projekte</h1>
+      <details>
+        <summary><a href="verax/index.html">Verax – Entscheidungsspiel in natürlichem Raum</a> (Abt. Soz.)</summary>
+        <p>Realweltliches Spielsystem für Bewegung, Ethik und Entscheidungen in einem 300&nbsp;m breiten Korridor mit dokumentierter Bewertung.</p>
+      </details>
+      <details>
+        <summary><a href="bsvrb-fischerabteilung.html">Fische Schweiz – nationale Artenliste und Verbesserung der FischeApp für alle Kantone</a> (Abt. Kul.)</summary>
+        <p>Pro Piscis Bernensis fördert eine ökologische Fischerei, schützt einheimische Arten und arbeitet an einer aktualisierten App.</p>
+      </details>
+      <details>
+        <summary><a href="beatclub-basel.html">Beatclub Basel – Bier, Solidarität, Vielfalt, Rave &amp; Beats</a> (Abt. Soz.)</summary>
+        <p>Gemeinschaftsprojekt für kulturellen Austausch und elektronische Musik.</p>
+      </details>
+      <details>
+        <summary><a href="grimmhorn.html">Grimmhorn – Raum für laute Experimente</a> (Abt. Wis.)</summary>
+        <p>Ein archaisch-modernes Instrument mit zwei Klangkernen; lädt zu Klangexperimenten ein.</p>
+      </details>
+      <details>
+        <summary><a href="wings/index.html">Wings – Ethik-Kompass für technologische Projekte</a> (Abt. Ver.)</summary>
+        <p>Minimales Interface zur Bewertung technologischer Ideen nach ethischen Kriterien.</p>
+      </details>
+      <details>
+        <summary><a href="tantes.html">Tanna Demo – Hintergrundanimation</a> (Abt. Wis.)</summary>
+        <p>Demonstration einer animierten Tanna-Kollisionsgrafik im 4789-Stil.</p>
+      </details>
+    </section>
+    <section class="card" style="max-width:40em;margin:2em auto;">
+      <h2>Disclaimers</h2>
+      <ul>
+        <li>Diese Struktur wird ohne Gewährleistung bereitgestellt.</li>
+        <li>Die Nutzung erfolgt auf eigene Verantwortung.</li>
+        <li>4789 ist ein Standard für Verantwortung, keine Person.</li>
+        <li>Nutzung nur reflektiert und mit Konsequenz.</li>
+      </ul>
+    </section>
   </main>
   <footer id="version_footer" class="text-xs text-center my-4"></footer>
   <script>


### PR DESCRIPTION
## Summary
- list all departments with links to the existing department pages
- add expandable project overview with links
- show base disclaimers on the start page

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_684d4c4418608321a1a0819e66531bb3