### PR TITLE
Add fallback Tanna animation and restrict settings

### DIFF
--- a/bsvrb.ch/settings.html
+++ b/bsvrb.ch/settings.html
@@ -59,7 +59,7 @@
       <button id="color_wizard_btn" class="accent-button" type="button" onclick="openColorSettingsWizard()">Color Wizard</button>
       <button id="color_cli_wizard_btn" class="accent-button" type="button" onclick="openColorSettingsWizardCLI()">Text Wizard</button>
     </details>
-    <details class="card">
+    <details class="card" id="background_card">
       <summary>Background</summary>
       <div id="background_settings">
         <div id="background_count">
@@ -225,10 +225,12 @@
       const lvlNum = typeof getStoredOpLevel === 'function' ? opLevelToNumber(getStoredOpLevel()) : 0;
       const themeWrap = document.getElementById('theme_selection');
       const colorWrap = document.getElementById('color_settings');
+      const bgCard = document.getElementById('background_card');
       if (lvlNum < 3) {
         if (themeWrap) themeWrap.style.display = 'none';
         if (colorWrap) colorWrap.style.display = 'none';
       }
+      if (bgCard) bgCard.style.display = lvlNum >= 2 ? 'block' : 'none';
       if (sameWrap) sameWrap.style.display = lvlNum >= 1 ? 'block' : 'none';
       if (lvlNum >= 1 && sameSlider && sameVal) {
         const storedSame = parseInt(localStorage.getItem('ethicom_same_level_count') || '1', 10);

--- a/interface/css/content.css
+++ b/interface/css/content.css
@@ -296,6 +296,20 @@ body.home #op_background {
   filter: drop-shadow(0 0 2px var(--bg-color));
 }
 
+#op_background::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: url('../sources/images/op-logo/tanna_op0.png') center/20vmin no-repeat;
+  opacity: 0.25;
+  animation: tannaFallback 12s linear infinite;
+}
+
+@keyframes tannaFallback {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
 @keyframes backgroundSway {
   0% { transform: scale(1) translate(0, 0); }
   50% { transform: scale(1.02) translate(1%, 1%); }

--- a/interface/settings.html
+++ b/interface/settings.html
@@ -62,7 +62,7 @@
       <button id="color_wizard_btn" class="accent-button" type="button" onclick="openColorSettingsWizard()">Color Wizard</button>
       <button id="color_cli_wizard_btn" class="accent-button" type="button" onclick="openColorSettingsWizardCLI()">Text Wizard</button>
     </details>
-    <details class="card">
+    <details class="card" id="background_card">
       <summary>Background</summary>
       <div id="background_settings">
         <div id="background_count">
@@ -228,10 +228,12 @@
       const lvlNum = typeof getStoredOpLevel === 'function' ? opLevelToNumber(getStoredOpLevel()) : 0;
       const themeWrap = document.getElementById('theme_selection');
       const colorWrap = document.getElementById('color_settings');
+      const bgCard = document.getElementById('background_card');
       if (lvlNum < 3) {
         if (themeWrap) themeWrap.style.display = 'none';
         if (colorWrap) colorWrap.style.display = 'none';
       }
+      if (bgCard) bgCard.style.display = lvlNum >= 2 ? 'block' : 'none';
       if (sameWrap) sameWrap.style.display = lvlNum >= 1 ? 'block' : 'none';
       if (lvlNum >= 1 && sameSlider && sameVal) {
         const storedSame = parseInt(localStorage.getItem('ethicom_same_level_count') || '1', 10);


### PR DESCRIPTION
## Summary
- ensure background shows a basic animation without JavaScript
- only allow background tweaks from OP‑2 onwards

## Testing
- `node --test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_6864f6ce04b08321abfedbe5d6d82e74