### PR TITLE
Make links bold

### DIFF
--- a/interface/ethicom-style.css
+++ b/interface/ethicom-style.css
@@ -183,6 +183,7 @@ body {
 a {
   color: var(--accent-color);
   text-decoration: underline;
+  font-weight: bold;
 }
 
 


### PR DESCRIPTION
## Summary
- add `font-weight: bold` rule in `interface/ethicom-style.css`

## Testing
- `node --test` *(fails: command not found)*
- `node tools/check-translations.js` *(fails: command not found)*
- `node tools/check-file-integrity.js` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587f476eec83219c4e78ccde1f69e0