### PR TITLE
Add GPX editor for Verax

### DIFF
--- a/i18n/ui-text.json
+++ b/i18n/ui-text.json
@@ -113,7 +113,9 @@
     "nav_navigator": "Navigator Menu",
     "nav_story": "Story",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "de": {
     "title": "Ethicom: Bewertung durch Menschen",
@@ -229,7 +231,9 @@
     "nav_navigator": "Navigator",
     "nav_story": "Geschichte",
     "signup_server_notice": "Nur mit lokalem Server nutzbar. Offline-signup.html verwenden, falls nötig.",
-    "login_welcome": "Willkommen zurück, {name}."
+    "login_welcome": "Willkommen zurück, {name}.",
+    "verax_new_route": "Neue Route",
+    "verax_add_stop": "Stopp hinzufügen"
   },
   "de-ch": {
     "title": "Ethicom: Bewertung durch Menschen",
@@ -345,7 +349,9 @@
     "nav_navigator": "Navigator",
     "nav_story": "Geschichte",
     "signup_server_notice": "Nur mit lokalem Server nutzbar. Offline-signup.html verwenden, falls nötig.",
-    "login_welcome": "Willkommen zurück, {name}."
+    "login_welcome": "Willkommen zurück, {name}.",
+    "verax_new_route": "Neue Route",
+    "verax_add_stop": "Stopp hinzufügen"
   },
   "fr": {
     "title": "Ethicom : Évaluation humaine",
@@ -461,7 +467,9 @@
     "nav_story": "Story",
     "nav_navigator": "Navigator Menu",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "es": {
     "title": "Ethicom: Evaluación Humana",
@@ -577,7 +585,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "pt": {
     "title": "Ethicom: Avaliação Humana",
@@ -692,7 +702,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "zh": {
     "title": "Ethicom：人工评估",
@@ -808,7 +820,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "hi": {
     "title": "Ethicom: मानवीय मूल्यांकन",
@@ -923,7 +937,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "ar": {
     "title": "إيثيكوم: التقييم البشري",
@@ -1038,7 +1054,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "ja": {
     "title": "Ethicom：人間による評価",
@@ -1153,7 +1171,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "sw": {
     "title": "Ethicom: Tathmini ya Kibinadamu",
@@ -1268,7 +1288,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "ru": {
     "title": "Ethicom: Оценка человеком",
@@ -1383,7 +1405,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "it": {
     "title": "Ethicom: Valutazione Umana",
@@ -1499,7 +1523,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "ko": {
     "title": "Ethicom: 인간 평가",
@@ -1614,7 +1640,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "fa": {
     "title": "ایتیکام: ارزیابی انسانی",
@@ -1729,7 +1757,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "pl": {
     "title": "Ethicom: Ocena Ludzka",
@@ -1844,7 +1874,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "am": {
     "title": "Ethicom: Human Evaluation",
@@ -1959,7 +1991,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "af": {
     "title": "Ethicom: Human Evaluation",
@@ -2074,7 +2108,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "bn": {
     "title": "Ethicom: Human Evaluation",
@@ -2189,7 +2225,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "ha": {
     "title": "Ethicom: Human Evaluation",
@@ -2304,7 +2342,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "id": {
     "title": "Ethicom: Human Evaluation",
@@ -2419,7 +2459,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "ig": {
     "title": "Ethicom: Human Evaluation",
@@ -2534,7 +2576,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "om": {
     "title": "Ethicom: Human Evaluation",
@@ -2649,7 +2693,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "rm": {
     "title": "Ethicom: Human Evaluation",
@@ -2764,7 +2810,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "ta": {
     "title": "Ethicom: Human Evaluation",
@@ -2879,7 +2927,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "te": {
     "title": "Ethicom: Human Evaluation",
@@ -2994,7 +3044,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "th": {
     "title": "Ethicom: Human Evaluation",
@@ -3109,7 +3161,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "tr": {
     "title": "Ethicom: Human Evaluation",
@@ -3224,7 +3278,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "ur": {
     "title": "Ethicom: Human Evaluation",
@@ -3340,7 +3396,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "vi": {
     "title": "Ethicom: Human Evaluation",
@@ -3455,7 +3513,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "xh": {
     "title": "Ethicom: Human Evaluation",
@@ -3570,7 +3630,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "yo": {
     "title": "Ethicom: Human Evaluation",
@@ -3685,7 +3747,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "zu": {
     "title": "Ethicom: Human Evaluation",
@@ -3800,7 +3864,9 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   },
   "nl": {
     "title": "Ethicom: Menselijke Evaluatie",
@@ -3915,6 +3981,8 @@
     "signup_country": "Country/Region:",
     "signup_placeholder_country": "US",
     "signup_server_notice": "Requires local server. Use offline-signup.html if unavailable.",
-    "login_welcome": "Welcome back, {name}."
+    "login_welcome": "Welcome back, {name}.",
+    "verax_new_route": "New Route",
+    "verax_add_stop": "Add Stop"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "express": "^4.19.2",
+        "js-yaml": "^4.1.0",
         "node-telegram-bot-api": "^0.66.0"
       },
       "engines": {
@@ -237,6 +238,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -1922,6 +1929,18 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsbn": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "tools/serve-interface.js",
   "dependencies": {
     "express": "^4.19.2",
+    "js-yaml": "^4.1.0",
     "node-telegram-bot-api": "^0.66.0"
   },
   "optionalDependencies": {

--- a/tools/verax-save.js
+++ b/tools/verax-save.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const [,, gpxInput, stopsInput] = process.argv;
+if (!gpxInput || !stopsInput) {
+  console.error('Usage: node tools/verax-save.js <route.gpx> <stops.json>');
+  process.exit(1);
+}
+
+const destGpx = path.join(__dirname, '..', 'verax', 'map', path.basename(gpxInput));
+fs.copyFileSync(gpxInput, destGpx);
+
+const stops = JSON.parse(fs.readFileSync(stopsInput, 'utf8'));
+const codexPath = path.join(__dirname, '..', 'verax', 'codex', 'verax.yaml');
+const doc = yaml.load(fs.readFileSync(codexPath, 'utf8')) || {};
+doc.stops = doc.stops || [];
+doc.stops.push(...stops);
+fs.writeFileSync(codexPath, yaml.dump(doc, { lineWidth: 0 }));
+
+console.log('Route saved to', destGpx);

--- a/verax/README.md
+++ b/verax/README.md
@@ -74,6 +74,7 @@ Die folgenden Abschnitte fassen die Kernbausteine von VERAX zusammen.
 - Gefahren wie Bären, Wildflüsse, Kälte oder moralische Dilemmata
 - Authentische Einbindung historisch-helvetischer Symbolik
 - Interaktive Karte mit GPX-Vektor und Engstellenanzeige (Leaflet.js)
+- Editor zum Zeichnen neuer Routen und Stops (`editor.html`)
 
 ## Voraussetzungen
 
@@ -81,6 +82,13 @@ Die folgenden Abschnitte fassen die Kernbausteine von VERAX zusammen.
 - Flutter SDK (für App-Entwicklung)
 - Zugriff auf `/verax/` auf bsvrb.ch
 - Optionaler Swisstopo-Zugang für Schweizer Kartenlayer
+
+### Editor
+
+Mit `editor.html` lassen sich neue Routen direkt im Browser einzeichnen.
+Mit dem Zeichenwerkzeug erstellt man die Linienführung und fügt Marker als
+Stops hinzu. Nach dem Speichern können GPX-Datei und Stop-Daten als JSON
+heruntergeladen und in `map/` bzw. `codex/verax.yaml` abgelegt werden.
 
 ## Projektstatus
 

--- a/verax/codex/verax.yaml
+++ b/verax/codex/verax.yaml
@@ -100,3 +100,11 @@ meta:
   erstellt: "2025-06-07"
   autor: "R. Lauper / Aarulon"
   lizenz: "BSVRB intern"
+
+stops:
+  - name: "Beispiel-Stop"
+    typ: "Rast"
+    versuche: 1
+    zeitlimit: 60
+    lat: 46.8345
+    lon: 7.4935

--- a/verax/editor.html
+++ b/verax/editor.html
@@ -26,13 +26,13 @@
   </header>
   <div id="map"></div>
   <form id="stopForm">
-    <h2 data-i18n="verax_add_stop">Add Stop</h2>
+    <h2>Add Stop</h2>
     <label>Name: <input type="text" id="stopName" required></label>
     <label>Type: <input type="text" id="stopType" required></label>
     <label>Attempts/Time limit: <input type="number" id="stopAttempts" min="1" value="1"></label>
     <button type="button" id="saveStop">Save</button>
   </form>
-  <button id="exportBtn" data-i18n="verax_new_route">Export</button>
+  <button id="exportBtn">Export</button>
 <script>
 const map = L.map('map').setView([46.8345, 7.4953], 14);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom:18 }).addTo(map);

--- a/verax/editor.html
+++ b/verax/editor.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Verax Editor</title>
+  <link rel="stylesheet" href="../interface/ethicom-style.css" />
+  <script src="../interface/bundle.js" defer></script>
+  <script src="../utils/op-level.js"></script>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css" />
+  <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
+  <script src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
+  <style>
+    body, html { margin: 0; padding: 0; }
+    #map { height: 60vh; width: 100%; }
+    form { margin: 1rem; display: none; }
+    label { display: block; margin-top: 0.5rem; }
+    #exportBtn { margin: 1rem; }
+  </style>
+</head>
+<body>
+  <div id="op_background" aria-hidden="true"></div>
+  <header>
+    <h1>VERAX Editor</h1>
+  </header>
+  <div id="map"></div>
+  <form id="stopForm">
+    <h2 data-i18n="verax_add_stop">Add Stop</h2>
+    <label>Name: <input type="text" id="stopName" required></label>
+    <label>Type: <input type="text" id="stopType" required></label>
+    <label>Attempts/Time limit: <input type="number" id="stopAttempts" min="1" value="1"></label>
+    <button type="button" id="saveStop">Save</button>
+  </form>
+  <button id="exportBtn" data-i18n="verax_new_route">Export</button>
+<script>
+const map = L.map('map').setView([46.8345, 7.4953], 14);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom:18 }).addTo(map);
+const drawnItems = new L.FeatureGroup().addTo(map);
+const drawControl = new L.Control.Draw({
+  edit: { featureGroup: drawnItems },
+  draw: { polygon:false, circle:false, rectangle:false, circlemarker:false }
+});
+map.addControl(drawControl);
+let currentMarker = null;
+const stops = [];
+map.on(L.Draw.Event.CREATED, e => {
+  const layer = e.layer;
+  if (e.layerType === 'polyline') {
+    drawnItems.addLayer(layer);
+  } else if (e.layerType === 'marker') {
+    currentMarker = layer;
+    document.getElementById('stopForm').style.display = 'block';
+  }
+});
+
+document.getElementById('saveStop').onclick = () => {
+  if (!currentMarker) return;
+  const stop = {
+    name: document.getElementById('stopName').value,
+    typ: document.getElementById('stopType').value,
+    versuche: parseInt(document.getElementById('stopAttempts').value, 10) || 1,
+    lat: currentMarker.getLatLng().lat,
+    lon: currentMarker.getLatLng().lng
+  };
+  stops.push(stop);
+  currentMarker.bindPopup(stop.name).addTo(drawnItems);
+  currentMarker = null;
+  document.getElementById('stopForm').reset();
+  document.getElementById('stopForm').style.display = 'none';
+};
+
+function toGPX() {
+  let gpx = '<?xml version="1.0" encoding="UTF-8"?>\n<gpx version="1.1" creator="VERAX">\n  <rte>\n';
+  drawnItems.eachLayer(l => {
+    if (l instanceof L.Polyline && !(l instanceof L.Polygon)) {
+      l.getLatLngs().forEach(pt => {
+        gpx += `    <rtept lat="${pt.lat}" lon="${pt.lng}"></rtept>\n`;
+      });
+    }
+  });
+  stops.forEach(s => {
+    gpx += `    <rtept lat="${s.lat}" lon="${s.lon}"><desc>${s.name}</desc></rtept>\n`;
+  });
+  gpx += '  </rte>\n</gpx>';
+  return gpx;
+}
+
+document.getElementById('exportBtn').onclick = () => {
+  const gpxData = toGPX();
+  const gpxBlob = new Blob([gpxData], { type: 'application/gpx+xml' });
+  const a1 = document.createElement('a');
+  a1.href = URL.createObjectURL(gpxBlob);
+  a1.download = 'editor-route.gpx';
+  a1.click();
+  const stopBlob = new Blob([JSON.stringify(stops, null, 2)], { type: 'application/json' });
+  const a2 = document.createElement('a');
+  a2.href = URL.createObjectURL(stopBlob);
+  a2.download = 'stops.json';
+  a2.click();
+};
+
+document.addEventListener('DOMContentLoaded', () => { applyTheme('tanna-dark'); });
+</script>
+</body>
+</html>

--- a/verax/index.html
+++ b/verax/index.html
@@ -17,7 +17,7 @@
   <main id="main_content">
     <iframe src="/verax/map/leaflet.html" width="100%" height="500" style="border:none;"></iframe>
     <p style="text-align:right;margin-top:0.5rem;">
-      <button onclick="window.open('editor.html', '_blank');" data-i18n="verax_new_route">Neue Route</button>
+      <button onclick="window.open('editor.html', '_blank');">Neue Route</button>
     </p>
   </main>
   <script>

--- a/verax/index.html
+++ b/verax/index.html
@@ -16,6 +16,9 @@
   </header>
   <main id="main_content">
     <iframe src="/verax/map/leaflet.html" width="100%" height="500" style="border:none;"></iframe>
+    <p style="text-align:right;margin-top:0.5rem;">
+      <button onclick="window.open('editor.html', '_blank');" data-i18n="verax_new_route">Neue Route</button>
+    </p>
   </main>
   <script>
     document.addEventListener('DOMContentLoaded', () => {

--- a/verax/map/editor-route.gpx
+++ b/verax/map/editor-route.gpx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="VERAX">
+  <rte>
+    <name>Editor Route</name>
+    <rtept lat="46.8350" lon="7.4950"></rtept>
+    <rtept lat="46.8340" lon="7.4920"></rtept>
+    <rtept lat="46.8330" lon="7.4900"></rtept>
+  </rte>
+</gpx>


### PR DESCRIPTION
## Summary
- add Leaflet-based `editor.html` for drawing routes and stops
- enable access via new button on Verax landing page
- append example GPX and stop to codex
- update i18n translations with `verax_new_route` and `verax_add_stop`
- document editor usage in README
- add helper script `verax-save.js` and `js-yaml` dependency

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_685871a4771c8321996322268a214d7e