### PR TITLE
Add hazard catalog for Verax

### DIFF
--- a/verax/README.md
+++ b/verax/README.md
@@ -73,6 +73,7 @@ Die folgenden Abschnitte fassen die Kernbausteine von VERAX zusammen.
 - Echtzeit-Entscheidungen per Lautstärketasten oder Spracheingabe
 - GPS-Interpretation von Bewegung, Stillstand und Richtung
 - Gefahren wie Bären, Wildflüsse, Kälte oder moralische Dilemmata
+- Vollständiger Gefahrenkatalog in `codex/gefahrenkatalog.yaml`
 - Authentische Einbindung historisch-helvetischer Symbolik
 - Interaktive Karte mit GPX-Vektor und Engstellenanzeige (Leaflet.js)
 - Editor zum Zeichnen neuer Routen und Stops (`editor.html`)

--- a/verax/codex/gefahrenkatalog.yaml
+++ b/verax/codex/gefahrenkatalog.yaml
@@ -1,0 +1,80 @@
+gefahrenkatalog:
+  tierische_bedrohungen:
+    - id: T001
+      art: Wildschwein
+      verhalten: "Verteidigt Frischlinge"
+      risiko: Verletzungsgefahr
+      aktiv: "D\u00e4mmerung, Fr\u00fchjahr"
+    - id: T002
+      art: Kreuzotter
+      verhalten: "Sonnenbad auf Pfaden"
+      risiko: "Biss (leicht giftig)"
+      aktiv: ">15\u00b0C, Kieszonen"
+    - id: T003
+      art: Fuchs
+      verhalten: "Scheu, aber evtl. tollw\u00fctig"
+      risiko: indirekt
+      aktiv: "Herbst, Waldn\u00e4he"
+    - id: T004
+      art: Bussard
+      verhalten: "Nestschutz durch Sturzfl\u00fcge"
+      risiko: Erschrecken
+      aktiv: "Fr\u00fchling, H\u00f6henlagen"
+
+  natuerliche_hindernisse:
+    - id: N001
+      element: Windbruch
+      risiko: "Weg blockiert"
+      aktiv: "nach Sturm"
+    - id: N002
+      element: Altwasser
+      risiko: Einsinken
+      aktiv: "nach Regen"
+    - id: N003
+      element: Mor\u00e4nenkante
+      risiko: Steinschlaggefahr
+      aktiv: Fr\u00fchjahr
+    - id: N004
+      element: Wurzelhang
+      risiko: "Glatt, laut"
+      aktiv: "feucht, Schatten"
+
+  menschliche_hindernisse:
+    - id: M001
+      typ: Weidezaun
+      wirkung: Elektroschock
+      aktiv: "Fr\u00fchjahr\u2013Herbst"
+    - id: M002
+      typ: Forstarbeiten
+      wirkung: "Sperrung, L\u00e4rm"
+      aktiv: Werktags
+    - id: M003
+      typ: Verkehrsweg
+      wirkung: "Sichtbarkeit, L\u00e4rm"
+      aktiv: Querung
+    - id: M004
+      typ: Fremdperson
+      wirkung: Verunsicherung
+      aktiv: "alle Tageszeiten"
+
+  zeit_und_wetterrisiken:
+    - id: Z001
+      typ: Nebel
+      wirkung: "Sicht < 10 m"
+      bedingung: "<8\u00b0C, 90% LF"
+    - id: Z002
+      typ: D\u00e4mmerung
+      wirkung: "Ver\u00e4nderte Akustik"
+      bedingung: "<06:00 oder >21:00"
+    - id: Z003
+      typ: Hitze
+      wirkung: Ersch\u00f6pfung
+      bedingung: ">30\u00b0C, 11\u201316 Uhr"
+    - id: Z004
+      typ: Windb\u00f6en
+      wirkung: Astbruchgefahr
+      bedingung: ">40 km/h"
+
+metadata:
+  version: 1
+  stand: 2025

--- a/verax/codex/verax.yaml
+++ b/verax/codex/verax.yaml
@@ -14,6 +14,7 @@ modules:
   - entscheidung
   - inventar
   - protokoll
+  - gefahrenkatalog
   - meta
 
 limen:
@@ -95,6 +96,9 @@ anzeige:
     - route
     - engstellen
     - gefahrensymbole
+
+gefahrenkatalog:
+  datei: "gefahrenkatalog.yaml"
 
 meta:
   erstellt: "2025-06-07"

--- a/verax/docs/systembeschreibung.md
+++ b/verax/docs/systembeschreibung.md
@@ -8,7 +8,7 @@ VERAX ist ein naturnahes Bewegungsspiel im realen Raum. Der Spieler befindet sic
 
 - **Codex**: Ethikregeln und Signaturen
 - **Szenario**: Orts- und situationsgebundene Aufgabe
-- **Gefahrenkatalog**: Adaptiver Modulspeicher
+- **Gefahrenkatalog**: Adaptiver Modulspeicher (`codex/gefahrenkatalog.yaml`)
 - **Resonanzpunkte**: Reale Orte mit Aufgaben
 - **Linien**: Symbolische Verbindung durch Handlung
 
@@ -51,6 +51,8 @@ VERAX ist ein naturnahes Bewegungsspiel im realen Raum. Der Spieler befindet sic
 | Z004 | Windböen  | Astbruchgefahr           | >40 km/h           |
 
 ## Szenarienlogik
+
+Der Katalog wird als YAML-Datei geführt und steht unter `codex/gefahrenkatalog.yaml` zur Verfügung.
 
 Ein Szenario kombiniert jeweils 1–2 tierische Gefahren, 1–2 natürliche Hindernisse, ein menschliches Hindernis und einen Zeit-/Wetterfaktor. Beispiel:
 


### PR DESCRIPTION
## Summary
- provide a YAML file with the Verax hazard catalog
- reference the catalog in `verax.yaml`
- mention catalog file in README and system documentation

## Testing
- `node --test` *(fails: Cannot find module 'express')*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_6864f49821d4832196d6780dc0c9f375