### PR TITLE
Fix logo paths

### DIFF
--- a/interface/css/content.css
+++ b/interface/css/content.css
@@ -300,7 +300,7 @@ body.home #op_background {
   content: '';
   position: absolute;
   inset: 0;
-  background: url('../sources/images/op-logo/tanna_op0.png') center/20vmin no-repeat;
+  background: url('/sources/images/op-logo/tanna_op0.png') center/20vmin no-repeat;
   opacity: 0.25;
   animation: tannaFallback 12s linear infinite;
 }

--- a/interface/logo-background.js
+++ b/interface/logo-background.js
@@ -121,11 +121,11 @@ function initLogoBackground() {
   const maxLvl = Math.max(...levels);
   const minScale = 0.5;
   const FADE_MS = 0;
-  const imgBase = window.location.pathname.includes('/interface/') ||
-                  window.location.pathname.includes('/wings/') ||
-                  window.location.pathname.includes('/bsvrb.ch/')
-                    ? '../sources/images/op-logo/'
-                    : 'sources/images/op-logo/';
+  const depth = window.location.pathname
+    .replace(/[^/]+$/, '')
+    .split('/')
+    .filter(Boolean).length;
+  const imgBase = '../'.repeat(depth) + 'sources/images/op-logo/';
   const images = levels.map(lvl => {
     const img = new Image();
     const src = lvl >= 8 ? 7 : lvl;


### PR DESCRIPTION
## Summary
- compute logo path depth dynamically
- update fallback background path

## Testing
- `node --test` *(fails: extracts DNA from PDF into identity record)*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68651c4a0c9c83218eab92664e3a2b7f