### PR TITLE
Implement humor option and version display

### DIFF
--- a/app/userprofile.json
+++ b/app/userprofile.json
@@ -1,3 +1,4 @@
 {
-  "formality": "du"
+  "formality": "du",
+  "humor": false
 }

--- a/config.json
+++ b/config.json
@@ -11,5 +11,9 @@
     "gatekeeperDevices": "app/gatekeeper_devices.json",
     "gatekeeperLog": "app/gatekeeper_log.json",
     "demotionLog": "app/demotion_log.json"
+  },
+  "defaults": {
+    "formality": "du",
+    "humor": false
   }
 }

--- a/docs/TASKS_OVERVIEW.md
+++ b/docs/TASKS_OVERVIEW.md
@@ -8,7 +8,7 @@ This file tracks pending improvements and roadmap actions.
 - [x] Add a simple ASCII diagram of the workflow.
 - [x] Provide a setup script for initial configuration (`tools/guided-install.sh`).
 - [x] Document a consistent folder structure.
-- [ ] Keep default settings in `config.json`.
+ - [x] Keep default settings in `config.json`.
 
 ## User Handling
 - [x] Offer optional local login.
@@ -23,14 +23,14 @@ This file tracks pending improvements and roadmap actions.
 
 ## Language and Feedback
 - [x] Allow global language switching via `locales/*.json`.
-- [ ] Provide options for formal, informal or neutral address.
+ - [x] Provide options for formal, informal or neutral address.
 - [x] Give clearer error messages with hints.
-- [ ] Add optional humorous responses.
+ - [x] Add optional humorous responses.
 
 ## Advanced
 - [x] Publish an OpenAPI spec.
 - [x] Add integrated help (`--help` or hotkeys).
-- [ ] Display version and build number in the interface.
+ - [x] Display version and build number in the interface.
 
 ## Roadmap Items
 - [ ] Replace the pass/ID system with an optional anonymous level.

