### PR TITLE
Implement optional dependency checks

### DIFF
--- a/aari/say.py
+++ b/aari/say.py
@@ -1,8 +1,14 @@
-import pyttsx3
+try:
+    import pyttsx3
+except ImportError:  # pragma: no cover - optional dependency
+    pyttsx3 = None
 
 
 def spreche(text: str) -> None:
     """Vocalize text using the default speech engine."""
+    if pyttsx3 is None:
+        print("pyttsx3 not installed. Please install it with 'pip install pyttsx3'.")
+        return
     engine = pyttsx3.init()
     engine.say(text)
     engine.runAndWait()

--- a/test/optional-dependencies.test.js
+++ b/test/optional-dependencies.test.js
@@ -1,0 +1,35 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const root = path.join(__dirname, '..');
+
+function runNode(args) {
+  return spawnSync(process.execPath, args, { cwd: root, encoding: 'utf8' });
+}
+
+test('serve-interface warns if canvas is missing', {
+  skip: (() => { try { require.resolve('canvas'); return true; } catch { return false; } })()
+}, () => {
+  const res = runNode(['-e', "require('./tools/serve-interface.js')"]);
+  assert.strictEqual(res.status, 0);
+  assert.match(res.stderr, /Optional dependency "canvas" missing/);
+});
+
+test('stereo-anaglyph exits when canvas missing', {
+  skip: (() => { try { require.resolve('canvas'); return true; } catch { return false; } })()
+}, () => {
+  const script = path.join(root, 'tools', 'stereo-anaglyph.js');
+  const res = runNode([script, 'left.png', 'right.png', 'out.png']);
+  assert.strictEqual(res.status, 1);
+  assert.match(res.stderr, /canvas/);
+});
+
+test('text_to_speech exits when pyttsx3 missing', () => {
+  const script = path.join(root, 'tools', 'text_to_speech.py');
+  const res = spawnSync('python3', [script, 'hello'], { encoding: 'utf8' });
+  assert.strictEqual(res.status, 1);
+  const output = res.stdout + res.stderr;
+  assert.match(output, /pyttsx3 not installed/);
+});

--- a/test/pdf_dna_extract.test.js
+++ b/test/pdf_dna_extract.test.js
@@ -6,8 +6,9 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 const PDFDocument = require('pdfkit');
 const yaml = require('js-yaml');
+const hasPyDeps = spawnSync('python3', ['-c', 'import yaml, PyPDF2'], { encoding: 'utf8' }).status === 0;
 
-test('extracts DNA from PDF into identity record', () => {
+test('extracts DNA from PDF into identity record', { skip: !hasPyDeps }, () => {
   const pdfFile = path.join(os.tmpdir(), 'dna.pdf');
   const doc = new PDFDocument();
   const stream = fs.createWriteStream(pdfFile);


### PR DESCRIPTION
## Summary
- handle missing **pyttsx3** gracefully in `aari/say.py`
- add tests for optional dependencies
- skip PDF DNA extraction test if Python deps are unavailable

## Testing
- `npm test`
- `node tools/check-translations.js`
- `node tools/check-file-integrity.js`


------
https://chatgpt.com/codex/tasks/task_e_686639daf98883218ce5d0dc9a3eecda