### PR TITLE
Add department display

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ together form the core of MYRIA.
 4. Optionally compile the Flutter launcher in `launcher/` to start the server
    without the terminal (`flutter run launcher`).
 5. The interface opens at `http://localhost:8080/index.html`.
-6. For quick static hosting, deploy the interface on
+6. Beim Start werden die Abteilungen automatisch unter den Projekten angezeigt.
+7. For quick static hosting, deploy the interface on
    [Netsly](interface/deploy_netsly.md) or
    [Hostpoint](interface/deploy_hostpoint.md).
-7. For the minimal Python helper see [docs/how_to_use.md](docs/how_to_use.md).
+8. For the minimal Python helper see [docs/how_to_use.md](docs/how_to_use.md).
 
 ```
     +-----------+

--- a/index.html
+++ b/index.html
@@ -22,6 +22,8 @@
         <li><a href="interface/fish-interface/fischeSchweiz.html">Fische Schweiz</a> – nationale Artenliste</li>
       </ul>
     </section>
+    <section id="departments_section"></section>
+    <p id="departments_fallback">Abteilungen werden geladen…</p>
     <section class="card" style="max-width:40em;margin:2em auto;">
       <h2>Disclaimers</h2>
       <ul>


### PR DESCRIPTION
## Summary
- show departments on the landing page
- mention departments in quick start

## Testing
- `node --test` *(fails: ENOENT in pdf_dna_extract.test.js)*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_6865169513a88321aaf6db72183c63af