### PR TITLE
Fix offline signup script

### DIFF
--- a/interface/offline-signup.html
+++ b/interface/offline-signup.html
@@ -8,6 +8,7 @@
   <script src="bundle.js" defer></script>
   <script src="../utils/op-level.js"></script>
   <script src="signup.js"></script>
+  <script src="offline-signup.js"></script>
   <script src="disclaimer.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- load `offline-signup.js` in `offline-signup.html`

## Testing
- `node --test` *(fails: Cannot find module 'express')*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_6865194eb4e88321bbbda62900adb93d