### PR TITLE
Enable collisions by default

### DIFF
--- a/interface/bundle.js
+++ b/interface/bundle.js
@@ -2440,6 +2440,13 @@ function initLogoBackground() {
   if (!container) return;
   localStorage.setItem('ethicom_bg_collisions', 'true');
 
+  if (!localStorage.getItem('ethicom_bg_fill')) {
+    localStorage.setItem('ethicom_bg_fill', '90');
+  }
+  if (!localStorage.getItem('ethicom_bg_symbol_size')) {
+    localStorage.setItem('ethicom_bg_symbol_size', '120');
+  }
+
   let RESTITUTION = 1;
   const storedRest = parseFloat(localStorage.getItem('ethicom_bg_restitution'));
   if (!Number.isNaN(storedRest)) RESTITUTION = storedRest;

--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -3,6 +3,13 @@ function initLogoBackground() {
   if (!container) return;
   localStorage.setItem('ethicom_bg_collisions', 'true');
 
+  if (!localStorage.getItem('ethicom_bg_fill')) {
+    localStorage.setItem('ethicom_bg_fill', '90');
+  }
+  if (!localStorage.getItem('ethicom_bg_symbol_size')) {
+    localStorage.setItem('ethicom_bg_symbol_size', '120');
+  }
+
   let RESTITUTION = 1;
   const storedRest = parseFloat(localStorage.getItem('ethicom_bg_restitution'));
   if (!Number.isNaN(storedRest)) RESTITUTION = storedRest;


### PR DESCRIPTION
## Summary
- ensure a default fill ratio and symbol size so that collisions appear on page load

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_68586ebcf3d48321aa7d9a5a7f368b14