### PR TITLE
Add offline login feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ See [docs/FOLDER_STRUCTURE.md](docs/FOLDER_STRUCTURE.md) for a concise directory
 | [interface/settings_OLD.html](interface/settings_OLD.html) | Language, theme, Tanna logo, and low motion settings |
 | [interface/signup.html](interface/signup.html) | Registration form |
 | [interface/offline-signup.html](interface/offline-signup.html) | Offline local signup |
+| [interface/offline-login.html](interface/offline-login.html) | Offline login |
 
 Signup requires the local server started via `node tools/serve-interface.js`.
 | [interface/donate.html](interface/donate.html) | Donation interface (requires OP‑9.A confirmation) |

--- a/interface/offline-login.html
+++ b/interface/offline-login.html
@@ -3,33 +3,31 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Offline Signup</title>
+  <title>Offline Login</title>
   <link rel="stylesheet" href="/ethicom-style.css">
   <script src="/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
+  <script src="offline-login.js" defer></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>
   <div id="op_background"></div>
   <header>
-    <h1>Offline Signup</h1>
+    <h1>Offline Login</h1>
   </header>
   <main id="main_content">
     <div id="lang_selection" class="card" style="margin-bottom:1em;">
       <label for="lang_select" data-ui="choose_language_label">Language:</label>
       <select id="lang_select"></select>
     </div>
-    <p>This page stores a local profile when no server is available.</p>
-    <label for="nick_input">Nickname:</label>
-    <input type="text" id="nick_input" placeholder="Optional nickname" />
+    <p>Sign in with your locally stored profile.</p>
     <label for="email_input">Email:</label>
     <input type="email" id="email_input" placeholder="name@provider.com" />
 
     <label for="pw_input">Password:</label>
-    <input type="password" id="pw_input" placeholder="At least 8 characters" />
+    <input type="password" id="pw_input" placeholder="Password" />
 
-    <button onclick="storeOfflineProfile()">Store Locally</button>
-    <p><a href="offline-login.html">Offline login</a> after storing.</p>
+    <button onclick="offlineLogin()">Log in</button>
     <pre id="status" style="white-space:pre-wrap;margin-top:1em;"></pre>
     <section class="card" style="margin-top:2em;">
       <h2>Disclaimers</h2>

--- a/interface/offline-login.js
+++ b/interface/offline-login.js
@@ -1,0 +1,37 @@
+async function offlineLogin() {
+  const emailEl = document.getElementById('email_input');
+  const pwEl = document.getElementById('pw_input');
+  const statusEl = document.getElementById('status');
+  const email = emailEl.value.trim();
+  const pw = pwEl.value;
+  statusEl.textContent = '';
+
+  const stored = localStorage.getItem('ethicom_offline_user');
+  if (!stored) {
+    statusEl.textContent = 'No offline profile found. Use offline-signup.html.';
+    return;
+  }
+  const profile = JSON.parse(stored);
+  const emailHash = await sha256(email);
+  if (emailHash !== profile.emailHash) {
+    statusEl.textContent = 'Email not found.';
+    return;
+  }
+  const pwHash = await sha256(pw + profile.salt);
+  if (pwHash !== profile.pwHash) {
+    statusEl.textContent = 'Password incorrect.';
+    return;
+  }
+  const sig = {
+    emailHash: profile.emailHash,
+    op_level: profile.op_level || 'OP-1',
+    alias: profile.alias || ''
+  };
+  localStorage.setItem('ethicom_signature', JSON.stringify(sig));
+  statusEl.textContent = 'Login successful.';
+  setTimeout(() => { window.location.href = 'ethicom.html'; }, 500);
+}
+
+if (typeof window !== 'undefined') {
+  window.offlineLogin = offlineLogin;
+}

--- a/interface/offline-signup.js
+++ b/interface/offline-signup.js
@@ -1,6 +1,7 @@
 async function storeOfflineProfile() {
   const emailEl = document.getElementById('email_input');
   const pwEl = document.getElementById('pw_input');
+  const nickEl = document.getElementById('nick_input');
   const statusEl = document.getElementById('status');
   const email = emailEl.value.trim();
   const pw = pwEl.value;
@@ -19,7 +20,8 @@ async function storeOfflineProfile() {
   const emailHash = await sha256(email);
   const pwHash = await sha256(pw + salt);
   const created = new Date().toISOString();
-  const obj = { emailHash, pwHash, salt, created };
+  const alias = nickEl && nickEl.value.trim() ? `${nickEl.value.trim()}@OP-1` : '';
+  const obj = { emailHash, pwHash, salt, created, op_level: 'OP-1', alias };
   localStorage.setItem('ethicom_offline_user', JSON.stringify(obj));
   statusEl.textContent = 'Profile stored locally.';
 }


### PR DESCRIPTION
## Summary
- support local login via `offline-login.html`
- store nickname and OP level in offline signup
- link to offline login page in README and signup page

## Testing
- `node --test`
- `node tools/check-translations.js` *(fails: Unexpected non-whitespace character after JSON at position 101255)*
- `node tools/check-file-integrity.js`

------
https://chatgpt.com/codex/tasks/task_e_685913cec2808321a05f16b0b7ed0a29