### PR TITLE
Fix fish quiz image sizing

### DIFF
--- a/interface/css/content.css
+++ b/interface/css/content.css
@@ -338,7 +338,7 @@ body.home #op_background {
 }
 
 .fish-image {
-  width: 60px;
+  width: 180px;
   height: auto;
 }
 


### PR DESCRIPTION
## Summary
- enlarge fish images in quiz

## Testing
- `npm install`
- `node --test` *(fails: ENOENT no such file or directory '/tmp/id.yaml')*
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_6866383125208321ac2b01c2aebf4ea2