### PR TITLE
Add fish quiz module

### DIFF
--- a/interface/fish-interface/fischQuiz.html
+++ b/interface/fish-interface/fischQuiz.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Fisch-Quiz</title>
+  <link rel="stylesheet" href="../ethicom-style.css">
+  <script src="../bundle.js" defer></script>
+  <script src="../../utils/op-level.js"></script>
+  <script src="fischQuiz.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main_content">Skip to main content</a>
+  <div id="op_background"></div>
+  <header>
+    <h1>Fisch-Quiz</h1>
+    <nav>
+      <a href="../../index.html">Home</a>
+      <a href="../../bewertung.html">Bewertung</a>
+      <a href="../settings.html" class="icon-only">⚙</a>
+      <a href="../login.html">Login</a>
+      <a href="../wings/ratings.html">Ratings</a>
+      <a href="../signup.html">Signup</a>
+      <a href="../../README.html" class="readme-link">README</a>
+    </nav>
+  </header>
+  <main id="main_content">
+    <section id="start_screen" class="card">
+      <label>Fragenanzahl (0 = endlos)
+        <input id="quiz_length" type="number" min="0" value="0" />
+      </label>
+      <button id="start_btn">Start</button>
+    </section>
+    <section id="quiz_area" class="card" style="display:none;">
+      <img id="quiz_image" alt="" class="fish-image" />
+      <p id="quiz_question"></p>
+      <div id="quiz_options"></div>
+      <button id="stop_btn">Stop</button>
+    </section>
+    <section id="quiz_result" class="card" style="display:none;"></section>
+  </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      initSideDrop('../op-navigation.html');
+      const menu = document.getElementById('side_menu');
+      if (menu) menu.addEventListener('click', e => { e.preventDefault(); toggleSideDrop(); });
+    });
+  </script>
+  <div id="side_drop"></div>
+</body>
+</html>

--- a/interface/fish-interface/fischQuiz.js
+++ b/interface/fish-interface/fischQuiz.js
@@ -1,0 +1,72 @@
+let fishData = [];
+let quizLength = 0;
+let asked = 0;
+let score = 0;
+
+async function loadFishData() {
+  try {
+    fishData = await fetch('../../sources/fish/swiss-fish.json').then(r => r.json());
+  } catch {
+    document.getElementById('start_screen').innerHTML = '<p>Daten konnten nicht geladen werden.</p>';
+  }
+}
+
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function startQuiz() {
+  quizLength = parseInt(document.getElementById('quiz_length').value, 10) || 0;
+  asked = 0;
+  score = 0;
+  document.getElementById('start_screen').style.display = 'none';
+  document.getElementById('quiz_result').style.display = 'none';
+  document.getElementById('quiz_area').style.display = 'block';
+  nextQuestion();
+}
+
+function nextQuestion() {
+  if (quizLength && asked >= quizLength) return finishQuiz();
+  asked++;
+  const fish = fishData[Math.floor(Math.random() * fishData.length)];
+  const options = [fish.name];
+  while (options.length < 4) {
+    const r = fishData[Math.floor(Math.random() * fishData.length)].name;
+    if (!options.includes(r)) options.push(r);
+  }
+  shuffle(options);
+  const img = document.getElementById('quiz_image');
+  img.src = '../../' + (fish.image || '');
+  img.alt = fish.name;
+  document.getElementById('quiz_question').textContent = 'Welcher Fisch ist das?';
+  const optDiv = document.getElementById('quiz_options');
+  optDiv.innerHTML = '';
+  options.forEach(o => {
+    const btn = document.createElement('button');
+    btn.textContent = o;
+    btn.addEventListener('click', () => {
+      if (o === fish.name) score++;
+      nextQuestion();
+    });
+    optDiv.appendChild(btn);
+  });
+}
+
+function finishQuiz() {
+  document.getElementById('quiz_area').style.display = 'none';
+  const result = `Ergebnis: ${score} von ${asked}`;
+  const resDiv = document.getElementById('quiz_result');
+  resDiv.textContent = result;
+  resDiv.style.display = 'block';
+  document.getElementById('start_screen').style.display = 'block';
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadFishData();
+  document.getElementById('start_btn').addEventListener('click', startQuiz);
+  document.getElementById('stop_btn').addEventListener('click', finishQuiz);
+});

--- a/interface/fish.html
+++ b/interface/fish.html
@@ -36,6 +36,9 @@
       <p>
         <a href="fish-interface/fischEditor.html">Fisch-Editor</a> – Datenbearbeitung ab OP-5.
       </p>
+      <p>
+        <a href="fish-interface/fischQuiz.html">Fisch-Quiz</a> – Selbsttest mit Bildern.
+      </p>
     </section>
   </main>
 </body>


### PR DESCRIPTION
## Summary
- add new Fish-Quiz page and script
- link the quiz from the fish interface
- tests fail due to missing optional modules

## Testing
- `npm test` *(fails: MODULE_NOT_FOUND)*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_6865abc2f1008321a395c6730cf46312