### PR TITLE
Add unethical bumper tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ Tokens and device hashes are stored hashed in `app/gatekeeper_devices.json`.
 Run `node tools/gatekeeper.js prune` regularly to remove expired tokens and keep the file minimal.
 Monitor repeated failed attempts with `node tools/watchdog.js`. The script reads `app/gatekeeper_log.json` and warns when too many denials occur. Calm the watchdog with `node tools/watchdog.js feed` which appends a success entry.
 View recent log entries with `node tools/read-gatekeeper-log.js` to diagnose failures.
+Flag unethical text with `node tools/unethical-bumper.js`. The script scans input for unethical words and records repeated offences in `app/unethical_log.json`.
 Verify the stored hashes after updates with:
 
 ```bash

--- a/i18n/unethical-words.json
+++ b/i18n/unethical-words.json
@@ -1,0 +1,5 @@
+{
+  "en": ["fraud", "hate", "exploit"],
+  "de": ["betrug", "hass", "ausbeutung"],
+  "de-ch": ["betrug", "hass", "ausbeutig"]
+}

--- a/test/unethical-bumper.test.js
+++ b/test/unethical-bumper.test.js
@@ -1,0 +1,35 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const {
+  containsUnethical,
+  requiredConfirmationDiff,
+  logUnethical,
+  historyFor,
+  shouldDemote
+} = require('../tools/unethical-bumper');
+
+test('containsUnethical detects words', () => {
+  assert.strictEqual(containsUnethical('This is pure fraud', 'en'), true);
+  assert.strictEqual(containsUnethical('Clean text', 'en'), false);
+});
+
+test('requiredConfirmationDiff by level', () => {
+  assert.strictEqual(requiredConfirmationDiff('OP-1'), 2);
+  assert.strictEqual(requiredConfirmationDiff('OP-6'), 1);
+  assert.strictEqual(requiredConfirmationDiff('OP-9'), 0);
+});
+
+test('logUnethical records entries and demotion check', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bumper-'));
+  const file = path.join(dir, 'log.json');
+  logUnethical('sig', 'fraud', 'en', file);
+  logUnethical('sig', 'fraud again', 'en', file);
+  logUnethical('sig', 'third fraud', 'en', file);
+  const hist = historyFor('sig', file);
+  assert.strictEqual(hist.length, 3);
+  assert.strictEqual(shouldDemote('sig', 3, file), true);
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/tools/unethical-bumper.js
+++ b/tools/unethical-bumper.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+const path = require('path');
+
+const WORD_FILE = path.join(__dirname, '..', 'i18n', 'unethical-words.json');
+const LOG_FILE = path.join(__dirname, '..', 'app', 'unethical_log.json');
+
+function loadWords(lang = 'en') {
+  const data = JSON.parse(fs.readFileSync(WORD_FILE, 'utf8'));
+  return data[lang] || [];
+}
+
+function containsUnethical(text, lang = 'en') {
+  if (!text) return false;
+  const words = loadWords(lang);
+  const lower = text.toLowerCase();
+  return words.some(w => lower.includes(w.toLowerCase()));
+}
+
+function requiredConfirmationDiff(opLevel) {
+  const num = parseFloat(String(opLevel).replace('OP-', '')) || 0;
+  if (num >= 8) return 0;
+  if (num >= 5) return 1;
+  return 2;
+}
+
+function readLog(file = LOG_FILE) {
+  if (!fs.existsSync(file)) return [];
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return []; }
+}
+
+function writeLog(entries, file = LOG_FILE) {
+  fs.writeFileSync(file, JSON.stringify(entries, null, 2));
+}
+
+function logUnethical(signature, text, lang = 'en', file = LOG_FILE) {
+  const list = readLog(file);
+  const entry = {
+    ts: new Date().toISOString(),
+    signature,
+    lang,
+    excerpt: text.slice(0, 80)
+  };
+  list.push(entry);
+  writeLog(list, file);
+  return entry;
+}
+
+function historyFor(signature, file = LOG_FILE) {
+  return readLog(file).filter(e => e.signature === signature);
+}
+
+function shouldDemote(signature, threshold = 3, file = LOG_FILE) {
+  return historyFor(signature, file).length >= threshold;
+}
+
+if (require.main === module) {
+  const [opLevel, lang, signature, ...parts] = process.argv.slice(2);
+  if (!opLevel || !lang || !signature || parts.length === 0) {
+    console.error('Usage: node unethical-bumper.js <op-level> <lang> <signature> <text>');
+    process.exit(1);
+  }
+  const text = parts.join(' ');
+  const unethical = containsUnethical(text, lang);
+  if (unethical) logUnethical(signature, text, lang);
+  const confirm_diff = requiredConfirmationDiff(opLevel);
+  const demote = unethical && shouldDemote(signature);
+  console.log(JSON.stringify({ unethical, confirm_diff, demote }));
+}
+
+module.exports = {
+  loadWords,
+  containsUnethical,
+  requiredConfirmationDiff,
+  logUnethical,
+  historyFor,
+  shouldDemote
+};


### PR DESCRIPTION
## Summary
- implement `unethical-bumper.js` with log and demotion logic
- create minimal word list in `i18n/unethical-words.json`
- test bumper behaviour
- document usage in README

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_6852d4a12e5c832196138733ecce3b76