--- a/i18n/ui-text.json
+++ b/i18n/ui-text.json
@@ -113,7 +113,8 @@
     "nav_navigator": "Navigator Menu",
     "nav_story": "Story",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "de": {
     "title": "Ethicom: Bewertung durch Menschen",
@@ -229,7 +230,8 @@
     "nav_navigator": "Navigator",
     "nav_story": "Geschichte",
     "signup_server_notice": "Nur mit lokalem Server nutzbar. Offline-signup.html verwenden, falls nötig.",
-    "login_welcome": "Willkommen zurück, {name}."
+    "login_welcome": "Willkommen zurück, {name}.",
+    "humor_toggle_label": "Humorvolle Rückmeldungen"
   },
   "de-ch": {
     "title": "Ethicom: Bewertung durch Menschen",
@@ -345,7 +347,8 @@
     "nav_navigator": "Navigator",
     "nav_story": "Geschichte",
     "signup_server_notice": "Nur mit lokalem Server nutzbar. Offline-signup.html verwenden, falls nötig.",
-    "login_welcome": "Willkommen zurück, {name}."
+    "login_welcome": "Willkommen zurück, {name}.",
+    "humor_toggle_label": "Humorvolle Rückmeldungen"
   },
   "fr": {
     "title": "Ethicom : Évaluation humaine",
@@ -461,7 +464,8 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "es": {
     "title": "Ethicom: Evaluación Humana",
@@ -577,7 +581,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "pt": {
     "title": "Ethicom: Avaliação Humana",
@@ -692,7 +697,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "zh": {
     "title": "Ethicom：人工评估",
@@ -808,7 +814,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "hi": {
     "title": "Ethicom: मानवीय मूल्यांकन",
@@ -923,7 +930,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "ar": {
     "title": "إيثيكوم: التقييم البشري",
@@ -1038,7 +1046,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "ja": {
     "title": "Ethicom：人間による評価",
@@ -1153,7 +1162,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "sw": {
     "title": "Ethicom: Tathmini ya Kibinadamu",
@@ -1268,7 +1278,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "ru": {
     "title": "Ethicom: Оценка человеком",
@@ -1383,7 +1394,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "it": {
     "title": "Ethicom: Valutazione Umana",
@@ -1499,7 +1511,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "ko": {
     "title": "Ethicom: 인간 평가",
@@ -1614,7 +1627,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "fa": {
     "title": "ایتیکام: ارزیابی انسانی",
@@ -1729,7 +1743,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "pl": {
     "title": "Ethicom: Ocena Ludzka",
@@ -1844,7 +1859,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "am": {
     "title": "Ethicom: Human Evaluation",
@@ -1959,7 +1975,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "af": {
     "title": "Ethicom: Human Evaluation",
@@ -2074,7 +2091,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "bn": {
     "title": "Ethicom: Human Evaluation",
@@ -2189,7 +2207,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "ha": {
     "title": "Ethicom: Human Evaluation",
@@ -2304,7 +2323,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "id": {
     "title": "Ethicom: Human Evaluation",
@@ -2419,7 +2439,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "ig": {
     "title": "Ethicom: Human Evaluation",
@@ -2534,7 +2555,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "om": {
     "title": "Ethicom: Human Evaluation",
@@ -2649,7 +2671,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "rm": {
     "title": "Ethicom: Human Evaluation",
@@ -2764,7 +2787,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "ta": {
     "title": "Ethicom: Human Evaluation",
@@ -2879,7 +2903,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "te": {
     "title": "Ethicom: Human Evaluation",
@@ -2994,7 +3019,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "th": {
     "title": "Ethicom: Human Evaluation",
@@ -3109,7 +3135,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "tr": {
     "title": "Ethicom: Human Evaluation",
@@ -3224,7 +3251,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "ur": {
     "title": "Ethicom: Human Evaluation",
@@ -3340,7 +3368,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "vi": {
     "title": "Ethicom: Human Evaluation",
@@ -3455,7 +3484,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "xh": {
     "title": "Ethicom: Human Evaluation",
@@ -3570,7 +3600,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "yo": {
     "title": "Ethicom: Human Evaluation",
@@ -3685,7 +3716,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "zu": {
     "title": "Ethicom: Human Evaluation",
@@ -3800,7 +3832,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   },
   "nl": {
     "title": "Ethicom: Menselijke Evaluatie",
@@ -3915,6 +3948,7 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "humor_toggle_label": "Humorous responses"
   }
 }

--- a/improvements.md
+++ b/improvements.md
@@ -22,9 +22,9 @@ Diese Liste enthält konkrete Vorschläge zur Verbesserung der Benutzerfreundlic
 
 ## 5. Sprachführung & Dialoge
 - [x] Globale Sprachumschaltung via locales/*.json.
-- [ ] Einstellung für Du/Sie oder neutrale Ansprache.
+- [x] Einstellung für Du/Sie oder neutrale Ansprache.
 - [x] Fehlermeldungen mit klaren Hinweisen zur Lösung.
-- [ ] Optionale humorvolle Rückmeldungen ohne Klarheit zu verlieren.
+- [x] Optionale humorvolle Rückmeldungen ohne Klarheit zu verlieren.
 
 ## 6. Weiterführende Verbesserungen
 - [x] API-Dokumentation mit OpenAPI/YAML.

--- a/interface/bundle.js
+++ b/interface/bundle.js
@@ -868,7 +868,7 @@ function openColorSettingsWizard(){
 
   cancelBtn.addEventListener('click', () => overlay.remove());
 
-  const tempTheme = localStorage.getItem('ethicom_theme') || 'transparent';
+  const tempTheme = localStorage.getItem('ethicom_theme') || 'tanna-dark';
   tempColors = {};
 
   const steps = [];
@@ -948,7 +948,7 @@ window.openColorSettingsWizard = openColorSettingsWizard;
 
 function openColorSettingsWizardCLI(){
   const themes=['dark','tanna-dark','tanna','transparent','ocean','desert','accessible','custom'];
-  let theme=prompt('Color Scheme ('+themes.join(', ')+'):',localStorage.getItem('ethicom_theme')||'transparent');
+  let theme=prompt('Color Scheme ('+themes.join(', ')+'):',localStorage.getItem('ethicom_theme')||'tanna-dark');
   if(theme&&themes.includes(theme)){
     localStorage.setItem('ethicom_theme',theme);
     if(typeof applyTheme==='function') applyTheme(theme);
@@ -2326,16 +2326,22 @@ function applyLoginTexts() {
     if (lang.startsWith('de')) formalityLabel.textContent = 'Ansprache:';
     else formalityLabel.textContent = 'Address formality:';
   }
+  const humorLabel = document.querySelector('label[for="humor_toggle"]');
+  if (humorLabel) humorLabel.textContent = t.humor_toggle_label || humorLabel.textContent;
 }
 
-function makeWelcome(name, formality) {
+function makeWelcome(name, formality, humor) {
   const lang = document.documentElement.lang || 'de';
   if (lang.startsWith('de')) {
     if (formality === 'sie') return `Sch\u00f6n, dass Sie wieder da sind, ${name}.`;
     if (formality === 'neutral') return `Willkommen zur\u00fcck, ${name}.`;
-    return `Sch\u00f6n, dass du wieder da bist, ${name}.`;
+    let msg = `Sch\u00f6n, dass du wieder da bist, ${name}.`;
+    if (humor) msg += ' \u263A';
+    return msg;
   }
-  return (uiText.login_welcome || 'Welcome back, {name}.').replace('{name}', name);
+  let msg = (uiText.login_welcome || 'Welcome back, {name}.').replace('{name}', name);
+  if (humor) msg += ' \u263A';
+  return msg;
 }
 
 function initLogin() {
@@ -2358,9 +2364,11 @@ function loadProfile() {
       }
       const sel = document.getElementById('formality_select');
       if (sel && p.formality) sel.value = p.formality;
+      const humorBox = document.getElementById('humor_toggle');
+      if (humorBox) humorBox.checked = !!p.humor;
       if (p.alias) {
         const statusEl = document.getElementById('login_status');
-        statusEl.textContent = makeWelcome(p.alias, p.formality);
+        statusEl.textContent = makeWelcome(p.alias, p.formality, p.humor);
       }
     })
     .catch(() => {});
@@ -2399,10 +2407,11 @@ function handleLogin() {
       const sig = { email, id: data.id, op_level: data.op_level, alias: data.alias };
       localStorage.setItem('ethicom_signature', JSON.stringify(sig));
       const formality = document.getElementById('formality_select')?.value || 'du';
+      const humor = document.getElementById('humor_toggle')?.checked || false;
       fetch('/api/profile', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ alias: data.alias, lang: getLanguage(), formality })
+        body: JSON.stringify({ alias: data.alias, lang: getLanguage(), formality, humor })
       }).catch(() => {});
       statusEl.textContent = uiText.login_saved || 'Login successful. ID stored.';
       setTimeout(() => { window.location.href = 'ethicom.html'; }, 500);
@@ -2552,8 +2561,8 @@ function initLogoBackground() {
 
   const symbols = [];
   // Density of floating symbols can be customized via settings
-  const storedPct = parseInt(localStorage.getItem('ethicom_bg_fill') || '40', 10);
-  const fillRatio = Number.isFinite(storedPct) ? storedPct / 100 : 0.4;
+  const storedPct = parseInt(localStorage.getItem('ethicom_bg_fill') || '80', 10);
+  const fillRatio = Number.isFinite(storedPct) ? storedPct / 100 : 0.8;
   const storedSize = parseInt(localStorage.getItem('ethicom_bg_symbol_size') || '100', 10);
   const sizeScale = Number.isFinite(storedSize) ? storedSize / 100 : 1;
   const avgSize =
@@ -3530,6 +3539,69 @@ if (typeof module !== 'undefined') {
   setInterval(check, 60 * 1000);
 })();
 
+
+
+//----- set-password.js -----
+function getParam(name) {
+  const m = new URLSearchParams(location.search).get(name);
+  return m ? m.replace(/[^a-z0-9_-]/gi, '') : '';
+}
+
+async function savePassword(user) {
+  const pw1 = document.getElementById('pw1').value;
+  const pw2 = document.getElementById('pw2').value;
+  const status = document.getElementById('status');
+  status.textContent = '';
+  if (pw1 !== pw2) { status.textContent = 'Passw\u00f6rter stimmen nicht \u00fcberein.'; return; }
+  if (pw1.length < 8) { status.textContent = 'Mindestens 8 Zeichen.'; return; }
+  const hash = await sha256(pw1);
+  localStorage.setItem('pw_' + user, hash);
+  localStorage.setItem('pwSet_' + user, '1');
+  status.textContent = 'Gespeichert.';
+  setTimeout(() => { location.href = '../index.html'; }, 500);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  const user = getParam('u');
+  const label = document.getElementById('user_label');
+  if (user === 'ref') label.textContent = 'Login f\u00fcr RL';
+  else if (user === 'baduren') label.textContent = 'Login f\u00fcr MB';
+  else label.textContent = user;
+  document.getElementById('save_btn').addEventListener('click', () => savePassword(user));
+});
+
+
+//----- set-pin.js -----
+function tryPin() {
+  const pin = document.getElementById('pin_input').value.trim();
+  const status = document.getElementById('status');
+  const blockedUntil = parseInt(localStorage.getItem('sime_blocked') || '0', 10);
+  if (blockedUntil > Date.now()) {
+    const dt = new Date(blockedUntil).toLocaleString();
+    status.textContent = 'Gesperrt bis ' + dt;
+    return;
+  }
+  if (pin === '1988') {
+    localStorage.setItem('pin_sime', '1988');
+    localStorage.removeItem('sime_attempts');
+    status.textContent = 'Willkommen.';
+    setTimeout(() => { location.href = '../index.html'; }, 500);
+    return;
+  }
+  let attempts = parseInt(localStorage.getItem('sime_attempts') || '0', 10) + 1;
+  localStorage.setItem('sime_attempts', attempts);
+  if (attempts > 2) {
+    const until = Date.now() + 24*3600*1000;
+    localStorage.setItem('sime_blocked', until.toString());
+    status.textContent = 'Zu viele Fehlversuche. IP 24h blockiert. Admin RL informiert.';
+  } else {
+    status.textContent = 'Falscher PIN.';
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('pin_btn').addEventListener('click', tryPin);
+});
 
 
 //----- side-drop.js -----
@@ -4940,7 +5012,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
 //----- version.js -----
 window.APP_VERSION = '1.0.0';
-window.APP_COMMIT = 'd19fed3';
+window.APP_COMMIT = '5b1c26a';
 
 function displayVersionInfo() {
   var el = document.getElementById('version_footer');

--- a/interface/login.html
+++ b/interface/login.html
@@ -42,6 +42,10 @@
         <option value="neutral">Neutral</option>
       </select>
     </div>
+    <div id="humor_selection" class="card" style="margin-bottom:1em;">
+      <label for="humor_toggle" data-ui="humor_toggle_label">Humorous responses</label>
+      <input type="checkbox" id="humor_toggle" />
+    </div>
     <h2 data-ui="login_title">Login</h2>
     <label for="email_input" data-ui="login_email">Email:</label>
     <input type="email" id="email_input" placeholder="name@provider.com" />
@@ -58,6 +62,7 @@
     <button id="google_btn" onclick="startGoogleLogin()">Login with Google</button>
     <pre id="login_status" style="white-space:pre-wrap;margin-top:1em;"></pre>
   </main>
+  <footer id="version_footer" class="text-xs text-center my-4"></footer>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       checkLanguageSetup();

--- a/interface/login.js
+++ b/interface/login.js
@@ -19,16 +19,22 @@ function applyLoginTexts() {
     if (lang.startsWith('de')) formalityLabel.textContent = 'Ansprache:';
     else formalityLabel.textContent = 'Address formality:';
   }
+  const humorLabel = document.querySelector('label[for="humor_toggle"]');
+  if (humorLabel) humorLabel.textContent = t.humor_toggle_label || humorLabel.textContent;
 }
 
-function makeWelcome(name, formality) {
+function makeWelcome(name, formality, humor) {
   const lang = document.documentElement.lang || 'de';
   if (lang.startsWith('de')) {
     if (formality === 'sie') return `Sch\u00f6n, dass Sie wieder da sind, ${name}.`;
     if (formality === 'neutral') return `Willkommen zur\u00fcck, ${name}.`;
-    return `Sch\u00f6n, dass du wieder da bist, ${name}.`;
+    let msg = `Sch\u00f6n, dass du wieder da bist, ${name}.`;
+    if (humor) msg += ' \u263A';
+    return msg;
   }
-  return (uiText.login_welcome || 'Welcome back, {name}.').replace('{name}', name);
+  let msg = (uiText.login_welcome || 'Welcome back, {name}.').replace('{name}', name);
+  if (humor) msg += ' \u263A';
+  return msg;
 }
 
 function initLogin() {
@@ -51,9 +57,11 @@ function loadProfile() {
       }
       const sel = document.getElementById('formality_select');
       if (sel && p.formality) sel.value = p.formality;
+      const humorBox = document.getElementById('humor_toggle');
+      if (humorBox) humorBox.checked = !!p.humor;
       if (p.alias) {
         const statusEl = document.getElementById('login_status');
-        statusEl.textContent = makeWelcome(p.alias, p.formality);
+        statusEl.textContent = makeWelcome(p.alias, p.formality, p.humor);
       }
     })
     .catch(() => {});
@@ -92,10 +100,11 @@ function handleLogin() {
       const sig = { email, id: data.id, op_level: data.op_level, alias: data.alias };
       localStorage.setItem('ethicom_signature', JSON.stringify(sig));
       const formality = document.getElementById('formality_select')?.value || 'du';
+      const humor = document.getElementById('humor_toggle')?.checked || false;
       fetch('/api/profile', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ alias: data.alias, lang: getLanguage(), formality })
+        body: JSON.stringify({ alias: data.alias, lang: getLanguage(), formality, humor })
       }).catch(() => {});
       statusEl.textContent = uiText.login_saved || 'Login successful. ID stored.';
       setTimeout(() => { window.location.href = 'ethicom.html'; }, 500);

--- a/tools/serve-interface.js
+++ b/tools/serve-interface.js
@@ -191,7 +191,9 @@ function writeJson(file, data) {
 }
 
 function readProfile() {
-  return db.getProfile();
+  const base = db.getProfile();
+  const defaults = cfg.defaults || {};
+  return { ...defaults, ...base };
 }
 
 function writeProfile(data) {


### PR DESCRIPTION
## Summary
- keep default settings in `config.json`
- add humor toggle to user profile and login
- show version in login page
- update translation file with humor label
- mark tasks as completed in docs
- load defaults when serving profile

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_68586ea09df48321be73bfebc655f388