### PR TITLE
Call initSignup on offline-signup page

### DIFF
--- a/interface/offline-signup.html
+++ b/interface/offline-signup.html
@@ -53,6 +53,7 @@
       getLanguage();
       checkLanguageSetup();
       initLanguageDropdown('lang_select');
+      initSignup();
       setTimeout(() => {
         if (window.uiText && Array.isArray(window.uiText.disclaimer_items)) {
           const list = document.getElementById('disclaimers_list');


### PR DESCRIPTION
## Summary
- initialize signup flow on the offline signup page before loading disclaimer text

## Testing
- `node --test` *(fails: test/backend.test.js, test/pdf_dna_extract.test.js)*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_686519500bd08321bdb06aecdc13b93d