### PR TITLE
Add language support for offline signup

### DIFF
--- a/interface/offline-signup.html
+++ b/interface/offline-signup.html
@@ -3,41 +3,39 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Offline Signup</title>
+  <title data-ui="signup_title">Offline Signup</title>
   <link rel="stylesheet" href="/ethicom-style.css">
   <script src="/bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
+  <script src="signup.js"></script>
+  <script src="disclaimer.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main_content">Skip to main content</a>
   <div id="op_background"></div>
   <header>
-    <h1>Offline Signup</h1>
+    <h1 data-ui="signup_title">Offline Signup</h1>
   </header>
   <main id="main_content">
     <div id="lang_selection" class="card" style="margin-bottom:1em;">
       <label for="lang_select" data-ui="choose_language_label">Language:</label>
       <select id="lang_select"></select>
     </div>
-    <p>This page stores a local profile when no server is available.</p>
-    <label for="nick_input">Nickname:</label>
+    <p data-ui="signup_server_notice" class="card">This page stores a local profile when no server is available.</p>
+    <label for="nick_input" data-ui="signup_nick">Nickname:</label>
     <input type="text" id="nick_input" placeholder="Optional nickname" />
-    <label for="email_input">Email:</label>
+    <label for="email_input" data-ui="signup_email">Email:</label>
     <input type="email" id="email_input" placeholder="name@provider.com" />
 
-    <label for="pw_input">Password:</label>
+    <label for="pw_input" data-ui="signup_password">Password:</label>
     <input type="password" id="pw_input" placeholder="At least 8 characters" />
 
-    <button onclick="storeOfflineProfile()">Store Locally</button>
-    <p><a href="offline-login.html">Offline login</a> after storing.</p>
+    <button id="signup_btn" onclick="storeOfflineProfile()" data-ui="signup_btn">Store Locally</button>
+    <p><a id="offline_login_link" href="offline-login.html" data-ui="signup_offline_login">Offline login</a> after storing.</p>
     <pre id="status" style="white-space:pre-wrap;margin-top:1em;"></pre>
     <section class="card" style="margin-top:2em;">
-      <h2>Disclaimers</h2>
-      <ul>
-        <li>This structure is provided without warranty.</li>
-        <li>Use it responsibly and at your own risk.</li>
-        <li>Registration data is hashed and stored locally.</li>
-      </ul>
+      <h2 data-ui="disclaimer_title">Disclaimers</h2>
+      <ul id="disclaimers_list"></ul>
     </section>
     <section class="card" style="text-align:center;margin-top:2em;">
       <img id="tanna_animation" src="../sources/images/op-logo/tanna_op0.png" alt="Tanna animation" style="max-width:80%;height:auto;" />
@@ -48,6 +46,16 @@
       getLanguage();
       checkLanguageSetup();
       initLanguageDropdown('lang_select');
+      setTimeout(() => {
+        if (window.uiText && Array.isArray(window.uiText.disclaimer_items)) {
+          const list = document.getElementById('disclaimers_list');
+          if (list) {
+            list.innerHTML = window.uiText.disclaimer_items
+              .map(i => `<li>${i}</li>`)
+              .join('');
+          }
+        }
+      }, 100);
     });
   </script>
 </body>

--- a/interface/offline-signup.js
+++ b/interface/offline-signup.js
@@ -3,16 +3,17 @@ async function storeOfflineProfile() {
   const pwEl = document.getElementById('pw_input');
   const nickEl = document.getElementById('nick_input');
   const statusEl = document.getElementById('status');
+  const t = window.uiText || {};
   const email = emailEl.value.trim();
   const pw = pwEl.value;
   statusEl.textContent = '';
 
   if (!/^[^@]+@[^@]+\.[^@]+$/.test(email)) {
-    statusEl.textContent = 'Invalid email format.';
+    statusEl.textContent = t.signup_invalid_email || 'Invalid email format.';
     return;
   }
   if (pw.length < 8) {
-    statusEl.textContent = 'Password must be at least 8 characters.';
+    statusEl.textContent = t.signup_pw_short || 'Password must be at least 8 characters.';
     return;
   }
 
@@ -23,7 +24,7 @@ async function storeOfflineProfile() {
   const alias = nickEl && nickEl.value.trim() ? `${nickEl.value.trim()}@OP-1` : '';
   const obj = { emailHash, pwHash, salt, created, op_level: 'OP-1', alias };
   localStorage.setItem('ethicom_offline_user', JSON.stringify(obj));
-  statusEl.textContent = 'Profile stored locally.';
+  statusEl.textContent = t.signup_saved || 'Profile stored locally.';
 }
 
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- translate offline signup page using existing language keys
- show translated disclaimers

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_68594b5e40208321be2e0f4fe3513c99