### PR TITLE
Document dependencies before tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,9 @@ This project welcomes ethical improvements and translations. Before changing the
 2. `structure_9874.md` – principles for clarity.
 3. `README.md` – overall goals and license.
 
+Before running tests or scripts, install the Node.js dependencies with `npm install` or run
+`tools/guided-install.sh` so that Express and other packages are available.
+
 Apply changes with intention and in alignment with the Open‑Ethics License:
 
 ```

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "serve-bsvrb": "BASE_URL=https://bsvrb.ch node tools/serve-interface.js",
     "bundle-interface": "node tools/bundle-interface.js",
     "generate-wiki": "node tools/generate-wiki.js",
+    "pretest": "npm install",
     "test": "node --test && node tools/check-translations.js && node tools/check-file-integrity.js",
     "telegram-bot": "node tools/telegram-bot.js",
     "coverage": "nyc npm test",


### PR DESCRIPTION
## Summary
- remind contributors to run `npm install` or `tools/guided-install.sh`
- automate installs before running tests

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/tmp/id.yaml')*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_6865afc6dea483218196bf43802d34f5