### PR TITLE
Add search to Swiss fish page

### DIFF
--- a/interface/fish-interface/fischeSchweiz.html
+++ b/interface/fish-interface/fischeSchweiz.html
@@ -25,6 +25,8 @@
     </nav>
   </header>
   <main id="main_content">
+    <label for="fish_search">Suche:</label>
+    <input type="text" id="fish_search" placeholder="Name oder wiss. Name" />
     <table id="fisch_table">
       <thead>
         <tr>

--- a/interface/fish-interface/fischeSchweiz.js
+++ b/interface/fish-interface/fischeSchweiz.js
@@ -1,5 +1,6 @@
 async function initFischeSchweiz() {
   const table = document.getElementById('fisch_table');
+  const searchInput = document.getElementById('fish_search');
   if (!table) return;
   try {
     const list = await fetch('../../sources/fish/swiss-fish.json').then(r => r.json());
@@ -47,6 +48,14 @@ async function initFischeSchweiz() {
       tbody.appendChild(row);
     });
     table.appendChild(tbody);
+    if (searchInput) {
+      searchInput.addEventListener('input', e => {
+        const q = e.target.value.toLowerCase();
+        Array.from(tbody.rows).forEach(r => {
+          r.style.display = r.textContent.toLowerCase().includes(q) ? '' : 'none';
+        });
+      });
+    }
   } catch (e) {
     table.innerHTML = '<tr><td colspan="7">Daten konnten nicht geladen werden. Bitte Seite neu laden.</td></tr>';
   }

--- a/sources/fish/swiss-fish.json
+++ b/sources/fish/swiss-fish.json
@@ -57,6 +57,7 @@
   {"scientific_name": "Scardinius erythrophthalmus", "name": "Rotfeder", "origin": "einheimisch", "status": "LC", "in_bern": false, "image": "sources/fish/ch/scardinius_erythrophthalmus_ch.png"},
   {"scientific_name": "Scardinius hesperidicus", "name": "Scardola italiana", "origin": "einheimisch", "status": "VU", "in_bern": false, "image": "sources/fish/ch/scardinius_hesperidicus_ch.png"},
   {"scientific_name": "Silurus glanis", "name": "Wels", "origin": "einheimisch", "status": "LC", "in_bern": false, "image": "sources/fish/ch/silurus_glanis_ch.png"},
+  {"scientific_name": "Sander lucioperca", "name": "Zander", "origin": "einheimisch", "status": "LC", "in_bern": false, "image": "sources/fish/ch/sander_lucioperca_ch.png"},
   {"scientific_name": "Squalius cephalus", "name": "Alet", "origin": "einheimisch", "status": "LC", "in_bern": false, "image": "sources/fish/ch/squalius_cephalus_ch.png"},
   {"scientific_name": "Squalius squalus", "name": "Cavedano italiano", "origin": "einheimisch", "status": "VU", "in_bern": false, "image": "sources/fish/ch/squalius_squalio_ch.png"},
   {"scientific_name": "Telestes muticellus", "name": "Strigione", "origin": "einheimisch", "status": "NT", "in_bern": false, "image": "sources/fish/ch/telestes_muticellus_ch.png"},


### PR DESCRIPTION
## Summary
- include missing Zander entry in `swiss-fish.json`
- add search input to `fischeSchweiz.html`
- enable filtering logic in `fischeSchweiz.js`

## Testing
- `node --test` *(fails: 2 tests)*
- `node tools/check-translations.js` *(fails: invalid JSON)*
- `node tools/check-file-integrity.js`

------
https://chatgpt.com/codex/tasks/task_e_68591a2e2a288321808fadf22363d036